### PR TITLE
Add touch-first INARA materials search

### DIFF
--- a/src/client/components/panels/eng/materials.js
+++ b/src/client/components/panels/eng/materials.js
@@ -1,5 +1,6 @@
 import { Fragment } from 'react'
 import CopyOnClick from 'components/copy-on-click'
+import { openInaraMaterials } from 'lib/inara'
 
 export default function Materials ({ materialType, materials }) {
   if (materials.length === 0) return (<p className='text-info text-uppercase'>No materials found.</p>)
@@ -54,6 +55,17 @@ function MaterialsTable ({ materialType, materialCategory, materials }) {
                   <div style={{ width: '70%', display: 'inline-block' }}>
                     <progress style={{ height: '1.25rem' }} value={item.count} max={item?.maxCount ?? item.count} className={item.count === item?.maxCount ? 'progress--secondary' : ''} />
                   </div>
+                </div>
+                <div style={{ marginTop: '.75rem', display: 'flex', gap: '.75rem', flexWrap: 'wrap' }}>
+                  <button
+                    type='button'
+                    className='button button--secondary'
+                    style={{ padding: '.75rem 1.5rem', borderRadius: '.85rem', fontSize: '.95rem' }}
+                    onClick={() => openInaraMaterials({ symbol: item.symbol, name: item.name })}
+                  >
+                    <i className='icon icarus-terminal-materials' style={{ marginRight: '.5rem' }} />
+                    Find on INARA
+                  </button>
                 </div>
               </td>
               <td className='hidden-large text-no-transform'>

--- a/src/client/lib/inara.js
+++ b/src/client/lib/inara.js
@@ -1,0 +1,39 @@
+import Router from 'next/router'
+
+const PRESET_KEY = 'INARA_MATERIALS_PRESET'
+
+export function openInaraMaterials (material, options = {}) {
+  if (typeof window === 'undefined') return
+  const payload = {
+    materials: [],
+    mode: options.mode || 'buy'
+  }
+
+  const materialsArray = Array.isArray(material) ? material : [material]
+  materialsArray.forEach(item => {
+    if (!item) return
+    if (typeof item === 'string') {
+      payload.materials.push(item)
+    } else if (item?.inaraValue) {
+      payload.materials.push(item.inaraValue)
+    } else if (item?.symbol) {
+      payload.materials.push(item.symbol)
+    } else if (item?.name) {
+      payload.materials.push(item.name)
+    }
+  })
+
+  if (options.system) payload.system = options.system
+
+  try {
+    window.sessionStorage.setItem(PRESET_KEY, JSON.stringify(payload))
+  } catch (err) {
+    // ignore storage errors
+  }
+
+  Router.push('/inara/materials')
+}
+
+export default {
+  openInaraMaterials
+}

--- a/src/client/pages/api/_lib/inara.js
+++ b/src/client/pages/api/_lib/inara.js
@@ -1,0 +1,61 @@
+import System from '../../../../service/lib/event-handlers/system.js'
+
+let systemInstance = null
+
+async function getSystemInstance () {
+  if (systemInstance) return systemInstance
+  if (global.ICARUS_SYSTEM_INSTANCE) {
+    systemInstance = global.ICARUS_SYSTEM_INSTANCE
+    return systemInstance
+  }
+  systemInstance = new System({
+    eliteLog: {
+      getEvent: async () => null,
+      getEventsFromTimestamp: async () => [],
+      _query: async () => []
+    }
+  })
+  global.ICARUS_SYSTEM_INSTANCE = systemInstance
+  return systemInstance
+}
+
+export async function getLocalStationDetails (systemName, stationName) {
+  if (!systemName || !stationName) return null
+  try {
+    const sysInstance = await getSystemInstance()
+    const sysData = await sysInstance.getSystem({ name: systemName })
+    if (!sysData?.spaceStations?.length) return null
+    const station = sysData.spaceStations.find(s => s?.name?.toLowerCase() === stationName.toLowerCase())
+    if (!station) return null
+    return {
+      padSize: station.landingPads?.large
+        ? 'Large'
+        : station.landingPads?.medium
+          ? 'Medium'
+          : station.landingPads?.small
+            ? 'Small'
+            : '',
+      market: !!station.haveMarket,
+      outfitting: !!station.haveOutfitting,
+      shipyard: !!station.haveShipyard,
+      stationDistance: station.distanceToArrival ? `${Math.round(station.distanceToArrival)} Ls` : '',
+      type: station.type || station.stationType || '',
+      services: station.otherServices || [],
+      economies: station.economies || [],
+      faction: station.faction || '',
+      government: station.government || '',
+      allegiance: station.allegiance || '',
+      updatedAt: station.updatedAt || ''
+    }
+  } catch (error) {
+    return null
+  }
+}
+
+export const MATERIAL_CATEGORY_LABELS = {
+  6: 'Field & Recovery Items',
+  7: 'Intel & Data Archives',
+  13: 'Chemical Goods',
+  14: 'Industrial Components',
+  15: 'Micro-Tech Components'
+}

--- a/src/client/pages/api/inara-materials.js
+++ b/src/client/pages/api/inara-materials.js
@@ -1,0 +1,262 @@
+import fetch from 'node-fetch'
+import path from 'path'
+import fs from 'fs'
+import { getLocalStationDetails, MATERIAL_CATEGORY_LABELS } from './_lib/inara.js'
+
+const headers = {
+  'User-Agent': 'Mozilla/5.0 (compatible; ICARUS/1.0)',
+  'Accept-Language': 'en-US,en;q=0.9'
+}
+
+const materialsLogPath = path.join(process.cwd(), 'inara-materials.log')
+function logMaterials (entry) {
+  try {
+    fs.appendFileSync(materialsLogPath, `[${new Date().toISOString()}] ${entry}\n`)
+  } catch (error) {
+    // ignore logging failures
+  }
+}
+
+const rarityMap = {
+  1: 'Very Common',
+  2: 'Common',
+  3: 'Standard',
+  4: 'Rare',
+  5: 'Very Rare'
+}
+
+let catalogueCache = null
+let catalogueFetchedAt = 0
+const CATALOGUE_TTL = 1000 * 60 * 30 // 30 minutes
+
+const resultCache = new Map()
+const RESULT_TTL = 1000 * 60 * 2
+
+function decodeHtml (text = '') {
+  return text
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&nbsp;/gi, ' ')
+    .trim()
+}
+
+function normalizeName (text = '') {
+  return text.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+async function fetchCatalogue () {
+  if (catalogueCache && (Date.now() - catalogueFetchedAt) < CATALOGUE_TTL) {
+    return catalogueCache
+  }
+
+  const response = await fetch('https://inara.cz/elite/market-materials/', { headers })
+  if (!response.ok) {
+    throw new Error('Failed to retrieve INARA catalogue')
+  }
+  const html = await response.text()
+  const selectMatch = html.match(/<select[^>]*name="pa1\[\]"[\s\S]*?<\/select>/i)
+  const materials = []
+  if (selectMatch) {
+    const optionRegex = /<option[^>]*value="([^"]+)"[^>]*>([\s\S]*?)<\/option>/gi
+    let optionMatch
+    while ((optionMatch = optionRegex.exec(selectMatch[0]))) {
+      const value = optionMatch[1]
+      const label = decodeHtml(optionMatch[2])
+      if (!value) continue
+      const [categoryCode, materialId] = value.split('|')
+      materials.push({
+        value,
+        id: materialId,
+        categoryCode,
+        name: label
+      })
+    }
+  }
+
+  const edcdPath = path.join(process.cwd(), 'src/service/data/edcd/fdevids/material.json')
+  let edcd = []
+  try {
+    edcd = JSON.parse(fs.readFileSync(edcdPath, 'utf8'))
+  } catch (error) {
+    logMaterials(`CATALOGUE_EDCD_READ_ERROR: ${error.message}`)
+  }
+  const edcdIndex = new Map()
+  edcd.forEach(item => {
+    edcdIndex.set(normalizeName(item.name), item)
+    if (item.symbol) edcdIndex.set(normalizeName(item.symbol), item)
+  })
+
+  const enriched = materials.map(option => {
+    const meta = edcdIndex.get(normalizeName(option.name)) || null
+    return {
+      id: option.id,
+      name: option.name,
+      inaraValue: option.value,
+      categoryCode: option.categoryCode,
+      categoryLabel: MATERIAL_CATEGORY_LABELS[option.categoryCode] || 'Other',
+      symbol: meta?.symbol || null,
+      type: meta?.type || null,
+      rarity: meta?.rarity ? Number(meta.rarity) : null,
+      rarityLabel: meta?.rarity ? rarityMap[String(meta.rarity)] || null : null
+    }
+  })
+
+  catalogueCache = { materials: enriched }
+  catalogueFetchedAt = Date.now()
+  return catalogueCache
+}
+
+function cacheKey (payload) {
+  return JSON.stringify(payload)
+}
+
+function setCache (key, value) {
+  resultCache.set(key, { value, expires: Date.now() + RESULT_TTL })
+}
+
+function getCache (key) {
+  const entry = resultCache.get(key)
+  if (!entry) return null
+  if (entry.expires < Date.now()) {
+    resultCache.delete(key)
+    return null
+  }
+  return entry.value
+}
+
+function parseMaterialsTable (html) {
+  const tableMatch = html.match(/<table[\s\S]*?<\/table>/i)
+  if (!tableMatch) return null
+  const tableHtml = tableMatch[0]
+  const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi
+  const rows = []
+  let rowMatch
+  while ((rowMatch = rowRegex.exec(tableHtml))) {
+    const cellsHtml = rowMatch[1]
+    const cols = [...cellsHtml.matchAll(/<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/gi)].map(col => decodeHtml(col[1].replace(/<br\s*\/?/gi, '\n').replace(/<[^>]+>/g, ' ')))
+    if (!cols.length) continue
+    rows.push(cols)
+  }
+  return rows
+}
+
+async function buildResults (html) {
+  if (/no components? found/i.test(html)) {
+    return { results: [], message: 'No matching market listings were reported on INARA.' }
+  }
+  const rows = parseMaterialsTable(html)
+  if (!rows || rows.length <= 1) {
+    return { results: [], message: 'No structured results returned from INARA.' }
+  }
+  const results = []
+  for (let i = 1; i < rows.length; i++) {
+    const cols = rows[i]
+    if (!cols.length) continue
+    const stationCell = cols[0] || ''
+    const systemCell = cols[1] || ''
+    const priceCell = cols[3] || ''
+    const amountCell = cols[4] || ''
+    const updatedCell = cols[cols.length - 1] || ''
+    let station = stationCell
+    let notes = ''
+    if (stationCell.includes('|')) {
+      const parts = stationCell.split('|')
+      station = parts[0].trim()
+      notes = parts.slice(1).join('|').trim()
+    }
+    const system = systemCell.split('\n')[0].trim()
+    const entry = {
+      station,
+      system,
+      notes: notes || null,
+      systemDistance: cols[2] || '',
+      price: priceCell || '',
+      amount: amountCell || '',
+      updated: updatedCell || ''
+    }
+    if (entry.system || entry.station) {
+      results.push(entry)
+    }
+  }
+
+  // Enrich with local data if available
+  await Promise.all(results.map(async (result, idx) => {
+    const enriched = await getLocalStationDetails(result.system, result.station)
+    if (enriched) {
+      results[idx] = { ...result, ...enriched }
+    }
+  }))
+
+  return { results }
+}
+
+export default async function handler (req, res) {
+  if (req.method === 'GET') {
+    try {
+      const catalogue = await fetchCatalogue()
+      res.status(200).json(catalogue)
+    } catch (error) {
+      logMaterials(`CATALOGUE_ERROR: ${error.message}`)
+      res.status(500).json({ error: 'Unable to load INARA materials catalogue.' })
+    }
+    return
+  }
+
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  const {
+    materials = [],
+    mode = 'buy',
+    system = '',
+    minAmount,
+    maxPrice
+  } = req.body || {}
+
+  if (!Array.isArray(materials) || materials.length === 0) {
+    res.status(400).json({ error: 'Select at least one material before searching.' })
+    return
+  }
+
+  const catalogue = await fetchCatalogue()
+  const validValues = new Set(catalogue.materials.map(item => item.inaraValue))
+  const selectedMaterials = materials.filter(value => validValues.has(value))
+  if (selectedMaterials.length === 0) {
+    res.status(400).json({ error: 'Selected materials are not recognised by INARA.' })
+    return
+  }
+
+  const payloadKey = cacheKey({ materials: selectedMaterials, mode, system, minAmount, maxPrice })
+  const cached = getCache(payloadKey)
+  if (cached) {
+    res.status(200).json(cached)
+    return
+  }
+
+  const params = new URLSearchParams()
+  const modeValue = String(mode).toLowerCase() === 'sell' ? '2' : '1'
+  params.append('pi1', modeValue)
+  selectedMaterials.forEach(value => params.append('pa1[]', value))
+  if (system) params.append('ps1', system)
+  if (minAmount !== undefined && minAmount !== null && minAmount !== '') params.append('pi2', String(minAmount))
+  if (maxPrice !== undefined && maxPrice !== null && maxPrice !== '') params.append('pi3', String(maxPrice))
+  params.append('formbrief', '1')
+
+  const url = `https://inara.cz/elite/market-materials/?${params.toString()}`
+  logMaterials(`REQUEST ${url}`)
+
+  try {
+    const response = await fetch(url, { headers })
+    if (!response.ok) throw new Error(`INARA request failed (${response.status})`)
+    const html = await response.text()
+    const parsed = await buildResults(html)
+    setCache(payloadKey, parsed)
+    res.status(200).json(parsed)
+  } catch (error) {
+    logMaterials(`REQUEST_ERROR ${error.message}`)
+    res.status(500).json({ error: 'Unable to query INARA components trading at the moment.' })
+  }
+}

