### PR TITLE
Restrict INARA logging to development mode

### DIFF
--- a/src/client/pages/api/inara-log-utils.js
+++ b/src/client/pages/api/inara-log-utils.js
@@ -1,0 +1,30 @@
+import fs from 'fs'
+
+const TRUTHY = new Set(['1', 'true', 'yes', 'on'])
+const FALSY = new Set(['0', 'false', 'no', 'off'])
+
+function readEnvFlag (name) {
+  const value = process.env[name]
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().toLowerCase()
+  if (TRUTHY.has(normalized)) return true
+  if (FALSY.has(normalized)) return false
+  return null
+}
+
+export function shouldLogInaraActivity () {
+  const explicitEnable = readEnvFlag('ICARUS_ENABLE_INARA_LOGS')
+  if (explicitEnable !== null) return explicitEnable
+
+  const explicitDisable = readEnvFlag('ICARUS_DISABLE_INARA_LOGS')
+  if (explicitDisable === true) return false
+
+  return (process.env.NODE_ENV || '').toLowerCase() === 'development'
+}
+
+export function appendInaraLogEntry (logPath, entry) {
+  if (!shouldLogInaraActivity()) return
+  try {
+    fs.appendFileSync(logPath, `[${new Date().toISOString()}] ${entry}\n`)
+  } catch (e) {}
+}

--- a/src/client/pages/api/inara-trade-routes.js
+++ b/src/client/pages/api/inara-trade-routes.js
@@ -7,13 +7,12 @@ import https from 'https'
 import EliteLog from '../../../service/lib/elite-log.js'
 import System from '../../../service/lib/event-handlers/system.js'
 import distance from '../../../shared/distance.js'
+import { appendInaraLogEntry } from './inara-log-utils.js'
 
 const logPath = path.join(process.cwd(), 'inara-trade-routes.log')
 const ipv4HttpsAgent = new https.Agent({ family: 4 })
 function logInaraTrade(entry) {
-  try {
-    fs.appendFileSync(logPath, `[${new Date().toISOString()}] ${entry}\n`)
-  } catch (e) {}
+  appendInaraLogEntry(logPath, entry)
 }
 
 function resolveLogDir() {

--- a/src/client/pages/api/inara-websearch.js
+++ b/src/client/pages/api/inara-websearch.js
@@ -8,12 +8,11 @@ import os from 'os'
 import EliteLog from '../../../service/lib/elite-log.js'
 import System from '../../../service/lib/event-handlers/system.js'
 import distance from '../../../shared/distance.js'
+import { appendInaraLogEntry } from './inara-log-utils.js'
 
 const logPath = path.join(process.cwd(), 'inara-websearch.log')
 function logInaraSearch(entry) {
-  try {
-    fs.appendFileSync(logPath, `[${new Date().toISOString()}] ${entry}\n`)
-  } catch (e) {}
+  appendInaraLogEntry(logPath, entry)
 }
 
 function resolveLogDir() {


### PR DESCRIPTION
## Summary
- add a shared INARA logging helper that respects environment flags
- update INARA websearch and trade routes APIs to only write request/response logs in development

## Testing
- npm run lint:javascript *(fails: existing repository lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d95706248c832394b4fa951aee0822