### PR TITLE
Condense navigation route hops into grouped panel

### DIFF
--- a/src/client/css/panels/navigation-panel.css
+++ b/src/client/css/panels/navigation-panel.css
@@ -361,3 +361,130 @@ table.navigation-panel__route-plan tbody tr.table__row--highlight-primary-hover:
   color: var(--color-primary-dark) !important;
   text-shadow: none;
 }
+
+.navigation-panel__route-hop-cell {
+  padding: .75rem 1rem .75rem .5rem;
+}
+
+.navigation-panel__route-hop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+}
+
+.navigation-panel__route-hop-card {
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+  flex: 1 1 auto;
+}
+
+.navigation-panel__route-hop-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.navigation-panel__route-hop-system {
+  display: flex;
+  gap: .75rem;
+  align-items: flex-start;
+}
+
+.navigation-panel__route-hop-icon {
+  font-size: 2rem;
+  position: relative;
+  top: .15rem;
+}
+
+.navigation-panel__route-hop-system-meta {
+  margin-top: .25rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.navigation-panel__route-hop-system-count {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+}
+
+.navigation-panel__route-hop-system-count .icon {
+  font-size: 1.5rem;
+  position: relative;
+  top: .35rem;
+}
+
+.navigation-panel__route-hop-distance {
+  text-align: right;
+  min-width: 12rem;
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+
+.navigation-panel__route-hop-distance-label {
+  text-transform: uppercase;
+  font-size: 1.2rem;
+}
+
+.navigation-panel__route-hop-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.navigation-panel__route-hop-star {
+  flex: 1 1 auto;
+}
+
+.navigation-panel__route-hop-flags {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+}
+
+.navigation-panel__route-hop-flags .icarus-terminal-scan,
+.navigation-panel__route-hop-flags .icarus-terminal-fuel,
+.navigation-panel__route-hop-flags .icarus-terminal-warning {
+  font-size: 2rem;
+  position: relative;
+  top: .25rem;
+}
+
+.navigation-panel__route-hop-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.navigation-panel__route-hop-chevron .icon {
+  font-size: 1rem;
+}
+
+.navigation-panel__route-hop--visited {
+  opacity: .6;
+}
+
+@media only screen and (max-width: 799px) {
+  .navigation-panel__route-hop {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .navigation-panel__route-hop-distance {
+    text-align: left;
+    min-width: 0;
+  }
+
+  .navigation-panel__route-hop-chevron {
+    justify-content: flex-start;
+  }
+}

--- a/src/client/pages/nav/route.js
+++ b/src/client/pages/nav/route.js
@@ -118,68 +118,81 @@ export default function NavListPage () {
                         key={`nav-route_${route.system}`}
                         className={`${route?.isCurrentSystem === true ? 'table__row--highlighted' : 'table__row--highlight-primary-hover'}`}
                         onClick={() => router.push({ pathname: '/nav/map', query: { system: route?.system?.toLowerCase() } })}
-                        style={{top: '-.5rem', position: 'relative'}}
+                        style={{ top: '-.5rem', position: 'relative' }}
                       >
                         <td className='text-center' style={{ width: '3rem', paddingLeft: '.5rem', paddingRight: '.5rem' }}>
                           <span className={previouslyVistedSystem ? 'text-muted' : ''}>{i + 1}</span>
                         </td>
-                        <td style={{ paddingLeft: '3.5rem' }}>
-                          <div style={{ position: 'relative' }} className={previouslyVistedSystem ? 'text-muted' : ''}>
-                            <i style={{ position: 'absolute', top: '.5rem', left: '-3rem', fontSize: '2rem' }} className={`icon ${icon} visible-medium`} />
-                            <i style={{ position: 'absolute', top: '.4rem', left: '-3rem', fontSize: '2rem' }} className={`icon ${icon} hidden-medium`} />
-                            <span className='text-info'>{route.system}</span>
-                            <br/>
-                            {route.numberOfStars > 0 && <span className='text-no-wrap'>
-                              <span style={{marginRight: '1rem'}}>
-                                <i className='icon icarus-terminal-star' style={{ position: 'relative', top: '.35rem', fontSize: '1.5rem'}}/> {route.numberOfStars}
-                                <span className='hidden-small'> {route.numberOfStars === 1 ? 'Star' : 'Stars'}</span>
-                              </span>
-                              {route.numberOfPlanets > 0 && <>
-                                <i className='icon icarus-terminal-planet' style={{ position: 'relative', top: '.35rem', fontSize: '1.5rem'}}/> {route.numberOfPlanets}
-                                <span className='hidden-small'> {route.numberOfPlanets === 1 ? 'Planet' : 'Planets'}</span>
-                              </>}
-                            </span>}
-                            {route.numberOfStars < 1 && <>
-                              <span className='text-muted'>Unknown System</span>
-                            </>}
+                        <td className='navigation-panel__route-hop-cell'>
+                          <div className={`navigation-panel__route-hop ${previouslyVistedSystem ? 'navigation-panel__route-hop--visited' : ''}`}>
+                            <div className='navigation-panel__route-hop-card'>
+                              <div className='navigation-panel__route-hop-header'>
+                                <div className='navigation-panel__route-hop-system'>
+                                  <i className={`icon ${icon} navigation-panel__route-hop-icon visible-medium`} />
+                                  <i className={`icon ${icon} navigation-panel__route-hop-icon hidden-medium`} />
+                                  <div>
+                                    <span className='text-info'>{route.system}</span>
+                                    <div className='navigation-panel__route-hop-system-meta'>
+                                      {route.numberOfStars > 0 &&
+                                        <span className='text-no-wrap'>
+                                          <span className='navigation-panel__route-hop-system-count'>
+                                            <i className='icon icarus-terminal-star' /> {route.numberOfStars}
+                                            <span className='hidden-small'> {route.numberOfStars === 1 ? 'Star' : 'Stars'}</span>
+                                          </span>
+                                          {route.numberOfPlanets > 0 &&
+                                            <span className='navigation-panel__route-hop-system-count'>
+                                              <i className='icon icarus-terminal-planet' /> {route.numberOfPlanets}
+                                              <span className='hidden-small'> {route.numberOfPlanets === 1 ? 'Planet' : 'Planets'}</span>
+                                            </span>}
+                                        </span>}
+                                      {route.numberOfStars < 1 && <span className='text-muted'>Unknown System</span>}
+                                    </div>
+                                  </div>
+                                </div>
+                                <div className='navigation-panel__route-hop-distance'>
+                                  {route?.isCurrentSystem === true
+                                    ? <span className='text-muted'>Current System</span>
+                                    : (
+                                      <>
+                                        <span className='text-muted navigation-panel__route-hop-distance-label'>Distance from {navRoute?.currentSystem?.name ?? 'current system'}</span>
+                                        <span className='text-info text-no-wrap'>{route.distance.toLocaleString(undefined, { maximumFractionDigits: 2 })} Ly</span>
+                                      </>
+                                      )}
+                                </div>
+                              </div>
+                              <div className='navigation-panel__route-hop-meta'>
+                                <div className='navigation-panel__route-hop-star hidden-small hidden-medium'>
+                                  <span className='text-muted'>
+                                    {route.starClass.match(/^[DNH]/)
+                                      ? route.starClass.match(/^D/)
+                                        ? 'White Dwarf'
+                                        : route.starClass.match(/^N/)
+                                          ? 'Neutron Star'
+                                          : 'Black Hole'
+                                      : `${route.starClass} Class`}
+                                    {route.starClass.match(/^[OBAFGKM]/) ? <><br />Main Sequence</> : ''}
+                                  </span>
+                                </div>
+                                <div className='navigation-panel__route-hop-flags'>
+                                  {route?.isExplored === false &&
+                                    <span className='text-info'>
+                                      <i className='icarus-terminal-scan' />
+                                    </span>}
+                                  {route.starClass.match(/^[OBAFGKM]/) &&
+                                    <span className='text-info'>
+                                      <i className='icarus-terminal-fuel' />
+                                    </span>}
+                                  {route.starClass.match(/^[DNH]/) &&
+                                    <span className='text-danger'>
+                                      <i className='icarus-terminal-warning' />
+                                    </span>}
+                                </div>
+                              </div>
+                            </div>
+                            <div className='navigation-panel__route-hop-chevron'>
+                              <i className='icon icarus-terminal-chevron-right' />
+                            </div>
                           </div>
-                        </td>
-                        <td className='text-no-wrap hidden-small hidden-medium'>
-                            <span className='text-muted'>
-                              {route.starClass.match(/^[DNH]/)
-                                ? route.starClass.match(/^D/)
-                                    ? 'White Dwarf'
-                                    : route.starClass.match(/^N/)
-                                      ? 'Neutron Star'
-                                      : 'Black Hole'
-                                : `${route.starClass} Class`
-                              }
-                              {route.starClass.match(/^[OBAFGKM]/) ? <><br/>Main Sequence</> : ''}
-                            </span>
-                        </td>
-                        <td className='text-right' style={{ width: '1rem', paddingLeft: '.5rem', paddingRight: '.5rem' }}>
-                          <span className={previouslyVistedSystem ? 'text-info text-muted' : 'text-info'}>
-                            {route?.isExplored === false && <>
-                              <i className='icarus-terminal-scan' style={{ position: 'relative', fontSize: '2rem', top: '.25rem', marginRight: '.5rem' }}/>
-                              <br className='visible-small'/>
-                            </>}
-                          </span>
-                          <span className={previouslyVistedSystem ? 'text-muted' : ''}>
-                            {route.starClass.match(/^[OBAFGKM]/)
-                              ? <i className='icarus-terminal-fuel' style={{ position: 'relative', fontSize: '2rem', top: '.25rem', marginRight: '.5rem' }} />
-                              : route.starClass.match(/^[DNH]/) 
-                                ? <i className='text-danger icarus-terminal-warning' style={{ position: 'relative', fontSize: '2rem', top: '.25rem', marginRight: '.5rem' }} />
-                                : ''}
-                            </span>
-                        </td>
-                        <td className='text-right' style={{ width: '1rem' }}>
-                          <span className={previouslyVistedSystem ? 'text-muted' : ''}>
-                            {route?.isCurrentSystem === false && <span className=' text-no-wrap text-no-transform'>{route.distance.toLocaleString(undefined, { maximumFractionDigits: 2 })} Ly</span>}
-                            {route?.isCurrentSystem === true && <span className='text-muted'>Current System</span>}
-                          </span>
-                        </td>
-                        <td className='text-center' style={{ width: '1rem' }}>
-                          <i className='icon icarus-terminal-chevron-right' style={{ fontSize: '1rem' }} />
                         </td>
                       </tr>
                     )


### PR DESCRIPTION
## Summary
- condense each navigation route hop into a grouped panel so the last five data points render together cleanly
- surface the distance from the current system within the hop card and add responsive styling for the updated layout

## Testing
- npm install *(fails: ENETUNREACH while downloading ResourceHacker)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f3e277388323852a4d0d878af60d