--- a/src/client/pages/api/inara-websearch.js
+++ b/src/client/pages/api/inara-websearch.js
@@ -1,53 +1,18 @@
-
 // Backend API: Proxies INARA nearest-outfitting for ships only
 // Only supports ship search (not modules or other outfitting)
-
 
 import fetch from 'node-fetch'
 import path from 'path'
 import fs from 'fs'
-import System from '../../../service/lib/event-handlers/system.js'
+import { getLocalStationDetails } from './_lib/inara.js'
 const logPath = path.join(process.cwd(), 'inara-websearch.log')
-function logInaraSearch(entry) {
+function logInaraSearch (entry) {
   try {
     fs.appendFileSync(logPath, `[${new Date().toISOString()}] ${entry}\n`)
   } catch (e) {}
 }
 
-export default async function handler(req, res) {
-  // Helper: get local station details from ICARUS data
-  async function getLocalStationDetails(systemName, stationName) {
-    try {
-      // Use global cache if available, else instantiate System
-      let sysInstance = global.ICARUS_SYSTEM_INSTANCE
-      if (!sysInstance) {
-        sysInstance = new System({ eliteLog: { getEvent: async () => null, getEventsFromTimestamp: async () => [], _query: async () => [] } })
-        global.ICARUS_SYSTEM_INSTANCE = sysInstance
-      }
-      const sysData = await sysInstance.getSystem({ name: systemName })
-      if (!sysData || !sysData.spaceStations) return null;
-      // Find station by name (case-insensitive)
-      const station = sysData.spaceStations.find(s => s.name && s.name.toLowerCase() === stationName.toLowerCase());
-      if (!station) return null;
-      // Return canonical details
-      return {
-        padSize: station.landingPads?.large ? 'Large' : station.landingPads?.medium ? 'Medium' : station.landingPads?.small ? 'Small' : '',
-        market: !!station.haveMarket,
-        outfitting: !!station.haveOutfitting,
-        shipyard: !!station.haveShipyard,
-        stationDistance: station.distanceToArrival ? `${Math.round(station.distanceToArrival)} Ls` : '',
-        type: station.type || '',
-        services: station.otherServices || [],
-        economies: station.economies || [],
-        faction: station.faction || '',
-        government: station.government || '',
-        allegiance: station.allegiance || '',
-        updatedAt: station.updatedAt || '',
-      };
-    } catch (e) {
-      return null;
-    }
-  }
+export default async function handler (req, res) {
   if (req.method !== 'POST') {
     logInaraSearch(`INVALID_METHOD: ${req.method} ${req.url}`)
     res.status(405).json({ error: 'Method not allowed' })
@@ -60,7 +25,6 @@ export default async function handler(req, res) {
     return
   }
 
-
   // Map shipId to INARA xshipXX code using shipyard.json
   let xshipCode = null
   try {
@@ -70,15 +34,15 @@ export default async function handler(req, res) {
     if (ship) {
       // Full mapping from INARA ships page (https://inara.cz/elite/ships)
       const inaraShipMap = {
-        'Sidewinder': 'xship1',
-        'Eagle': 'xship2',
-        'Hauler': 'xship3',
-        'Adder': 'xship15',
+        Sidewinder: 'xship1',
+        Eagle: 'xship2',
+        Hauler: 'xship3',
+        Adder: 'xship15',
         'Viper MkIII': 'xship5',
         'Cobra MkIII': 'xship7',
         'Viper MkIV': 'xship9',
         'Type-6 Transporter': 'xship10',
-        'Keelback': 'xship11',
+        Keelback: 'xship11',
         'Type-7 Transporter': 'xship12',
         'Type-9 Heavy': 'xship14',
         'Asp Explorer': 'xship18',
@@ -86,7 +50,7 @@ export default async function handler(req, res) {
         'Diamondback Explorer': 'xship28',
         'Cobra MkIV': 'xship35',
         'Type-10 Defender': 'xship34',
-        'Dolphin': 'xship4',
+        Dolphin: 'xship4',
         'Imperial Eagle': 'xship6',
         'Imperial Courier': 'xship8',
         'Imperial Clipper': 'xship19',
@@ -95,19 +59,19 @@ export default async function handler(req, res) {
         'Federal Assault Ship': 'xship29',
         'Federal Gunship': 'xship30',
         'Federal Corvette': 'xship31',
-        'Orca': 'xship24',
+        Orca: 'xship24',
         'Beluga Liner': 'xship25',
         'Fer-de-Lance': 'xship21',
-        'Mamba': 'xship37',
+        Mamba: 'xship37',
         'Krait MkII': 'xship27',
         'Krait Phantom': 'xship36',
-        'Python': 'xship16',
-        'Anaconda': 'xship22',
-        'Vulture': 'xship17',
+        Python: 'xship16',
+        Anaconda: 'xship22',
+        Vulture: 'xship17',
         'Asp Scout': 'xship33',
         'Alliance Chieftain': 'xship38',
         'Alliance Crusader': 'xship39',
-        'Alliance Challenger': 'xship40',
+        'Alliance Challenger': 'xship40'
       }
       xshipCode = inaraShipMap[ship.name] || null
     }
@@ -153,84 +117,84 @@ export default async function handler(req, res) {
       return
     }
     // Find the first <table> after the 'SHIPS, MODULES AND PERSONAL EQUIPMENT SEARCH RESULTS' heading, or just the first <table>
-    let tableHtml = null;
-    const headingIdx = html.indexOf('SHIPS, MODULES AND PERSONAL EQUIPMENT SEARCH RESULTS');
+    let tableHtml = null
+    const headingIdx = html.indexOf('SHIPS, MODULES AND PERSONAL EQUIPMENT SEARCH RESULTS')
     if (headingIdx !== -1) {
-      const afterHeading = html.slice(headingIdx);
-      const tableMatch = afterHeading.match(/<table[\s\S]*?<\/table>/i);
-      if (tableMatch) tableHtml = tableMatch[0];
+      const afterHeading = html.slice(headingIdx)
+      const tableMatch = afterHeading.match(/<table[\s\S]*?<\/table>/i)
+      if (tableMatch) tableHtml = tableMatch[0]
     }
     if (!tableHtml) {
       // fallback: just first table in HTML
-      const tableMatch = html.match(/<table[\s\S]*?<\/table>/i);
-      if (tableMatch) tableHtml = tableMatch[0];
+      const tableMatch = html.match(/<table[\s\S]*?<\/table>/i)
+      if (tableMatch) tableHtml = tableMatch[0]
     }
     if (tableHtml) {
-      const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
-      let rowMatch;
-      let headerSkipped = false;
+      const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi
+      let rowMatch
+      let headerSkipped = false
       while ((rowMatch = rowRegex.exec(tableHtml))) {
-        const rowHtml = rowMatch[1];
+        const rowHtml = rowMatch[1]
         // Extract columns
-        const cols = [...rowHtml.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)].map(m => m[1].replace(/<[^>]+>/g, '').trim());
+        const cols = [...rowHtml.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)].map(m => m[1].replace(/<[^>]+>/g, '').trim())
         // Skip header row (may be <th> or <td> with 'Station')
         if (!headerSkipped && (cols.includes('Station') || cols.includes('System'))) {
-          headerSkipped = true;
-          continue;
+          headerSkipped = true
+          continue
         }
         if (cols.length >= 5) {
           // Parse station, system, notes from cols[0]
-          let stationRaw = cols[0];
-          let station = stationRaw;
-          let system = cols[1];
-          let notes = '';
+          const stationRaw = cols[0]
+          let station = stationRaw
+          let system = cols[1]
+          let notes = ''
           if (stationRaw.includes('|')) {
-            const parts = stationRaw.split('|');
-            station = parts[0].trim();
-            let rest = parts[1].trim();
+            const parts = stationRaw.split('|')
+            station = parts[0].trim()
+            let rest = parts[1].trim()
             // Remove all non-ASCII and non-printable chars from rest
-            rest = rest.replace(/[^\x20-\x7E]+/g, '');
+            rest = rest.replace(/[^\x20-\x7E]+/g, '')
             // System name: up to first non-word/space character (e.g. before dash, percent, etc)
-            const sysMatch = rest.match(/^([\w\s'-]+?)(?:\s*[-–—%].*)?$/u);
+            const sysMatch = rest.match(/^([\w\s'-]+?)(?:\s*[-–—%].*)?$/u)
             if (sysMatch) {
-              system = sysMatch[1].trim();
+              system = sysMatch[1].trim()
               // Notes: everything after system name
-              notes = rest.slice(sysMatch[1].length).replace(/^[-–—%\s]+/, '').trim();
+              notes = rest.slice(sysMatch[1].length).replace(/^[-–—%\s]+/, '').trim()
             } else {
-              system = rest;
+              system = rest
             }
           }
           // Distance (system distance, in Ly)
-          let systemDistance = '';
-          let stationDistance = '';
+          let systemDistance = ''
+          let stationDistance = ''
           // Try to extract number and 'Ly' from cols[2] and cols[3] (sometimes in either)
-          const lyMatch = (cols[2] + ' ' + (cols[3] || '')).match(/([\d.]+)\s*Ly/);
-          if (lyMatch) systemDistance = lyMatch[0].trim();
+          const lyMatch = (cols[2] + ' ' + (cols[3] || '')).match(/([\d.]+)\s*Ly/)
+          if (lyMatch) systemDistance = lyMatch[0].trim()
           // Try to extract number and 'Ls' from cols[4] and cols[3] (sometimes in either)
-          const lsMatch = (cols[4] + ' ' + (cols[3] || '')).match(/([\d,]+)\s*Ls/);
-          if (lsMatch) stationDistance = lsMatch[0].replace(/,/g, '').trim();
+          const lsMatch = (cols[4] + ' ' + (cols[3] || '')).match(/([\d,]+)\s*Ls/)
+          if (lsMatch) stationDistance = lsMatch[0].replace(/,/g, '').trim()
           // Updated time (try to extract from cols[3] or cols[5] if present)
-          let updated = '';
+          let updated = ''
           if (cols.length >= 6) {
-            updated = cols[5];
+            updated = cols[5]
           } else {
-            if (/\d{1,2}:\d{2}/.test(cols[3])) updated = cols[3];
-            else if (/(\d+\s+(minutes?|hours?|days?)\s+ago)/i.test(cols[3])) updated = cols[3];
+            if (/\d{1,2}:\d{2}/.test(cols[3])) updated = cols[3]
+            else if (/(\d+\s+(minutes?|hours?|days?)\s+ago)/i.test(cols[3])) updated = cols[3]
           }
           // Guess station type for icon (from station name)
-          let stationType = '';
-          const nameLower = station.toLowerCase();
-          if (nameLower.includes('outpost')) stationType = 'outpost';
-          else if (nameLower.includes('asteroid')) stationType = 'asteroid-base';
-          else if (nameLower.includes('ocellus')) stationType = 'ocellus-starport';
-          else if (nameLower.includes('orbis')) stationType = 'orbis-starport';
-          else if (nameLower.includes('megaship')) stationType = 'megaship';
-          else if (nameLower.includes('planetary')) stationType = 'planetary-port';
-          else if (nameLower.includes('settlement')) stationType = 'settlement';
-          else stationType = 'coriolis-starport';
+          let stationType = ''
+          const nameLower = station.toLowerCase()
+          if (nameLower.includes('outpost')) stationType = 'outpost'
+          else if (nameLower.includes('asteroid')) stationType = 'asteroid-base'
+          else if (nameLower.includes('ocellus')) stationType = 'ocellus-starport'
+          else if (nameLower.includes('orbis')) stationType = 'orbis-starport'
+          else if (nameLower.includes('megaship')) stationType = 'megaship'
+          else if (nameLower.includes('planetary')) stationType = 'planetary-port'
+          else if (nameLower.includes('settlement')) stationType = 'settlement'
+          else stationType = 'coriolis-starport'
 
           // Merge in local ICARUS data
-          let localDetails = await getLocalStationDetails(system, station);
+          const localDetails = await getLocalStationDetails(system, station)
           results.push({
             station,
             system,
@@ -242,12 +206,12 @@ export default async function handler(req, res) {
             price: '',
             distance: systemDistance,
             ...localDetails
-          });
+          })
         }
       }
     }
-    logInaraSearch(`RESPONSE: shipId=${shipId} system=${system} url=${url} results=${results.length}`);
-    res.status(200).json({ results });
+    logInaraSearch(`RESPONSE: shipId=${shipId} system=${system} url=${url} results=${results.length}`)
+    res.status(200).json({ results })
   } catch (err) {
     logInaraSearch(`ERROR: shipId=${shipId} system=${system} url=${url} error=${err}`)
     res.status(500).json({ error: 'Failed to fetch or parse INARA results', details: err.message })

--- a/src/client/pages/inara/materials.js
+++ b/src/client/pages/inara/materials.js
@@ -1,0 +1,463 @@
+import { useState, useEffect, useMemo, Fragment } from 'react'
+import { useRouter } from 'next/router'
+import Layout from '../../components/layout'
+import Panel from '../../components/panel'
+import PanelNavigation from '../../components/panel-navigation'
+
+const navItems = [
+  {
+    name: 'Search',
+    icon: 'search',
+    url: '/inara/search'
+  },
+  {
+    name: 'Ships',
+    icon: 'ship',
+    url: '/inara/ships'
+  },
+  {
+    name: 'Materials',
+    icon: 'materials',
+    url: '/inara/materials'
+  }
+]
+
+const MODE_OPTIONS = [
+  { value: 'buy', label: 'Buy' },
+  { value: 'sell', label: 'Sell' }
+]
+
+const MAX_SELECTION = 10
+const PRESET_STORAGE_KEY = 'INARA_MATERIALS_PRESET'
+
+function useCatalogue () {
+  const [catalogue, setCatalogue] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let mounted = true
+    setLoading(true)
+    fetch('/api/inara-materials')
+      .then(res => res.json())
+      .then(data => {
+        if (!mounted) return
+        if (data.error) {
+          setError(data.error)
+        } else {
+          setCatalogue(data)
+          setError('')
+        }
+      })
+      .catch(() => mounted && setError('Unable to load INARA catalogue.'))
+      .finally(() => mounted && setLoading(false))
+    return () => { mounted = false }
+  }, [])
+
+  return { catalogue, loading, error }
+}
+
+function useCurrentSystems () {
+  const [systems, setSystems] = useState({ currentSystem: null, nearby: [] })
+
+  useEffect(() => {
+    let mounted = true
+    fetch('/api/current-system')
+      .then(res => res.json())
+      .then(data => mounted && setSystems({ currentSystem: data.currentSystem, nearby: data.nearby || [] }))
+      .catch(() => mounted && setSystems({ currentSystem: null, nearby: [] }))
+    return () => { mounted = false }
+  }, [])
+
+  return systems
+}
+
+function toArray (value) {
+  if (!value) return []
+  if (Array.isArray(value)) return value
+  return [value]
+}
+
+export default function InaraMaterialsPage () {
+  const router = useRouter()
+  const { catalogue, loading: catalogueLoading, error: catalogueError } = useCatalogue()
+  const { currentSystem, nearby } = useCurrentSystems()
+
+  const [mode, setMode] = useState('buy')
+  const [selectedMaterials, setSelectedMaterials] = useState([])
+  const [selectedSystem, setSelectedSystem] = useState('')
+  const [minAmount, setMinAmount] = useState(0)
+  const [maxPrice, setMaxPrice] = useState(0)
+  const [results, setResults] = useState(null)
+  const [resultsMessage, setResultsMessage] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [expandedRow, setExpandedRow] = useState(null)
+  const [presetApplied, setPresetApplied] = useState(false)
+
+  const materialsByValue = useMemo(() => {
+    const map = new Map()
+    catalogue?.materials?.forEach(item => {
+      map.set(item.inaraValue, item)
+      if (item.symbol) map.set(item.symbol.toLowerCase(), item)
+      if (item.name) map.set(item.name.toLowerCase(), item)
+    })
+    return map
+  }, [catalogue])
+
+  const groupedMaterials = useMemo(() => {
+    if (!catalogue?.materials) return []
+    const groups = new Map()
+    catalogue.materials.forEach(item => {
+      const key = item.categoryLabel || 'Other'
+      if (!groups.has(key)) groups.set(key, [])
+      groups.get(key).push(item)
+    })
+    return Array.from(groups.entries()).map(([label, items]) => ({
+      label,
+      items: items.sort((a, b) => a.name.localeCompare(b.name))
+    })).sort((a, b) => a.label.localeCompare(b.label))
+  }, [catalogue])
+
+  useEffect(() => {
+    if (!catalogue || presetApplied) return
+    const queryMaterials = toArray(router.query.materials || router.query.material)
+    const queryMode = router.query.mode
+    const presetFromQuery = queryMaterials
+      .map(value => {
+        const match = materialsByValue.get(value) || materialsByValue.get(value?.toLowerCase?.())
+        if (!match) return null
+        if (match.inaraValue) return match.inaraValue
+        if (match.symbol) {
+          const viaSymbol = materialsByValue.get(match.symbol.toLowerCase())
+          if (viaSymbol?.inaraValue) return viaSymbol.inaraValue
+        }
+        return null
+      })
+      .filter(Boolean)
+    const preset = { materials: presetFromQuery, mode: queryMode }
+
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = window.sessionStorage.getItem(PRESET_STORAGE_KEY)
+        if (stored) {
+          const parsed = JSON.parse(stored)
+          window.sessionStorage.removeItem(PRESET_STORAGE_KEY)
+          preset.materials = (parsed?.materials || []).map(entry => {
+            if (materialsByValue.has(entry)) {
+              const hit = materialsByValue.get(entry)
+              if (hit?.inaraValue) return hit.inaraValue
+            }
+            const normalised = entry?.toLowerCase?.()
+            if (materialsByValue.has(normalised)) {
+              const hit = materialsByValue.get(normalised)
+              if (hit?.inaraValue) return hit.inaraValue
+            }
+            return null
+          }).filter(Boolean)
+          if (parsed?.mode) preset.mode = parsed.mode
+          if (parsed?.system) setSelectedSystem(parsed.system)
+        }
+      } catch (err) {
+        // ignore preset parsing errors
+      }
+    }
+
+    if (preset.materials.length) {
+      const unique = Array.from(new Set(preset.materials))
+      setSelectedMaterials(unique.slice(0, MAX_SELECTION))
+    }
+    if (preset.mode && ['buy', 'sell'].includes(String(preset.mode).toLowerCase())) {
+      setMode(String(preset.mode).toLowerCase())
+    }
+    setPresetApplied(true)
+  }, [catalogue, materialsByValue, presetApplied, router.query])
+
+  const selectedDetails = useMemo(() => {
+    return selectedMaterials.map(value => materialsByValue.get(value)).filter(Boolean)
+  }, [selectedMaterials, materialsByValue])
+
+  const systemsList = useMemo(() => {
+    const list = []
+    if (currentSystem?.name) {
+      list.push({ name: currentSystem.name, distance: 0, highlight: true })
+    }
+    nearby?.forEach(system => {
+      if (!list.find(item => item.name.toLowerCase() === system.name?.toLowerCase())) {
+        list.push(system)
+      }
+    })
+    return list
+  }, [currentSystem, nearby])
+
+  function toggleMaterial (value) {
+    setSelectedMaterials(prev => {
+      const exists = prev.includes(value)
+      if (exists) return prev.filter(item => item !== value)
+      if (prev.length >= MAX_SELECTION) return prev
+      return [...prev, value]
+    })
+  }
+
+  function clearSelection () {
+    setSelectedMaterials([])
+  }
+
+  async function executeSearch () {
+    if (!selectedMaterials.length) {
+      setError('Select at least one material first.')
+      return
+    }
+    setLoading(true)
+    setError('')
+    setResults(null)
+    setResultsMessage('')
+    setExpandedRow(null)
+    try {
+      const payload = {
+        materials: selectedMaterials,
+        mode,
+        system: selectedSystem,
+        minAmount: minAmount || '',
+        maxPrice: maxPrice || ''
+      }
+      const response = await fetch('/api/inara-materials', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+      const data = await response.json()
+      if (!response.ok || data.error) {
+        throw new Error(data.error || 'Search failed')
+      }
+      setResults(data.results || [])
+      setResultsMessage(data.message || '')
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Layout>
+      <PanelNavigation items={navItems.map(item => ({ ...item, active: item.name === 'Materials' }))} />
+      <Panel layout='full-width' scrollable search={false}>
+        <div style={{ padding: '2rem', color: '#fff' }}>
+          <h2 style={{ marginBottom: '1rem' }}>Touch Materials Finder</h2>
+          <p style={{ maxWidth: '52rem', color: '#aaa', marginBottom: '2rem' }}>
+            Choose up to ten Odyssey components or materials, set optional amount and price limits, then launch the INARA market materials search without any typing.
+          </p>
+
+          <section style={{ marginBottom: '2rem' }}>
+            <h3 style={{ color: '#ff7c22', marginBottom: '1rem' }}>Mode</h3>
+            <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+              {MODE_OPTIONS.map(option => (
+                <button
+                  key={option.value}
+                  className={`button button--secondary ${mode === option.value ? 'button--active' : ''}`}
+                  style={{ minWidth: '8rem', padding: '1.25rem 1.75rem', fontSize: '1.2rem' }}
+                  onClick={() => setMode(option.value)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section style={{ marginBottom: '2rem' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+              <h3 style={{ color: '#ff7c22' }}>Materials</h3>
+              <div>
+                <span style={{ color: '#aaa', marginRight: '1rem' }}>{selectedMaterials.length}/{MAX_SELECTION} selected</span>
+                <button className='button button--transparent' style={{ color: '#3af' }} onClick={clearSelection}>Clear</button>
+              </div>
+            </div>
+            {catalogueLoading && <div style={{ color: '#aaa', fontSize: '1.1rem' }}>Loading catalogue…</div>}
+            {catalogueError && <div style={{ color: '#ff4d4f' }}>{catalogueError}</div>}
+            {!catalogueLoading && groupedMaterials.map(group => (
+              <div key={group.label} style={{ marginBottom: '1.5rem' }}>
+                <h4 style={{ color: '#eee', marginBottom: '.75rem' }}>{group.label}</h4>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '.75rem' }}>
+                  {group.items.map(item => {
+                    const selected = selectedMaterials.includes(item.inaraValue)
+                    return (
+                      <button
+                        key={item.inaraValue}
+                        className={`button button--secondary ${selected ? 'button--active' : ''}`}
+                        style={{ padding: '1rem 1.5rem', borderRadius: '1.25rem', fontSize: '1.05rem', minWidth: '9rem' }}
+                        onClick={() => toggleMaterial(item.inaraValue)}
+                      >
+                        {item.name}
+                        {item.rarityLabel && <span style={{ display: 'block', fontSize: '.85rem', color: selected ? '#ffd166' : '#999' }}>{item.rarityLabel}</span>}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            ))}
+            {selectedDetails.length > 0 && (
+              <div style={{ marginTop: '1.5rem', background: '#141414', padding: '1rem 1.5rem', borderRadius: '1rem', border: '1px solid #222' }}>
+                <h4 style={{ color: '#ff7c22', marginBottom: '.5rem' }}>Selected</h4>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '.75rem' }}>
+                  {selectedDetails.map(item => (
+                    <span key={`selected-${item.inaraValue}`} className='button button--secondary button--active' style={{ borderRadius: '1.25rem', padding: '.75rem 1.25rem', fontSize: '1rem' }}>
+                      {item.name}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+
+          <section style={{ marginBottom: '2rem' }}>
+            <h3 style={{ color: '#ff7c22', marginBottom: '1rem' }}>Reference system</h3>
+            <div style={{ display: 'flex', gap: '1rem', overflowX: 'auto', paddingBottom: '.5rem' }}>
+              <button
+                className={`button button--secondary ${!selectedSystem ? 'button--active' : ''}`}
+                style={{ minWidth: '9rem', padding: '1.25rem 1.5rem', borderRadius: '1rem' }}
+                onClick={() => setSelectedSystem('')}
+              >
+                Anywhere
+              </button>
+              {systemsList.map(system => {
+                const isActive = selectedSystem && selectedSystem.toLowerCase() === system.name?.toLowerCase()
+                return (
+                  <button
+                    key={system.name}
+                    className={`button button--secondary ${isActive ? 'button--active' : ''}`}
+                    style={{ minWidth: '10rem', padding: '1.25rem 1.5rem', borderRadius: '1rem', textAlign: 'left' }}
+                    onClick={() => setSelectedSystem(system.name)}
+                  >
+                    <div style={{ fontWeight: 600 }}>{system.name}</div>
+                    {typeof system.distance === 'number' && (
+                      <div style={{ color: '#aaa', fontSize: '.9rem' }}>{system.distance === 0 ? 'Current system' : `${system.distance.toFixed(2)} ly`}</div>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          </section>
+
+          <section style={{ marginBottom: '2rem', display: 'flex', flexWrap: 'wrap', gap: '2rem' }}>
+            <div style={{ flex: '1 1 260px' }}>
+              <h3 style={{ color: '#ff7c22', marginBottom: '.75rem' }}>Minimum amount</h3>
+              <div style={{ background: '#141414', padding: '1.25rem', borderRadius: '1rem', border: '1px solid #222' }}>
+                <input
+                  type='range'
+                  min='0'
+                  max='500'
+                  step='5'
+                  value={minAmount}
+                  onChange={event => setMinAmount(Number(event.target.value))}
+                  style={{ width: '100%', accentColor: '#ff7c22', height: '3rem' }}
+                />
+                <div style={{ textAlign: 'center', marginTop: '.75rem', fontSize: '1.2rem' }}>
+                  {minAmount ? `${minAmount}+ units` : 'Any amount'}
+                </div>
+              </div>
+            </div>
+            <div style={{ flex: '1 1 260px' }}>
+              <h3 style={{ color: '#ff7c22', marginBottom: '.75rem' }}>Maximum price</h3>
+              <div style={{ background: '#141414', padding: '1.25rem', borderRadius: '1rem', border: '1px solid #222' }}>
+                <input
+                  type='range'
+                  min='0'
+                  max='100000'
+                  step='500'
+                  value={maxPrice}
+                  onChange={event => setMaxPrice(Number(event.target.value))}
+                  style={{ width: '100%', accentColor: '#ff7c22', height: '3rem' }}
+                />
+                <div style={{ textAlign: 'center', marginTop: '.75rem', fontSize: '1.2rem' }}>
+                  {maxPrice ? '< ' + maxPrice.toLocaleString() + ' cr' : 'Any price'}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1.5rem', alignItems: 'center', marginBottom: '2.5rem' }}>
+            <button
+              className='button button--active'
+              style={{ padding: '1.2rem 2.4rem', fontSize: '1.3rem', borderRadius: '1.1rem' }}
+              onClick={executeSearch}
+              disabled={loading || catalogueLoading}
+            >
+              {loading ? 'Searching…' : 'Search INARA'}
+            </button>
+            {error && <span style={{ color: '#ff4d4f', fontSize: '1.1rem' }}>{error}</span>}
+          </div>
+
+          <section>
+            <h3 style={{ color: '#ff7c22', marginBottom: '1rem' }}>Results</h3>
+            {loading && <div style={{ color: '#aaa' }}>Querying INARA…</div>}
+            {!loading && results && results.length === 0 && (
+              <div style={{ color: '#aaa' }}>{resultsMessage || 'No matching markets reported.'}</div>
+            )}
+            {!loading && results && results.length > 0 && (
+              <div className='navigation-panel__list' style={{ padding: 0, background: 'none', border: 'none', color: '#fff' }}>
+                <div className='scrollable' style={{ maxHeight: '32rem', overflow: 'auto' }}>
+                  <table className='table--animated table--interactive' style={{ width: '100%', borderCollapse: 'collapse', color: '#fff' }}>
+                    <thead>
+                      <tr>
+                        <th style={{ padding: '.75rem', textAlign: 'left' }}>Station</th>
+                        <th style={{ padding: '.75rem', textAlign: 'left' }}>System</th>
+                        <th className='hidden-small' style={{ padding: '.75rem', textAlign: 'right' }}>System distance</th>
+                        <th className='hidden-small' style={{ padding: '.75rem', textAlign: 'right' }}>{mode === 'buy' ? 'Sell price' : 'Buy price'}</th>
+                        <th className='hidden-small' style={{ padding: '.75rem', textAlign: 'right' }}>Stock</th>
+                        <th className='hidden-small' style={{ padding: '.75rem', textAlign: 'right' }}>Updated</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {results.map((row, index) => {
+                        const expanded = expandedRow === index
+                        return (
+                          <Fragment key={`result-${index}`}>
+                            <tr
+                              key={`row-${index}`}
+                              className={expanded ? 'expanded-row' : ''}
+                              style={{ cursor: 'pointer' }}
+                              onClick={() => setExpandedRow(expanded ? null : index)}
+                            >
+                              <td style={{ padding: '.75rem' }}>
+                                <div style={{ fontWeight: 600 }}>{row.station}</div>
+                                {row.notes && <div style={{ color: '#3af', fontSize: '.95rem' }}>{row.notes}</div>}
+                              </td>
+                              <td style={{ padding: '.75rem' }}>
+                                {row.system}
+                              </td>
+                              <td className='hidden-small' style={{ padding: '.75rem', textAlign: 'right' }}>{row.systemDistance || '—'}</td>
+                              <td className='hidden-small' style={{ padding: '.75rem', textAlign: 'right' }}>{row.price || '—'}</td>
+                              <td className='hidden-small' style={{ padding: '.75rem', textAlign: 'right' }}>{row.amount || '—'}</td>
+                              <td className='hidden-small' style={{ padding: '.75rem', textAlign: 'right' }}>{row.updated || '—'}</td>
+                            </tr>
+                            {expanded && (
+                              <tr key={`expanded-${index}`} className='expanded-details-row'>
+                                <td colSpan='6' style={{ background: '#111', padding: '1.5rem 2rem', borderTop: '1px solid #333' }}>
+                                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '2rem', fontSize: '1rem' }}>
+                                    <div><strong>Pad size:</strong> {row.padSize || 'Unknown'}</div>
+                                    <div><strong>Station type:</strong> {row.type || row.stationType || 'Unknown'}</div>
+                                    <div><strong>Market:</strong> {row.market ? 'Yes' : 'No'}</div>
+                                    <div><strong>Services:</strong> {row.services?.length ? row.services.join(', ') : 'None listed'}</div>
+                                    <div><strong>Economies:</strong> {row.economies?.length ? row.economies.map(e => e.name || e).join(', ') : 'Unknown'}</div>
+                                    {row.stationDistance && <div><strong>Arrival:</strong> {row.stationDistance}</div>}
+                                    {row.faction && <div><strong>Faction:</strong> {row.faction}</div>}
+                                    {row.updatedAt && <div><strong>Last update:</strong> {row.updatedAt}</div>}
+                                  </div>
+                                </td>
+                              </tr>
+                            )}
+                          </Fragment>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+      </Panel>
+    </Layout>
+  )
+}

--- a/src/client/pages/inara/outfitting.js
+++ b/src/client/pages/inara/outfitting.js
@@ -3,6 +3,8 @@ import Panel from 'components/panel'
 import PanelNavigation from 'components/panel-navigation'
 import { useRouter } from 'next/router'
 
+import { useState } from 'react'
+
 const navItems = [
   {
     name: 'Search',
@@ -15,9 +17,14 @@ const navItems = [
     icon: 'ship',
     url: '/inara/ships',
     active: true
+  },
+  {
+    name: 'Materials',
+    icon: 'materials',
+    url: '/inara/materials',
+    active: false
   }
 ]
-
 
 // Example ship list (should be loaded from backend or static file)
 const ships = [
@@ -40,10 +47,7 @@ const ships = [
   { id: '128049345', name: 'Beluga Liner' }
 ]
 
-import { useState } from 'react'
-
-
-export default function InaraShipsPage() {
+export default function InaraShipsPage () {
   const [selectedShip, setSelectedShip] = useState('')
   const [system, setSystem] = useState('')
 

--- a/src/client/pages/inara/search.js
+++ b/src/client/pages/inara/search.js
@@ -10,14 +10,20 @@ const navItems = [
     active: true
   },
   {
-    name: 'Outfitting',
-    icon: 'wrench',
-    url: '/inara/outfitting',
+    name: 'Ships',
+    icon: 'ship',
+    url: '/inara/ships',
+    active: false
+  },
+  {
+    name: 'Materials',
+    icon: 'materials',
+    url: '/inara/materials',
     active: false
   }
 ]
 
-export default function InaraSearchPage() {
+export default function InaraSearchPage () {
   return (
     <Layout>
       <PanelNavigation items={navItems} />

--- a/src/client/pages/inara/ships.js
+++ b/src/client/pages/inara/ships.js
@@ -18,17 +18,23 @@ const navItems = [
     icon: 'ship',
     url: '/inara/ships',
     active: true
+  },
+  {
+    name: 'Materials',
+    icon: 'materials',
+    url: '/inara/materials',
+    active: false
   }
 ]
 
-export default function InaraShipsPage() {
+export default function InaraShipsPage () {
   const [selectedShip, setSelectedShip] = useState('')
   const [system, setSystem] = useState('')
   const [results, setResults] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
-  async function handleSubmit(e) {
+  async function handleSubmit (e) {
     e.preventDefault()
     setResults(null)
     setError('')
@@ -78,32 +84,34 @@ export default function InaraShipsPage() {
         {results && (
           <div style={{ maxWidth: 900, margin: '2rem auto', background: '#181818', border: '1px solid #333', borderRadius: '1rem', padding: '2rem' }}>
             <h3 style={{ color: '#ff7c22', marginBottom: '1rem' }}>Results</h3>
-            {results.length === 0 ? (
-              <div style={{ color: '#aaa' }}>No stations found with this ship for sale near {system}.</div>
-            ) : (
-              <table style={{ width: '100%', borderCollapse: 'collapse', color: '#fff' }}>
-                <thead>
-                  <tr style={{ background: '#222' }}>
-                    <th style={{ padding: '.5rem', borderBottom: '1px solid #444', textAlign: 'left' }}>Station</th>
-                    <th style={{ padding: '.5rem', borderBottom: '1px solid #444', textAlign: 'left' }}>System</th>
-                    <th style={{ padding: '.5rem', borderBottom: '1px solid #444', textAlign: 'right' }}>Distance</th>
-                    <th style={{ padding: '.5rem', borderBottom: '1px solid #444', textAlign: 'right' }}>Price</th>
-                    <th style={{ padding: '.5rem', borderBottom: '1px solid #444', textAlign: 'right' }}>Updated</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {results.map((row, i) => (
-                    <tr key={i} style={{ background: i % 2 ? '#202020' : '#181818' }}>
-                      <td style={{ padding: '.5rem', borderBottom: '1px solid #333' }}>{row.station}</td>
-                      <td style={{ padding: '.5rem', borderBottom: '1px solid #333' }}>{row.system}</td>
-                      <td style={{ padding: '.5rem', borderBottom: '1px solid #333', textAlign: 'right' }}>{row.distance}</td>
-                      <td style={{ padding: '.5rem', borderBottom: '1px solid #333', textAlign: 'right' }}>{row.price}</td>
-                      <td style={{ padding: '.5rem', borderBottom: '1px solid #333', textAlign: 'right' }}>{row.updated}</td>
+            {results.length === 0
+              ? (
+                <div style={{ color: '#aaa' }}>No stations found with this ship for sale near {system}.</div>
+                )
+              : (
+                <table style={{ width: '100%', borderCollapse: 'collapse', color: '#fff' }}>
+                  <thead>
+                    <tr style={{ background: '#222' }}>
+                      <th style={{ padding: '.5rem', borderBottom: '1px solid #444', textAlign: 'left' }}>Station</th>
+                      <th style={{ padding: '.5rem', borderBottom: '1px solid #444', textAlign: 'left' }}>System</th>
+                      <th style={{ padding: '.5rem', borderBottom: '1px solid #444', textAlign: 'right' }}>Distance</th>
+                      <th style={{ padding: '.5rem', borderBottom: '1px solid #444', textAlign: 'right' }}>Price</th>
+                      <th style={{ padding: '.5rem', borderBottom: '1px solid #444', textAlign: 'right' }}>Updated</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
+                  </thead>
+                  <tbody>
+                    {results.map((row, i) => (
+                      <tr key={i} style={{ background: i % 2 ? '#202020' : '#181818' }}>
+                        <td style={{ padding: '.5rem', borderBottom: '1px solid #333' }}>{row.station}</td>
+                        <td style={{ padding: '.5rem', borderBottom: '1px solid #333' }}>{row.system}</td>
+                        <td style={{ padding: '.5rem', borderBottom: '1px solid #333', textAlign: 'right' }}>{row.distance}</td>
+                        <td style={{ padding: '.5rem', borderBottom: '1px solid #333', textAlign: 'right' }}>{row.price}</td>
+                        <td style={{ padding: '.5rem', borderBottom: '1px solid #333', textAlign: 'right' }}>{row.updated}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                )}
           </div>
         )}
       </Panel>


### PR DESCRIPTION
## Summary
- add a shared INARA helper and new /api/inara-materials endpoint that caches catalogue data, parses results, and enriches stations with local metadata
- build the touch-focused INARA materials page, navigation entry, and reusable client helper for preselecting searches from other panels
- expose an engineering materials shortcut that jumps into the INARA materials finder without typing

## Testing
- npm run lint:javascript *(fails: existing standard warnings throughout the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d88215878c8323a9859f10132b3777