### PR TITLE
Reorder INARA navigation to prioritize trade routes

### DIFF
--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -1515,27 +1515,27 @@ function TradeRoutesPanel () {
 }
 
 export default function InaraPage() {
-  const [activeTab, setActiveTab] = useState('ships')
+  const [activeTab, setActiveTab] = useState('tradeRoutes')
 
   const navigationItems = useMemo(() => ([
-    { name: 'Search', icon: 'search', type: 'SEARCH', active: false },
-    { name: 'Ships', icon: 'ship', active: activeTab === 'ships', onClick: () => setActiveTab('ships') },
+    { name: 'Trade Routes', icon: 'route', active: activeTab === 'tradeRoutes', onClick: () => setActiveTab('tradeRoutes') },
     { name: 'Missions', icon: 'table-rows', active: activeTab === 'missions', onClick: () => setActiveTab('missions') },
-    { name: 'Trade Routes', icon: 'route', active: activeTab === 'tradeRoutes', onClick: () => setActiveTab('tradeRoutes') }
+    { name: 'Search', icon: 'search', type: 'SEARCH', active: false },
+    { name: 'Ships', icon: 'ship', active: activeTab === 'ships', onClick: () => setActiveTab('ships') }
   ]), [activeTab])
 
   return (
     <Layout connected={true} active={true} ready={true} loader={false}>
       <Panel layout='full-width' navigation={navigationItems} search={false}>
         <div>
-          <div style={{ display: activeTab === 'ships' ? 'block' : 'none' }}>
-            <ShipsPanel />
+          <div style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
+            <TradeRoutesPanel />
           </div>
           <div style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
             <MissionsPanel />
           </div>
-          <div style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
-            <TradeRoutesPanel />
+          <div style={{ display: activeTab === 'ships' ? 'block' : 'none' }}>
+            <ShipsPanel />
           </div>
         </div>
       </Panel>


### PR DESCRIPTION
## Summary
- set the INARA Trade Routes tab as the default selection
- reorder the navigation items so Trade Routes appears first and Ships appears last
- adjust panel rendering order to match the updated navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97ddbc0ec83238e60ef122dd2348a