### PR TITLE
Add INARA missions panel

### DIFF
--- a/src/client/pages/api/inara-missions.js
+++ b/src/client/pages/api/inara-missions.js
@@ -1,0 +1,92 @@
+import fetch from 'node-fetch'
+import https from 'https'
+import { load } from 'cheerio'
+
+const MISSIONS_URL = 'https://inara.cz/elite/nearest-misc/?ps1=Sol&pi20=7'
+const USER_AGENT = 'Mozilla/5.0 (compatible; ICARUS/1.0)'
+const ipv4HttpsAgent = new https.Agent({ family: 4 })
+
+function cleanText(value) {
+  return (value || '')
+    .replace(/[\uE000-\uF8FF]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function toAbsoluteUrl(pathname) {
+  if (!pathname) return null
+  if (/^https?:\/\//i.test(pathname)) return pathname
+  return `https://inara.cz${pathname}`
+}
+
+function parseFloatOrNull(value) {
+  const num = Number.parseFloat(value)
+  return Number.isFinite(num) ? num : null
+}
+
+function parseIntOrNull(value) {
+  const num = Number.parseInt(value, 10)
+  return Number.isFinite(num) ? num : null
+}
+
+export default async function handler(req, res) {
+  if (req.method && req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    const response = await fetch(MISSIONS_URL, {
+      agent: ipv4HttpsAgent,
+      headers: {
+        'User-Agent': USER_AGENT
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error(`INARA request failed with status ${response.status}`)
+    }
+
+    const html = await response.text()
+    const $ = load(html)
+    const table = $('table.tablesortercollapsed').first()
+    const results = []
+
+    if (table && table.length) {
+      table.find('tbody tr').each((_, element) => {
+        const cells = $(element).find('td')
+        if (cells.length < 4) return
+
+        const systemLink = $(cells[0]).find('a').first()
+        const factionLink = $(cells[1]).find('a').first()
+        const distanceCell = $(cells[2])
+        const updatedCell = $(cells[3])
+
+        const systemName = cleanText(systemLink.text())
+        const factionName = cleanText(factionLink.text())
+        const distanceText = cleanText(distanceCell.text())
+        const updatedText = cleanText(updatedCell.text())
+
+        results.push({
+          systemName: systemName || null,
+          systemUrl: toAbsoluteUrl(systemLink.attr('href')),
+          factionName: factionName || null,
+          factionUrl: toAbsoluteUrl(factionLink.attr('href')),
+          distanceText: distanceText || null,
+          distanceLy: parseFloatOrNull(distanceCell.attr('data-order')),
+          updatedText: updatedText || null,
+          updatedEpoch: parseIntOrNull(updatedCell.attr('data-order'))
+        })
+      })
+    }
+
+    res.setHeader('Cache-Control', 'no-store')
+    res.status(200).json({
+      results,
+      source: MISSIONS_URL,
+      fetchedAt: new Date().toISOString()
+    })
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load missions from INARA.', details: err.message })
+  }
+}

--- a/src/client/pages/inara/missions.js
+++ b/src/client/pages/inara/missions.js
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react'
+import Layout from 'components/layout'
+import Panel from 'components/panel'
+import PanelNavigation from 'components/panel-navigation'
+import { getInaraNavItems } from './nav-items'
+
+export default function InaraMissionsPage() {
+  const [missions, setMissions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [sourceUrl, setSourceUrl] = useState('')
+  const [fetchedAt, setFetchedAt] = useState('')
+
+  const navItems = getInaraNavItems('missions')
+
+  async function loadMissions() {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch('/api/inara-missions')
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to load missions from INARA.')
+      setMissions(Array.isArray(data.results) ? data.results : [])
+      setSourceUrl(data.source || '')
+      setFetchedAt(data.fetchedAt || '')
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadMissions()
+  }, [])
+
+  return (
+    <Layout>
+      <PanelNavigation items={navItems} />
+      <Panel layout='full-width' scrollable>
+        <div style={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem', alignItems: 'center' }}>
+          <div>
+            <h2 style={{ marginBottom: '.5rem' }}>Nearby Mining Missions</h2>
+            <p style={{ margin: 0, color: '#aaa' }}>
+              Powered by INARA&apos;s nearest mission search for Sol. Results are sorted by distance and refreshed live from the source.
+            </p>
+          </div>
+          <button
+            onClick={loadMissions}
+            disabled={loading}
+            style={{
+              padding: '.75rem 1.5rem',
+              fontSize: '1rem',
+              borderRadius: '.75rem',
+              background: '#ff7c22',
+              color: '#222',
+              border: 'none',
+              fontWeight: 600,
+              cursor: loading ? 'default' : 'pointer'
+            }}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+
+        {error && (
+          <div style={{ marginTop: '1.5rem', padding: '1rem', borderRadius: '.75rem', background: '#2a1313', color: '#ff9b9b', border: '1px solid #632525' }}>
+            {error}
+          </div>
+        )}
+
+        {!error && loading && (
+          <div style={{ marginTop: '2rem', textAlign: 'center', color: '#888', fontSize: '1.2rem' }}>
+            Loading missions from INARA…
+          </div>
+        )}
+
+        {!loading && !error && (
+          <div style={{ marginTop: '2rem' }}>
+            {missions.length === 0 ? (
+              <div style={{ textAlign: 'center', color: '#aaa' }}>
+                No nearby mining missions reported by INARA for the selected search.
+              </div>
+            ) : (
+              <div style={{ overflowX: 'auto', borderRadius: '1rem', border: '1px solid #333', background: '#181818' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', color: '#fff' }}>
+                  <thead>
+                    <tr style={{ background: '#222' }}>
+                      <th style={{ padding: '.75rem 1rem', textAlign: 'left', borderBottom: '1px solid #333' }}>Star System</th>
+                      <th style={{ padding: '.75rem 1rem', textAlign: 'left', borderBottom: '1px solid #333' }}>Faction</th>
+                      <th style={{ padding: '.75rem 1rem', textAlign: 'right', borderBottom: '1px solid #333' }}>Distance</th>
+                      <th style={{ padding: '.75rem 1rem', textAlign: 'right', borderBottom: '1px solid #333' }}>Updated</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {missions.map((mission, index) => (
+                      <tr key={`${mission.systemUrl || mission.systemName}-${mission.factionUrl || mission.factionName}-${index}`} style={{ background: index % 2 ? '#202020' : '#181818' }}>
+                        <td style={{ padding: '.75rem 1rem', borderBottom: '1px solid #333' }}>
+                          {mission.systemUrl ? (
+                            <a href={mission.systemUrl} target='_blank' rel='noopener noreferrer' style={{ color: '#ffb347', textDecoration: 'none' }}>
+                              {mission.systemName || mission.systemUrl}
+                            </a>
+                          ) : (
+                            mission.systemName || '—'
+                          )}
+                        </td>
+                        <td style={{ padding: '.75rem 1rem', borderBottom: '1px solid #333' }}>
+                          {mission.factionUrl ? (
+                            <a href={mission.factionUrl} target='_blank' rel='noopener noreferrer' style={{ color: '#ffb347', textDecoration: 'none' }}>
+                              {mission.factionName || mission.factionUrl}
+                            </a>
+                          ) : (
+                            mission.factionName || '—'
+                          )}
+                        </td>
+                        <td style={{ padding: '.75rem 1rem', borderBottom: '1px solid #333', textAlign: 'right', whiteSpace: 'nowrap' }}>
+                          {mission.distanceText || '—'}
+                        </td>
+                        <td style={{ padding: '.75rem 1rem', borderBottom: '1px solid #333', textAlign: 'right', whiteSpace: 'nowrap' }}>
+                          {mission.updatedText || '—'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            <div style={{ marginTop: '1rem', color: '#666', fontSize: '.9rem' }}>
+              {sourceUrl && (
+                <span>
+                  Source: <a href={sourceUrl} target='_blank' rel='noopener noreferrer' style={{ color: '#ff7c22' }}>{sourceUrl}</a>
+                </span>
+              )}
+              {fetchedAt && (
+                <span style={{ marginLeft: sourceUrl ? '1rem' : 0 }}>
+                  Fetched at {fetchedAt}
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </Panel>
+    </Layout>
+  )
+}

--- a/src/client/pages/inara/nav-items.js
+++ b/src/client/pages/inara/nav-items.js
@@ -1,0 +1,27 @@
+export function getInaraNavItems(activeKey) {
+  const items = [
+    {
+      name: 'Search',
+      icon: 'search',
+      url: '/inara/search',
+      key: 'search'
+    },
+    {
+      name: 'Ships',
+      icon: 'ship',
+      url: '/inara/ships',
+      key: 'ships'
+    },
+    {
+      name: 'Missions',
+      icon: 'table-rows',
+      url: '/inara/missions',
+      key: 'missions'
+    }
+  ]
+
+  return items.map(item => ({
+    ...item,
+    active: item.key === activeKey
+  }))
+}

--- a/src/client/pages/inara/outfitting.js
+++ b/src/client/pages/inara/outfitting.js
@@ -1,23 +1,8 @@
 import Layout from 'components/layout'
 import Panel from 'components/panel'
 import PanelNavigation from 'components/panel-navigation'
-import { useRouter } from 'next/router'
-
-const navItems = [
-  {
-    name: 'Search',
-    icon: 'search',
-    url: '/inara/search',
-    active: false
-  },
-  {
-    name: 'Ships',
-    icon: 'ship',
-    url: '/inara/ships',
-    active: true
-  }
-]
-
+import { useState } from 'react'
+import { getInaraNavItems } from './nav-items'
 
 // Example ship list (should be loaded from backend or static file)
 const ships = [
@@ -40,12 +25,10 @@ const ships = [
   { id: '128049345', name: 'Beluga Liner' }
 ]
 
-import { useState } from 'react'
-
-
-export default function InaraShipsPage() {
+export default function InaraOutfittingPage() {
   const [selectedShip, setSelectedShip] = useState('')
   const [system, setSystem] = useState('')
+  const navItems = getInaraNavItems('ships')
 
   return (
     <Layout>

--- a/src/client/pages/inara/search.js
+++ b/src/client/pages/inara/search.js
@@ -1,23 +1,11 @@
 import Layout from 'components/layout'
 import Panel from 'components/panel'
 import PanelNavigation from 'components/panel-navigation'
-
-const navItems = [
-  {
-    name: 'Search',
-    icon: 'search',
-    url: '/inara/search',
-    active: true
-  },
-  {
-    name: 'Outfitting',
-    icon: 'wrench',
-    url: '/inara/outfitting',
-    active: false
-  }
-]
+import { getInaraNavItems } from './nav-items'
 
 export default function InaraSearchPage() {
+  const navItems = getInaraNavItems('search')
+
   return (
     <Layout>
       <PanelNavigation items={navItems} />

--- a/src/client/pages/inara/ships.js
+++ b/src/client/pages/inara/ships.js
@@ -1,25 +1,11 @@
 // Ships page for INARA search (mimics nearest-outfitting for ships)
 // This file was created by copying and adapting the old Outfitting page.
 import React, { useState } from 'react'
-import Layout from '../../components/layout'
-import PanelNavigation from '../../components/panel-navigation'
-import Panel from '../../components/panel'
+import Layout from 'components/layout'
+import PanelNavigation from 'components/panel-navigation'
+import Panel from 'components/panel'
 import ships from '../../../service/data/edcd/fdevids/shipyard.json'
-
-const navItems = [
-  {
-    name: 'Search',
-    icon: 'search',
-    url: '/inara/search',
-    active: false
-  },
-  {
-    name: 'Ships',
-    icon: 'ship',
-    url: '/inara/ships',
-    active: true
-  }
-]
+import { getInaraNavItems } from './nav-items'
 
 export default function InaraShipsPage() {
   const [selectedShip, setSelectedShip] = useState('')
@@ -27,6 +13,8 @@ export default function InaraShipsPage() {
   const [results, setResults] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+
+  const navItems = getInaraNavItems('ships')
 
   async function handleSubmit(e) {
     e.preventDefault()


### PR DESCRIPTION
## Summary
- add a shared INARA navigation helper that exposes the new Missions tab
- build a missions page that fetches nearby mining missions from INARA via a new API route

## Testing
- npm run lint:javascript *(fails: requires interactive install of standard)*

------
https://chatgpt.com/codex/tasks/task_e_68d9547342408323b8b8bdff89a08587