### PR TITLE
Add pristine mining locations panel to INARA view

### DIFF
--- a/src/client/pages/api/inara-pristine-mining.js
+++ b/src/client/pages/api/inara-pristine-mining.js
@@ -1,0 +1,167 @@
+import fetch from 'node-fetch'
+import https from 'https'
+import { load } from 'cheerio'
+
+const BASE_URL = 'https://inara.cz'
+const ipv4HttpsAgent = new https.Agent({ family: 4 })
+
+const INARA_REQUEST_HEADERS = {
+  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+  Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'Cache-Control': 'no-cache',
+  Pragma: 'no-cache',
+  Referer: 'https://inara.cz/elite/',
+  Cookie: 'inarasite=1'
+}
+
+const SEARCH_DEFAULTS = {
+  formbrief: '1',
+  pi40: '-1',
+  pi41: '50',
+  pi30: '1',
+  pi7: '0',
+  pi31: '0',
+  pi32: '0',
+  pi33: '0',
+  pi34: '0',
+  pi35: '0'
+}
+
+const MAX_DISTANCE_LY = Number(SEARCH_DEFAULTS.pi41)
+
+function cleanText (value) {
+  return (value || '').replace(/\s+/g, ' ').trim()
+}
+
+function parseNumber (value) {
+  if (value === null || value === undefined) return null
+  const num = Number(value)
+  return Number.isFinite(num) ? num : null
+}
+
+function parseDistance (text) {
+  if (!text) return null
+  const match = String(text).match(/[-+]?\d[\d,]*(?:\.\d+)?/)
+  if (!match) return null
+  const num = Number(match[0].replace(/,/g, ''))
+  return Number.isFinite(num) ? num : null
+}
+
+function parseTooltipDetails (html) {
+  if (!html || typeof html !== 'string') return {}
+  const $ = load(`<div>${html}</div>`, null, false)
+  const details = {}
+  $('div.itempaircontainer').each((_, element) => {
+    const label = cleanText($(element).find('.itempairlabel').text())
+    const value = cleanText($(element).find('.itempairvalue').text())
+    if (!label || !value) return
+    const lower = label.toLowerCase()
+    if (lower.includes('ring/belt')) details.ringType = value
+    if (lower.includes('reserves')) details.reservesLevel = value
+    if (lower === 'body type' && !details.bodyType) details.bodyType = value
+  })
+  return details
+}
+
+function buildInaraUrl (system) {
+  const params = new URLSearchParams({ ...SEARCH_DEFAULTS, ps1: system })
+  return `${BASE_URL}/elite/nearest-bodies/?${params.toString()}`
+}
+
+function parseBodies (html, targetSystem) {
+  const $ = load(html)
+  const table = $('table.tablesortercollapsed').first()
+  if (!table || !table.length) return []
+
+  const normalizedTarget = typeof targetSystem === 'string' ? targetSystem.trim().toLowerCase() : ''
+
+  const bodies = []
+  table.find('tbody tr').each((_, row) => {
+    const cells = $(row).find('td')
+    if (cells.length < 5) return
+
+    const systemCell = cells.eq(0)
+    const systemLink = systemCell.find('a').first()
+    const systemName = cleanText(systemLink.text()) || cleanText(systemCell.text()) || null
+    const systemUrl = systemLink && systemLink.attr('href') ? `${BASE_URL}${systemLink.attr('href')}` : null
+
+    const bodyCell = cells.eq(1)
+    const bodyTooltip = bodyCell.find('.tooltip').first()
+    const bodyName = cleanText(bodyTooltip.text()) || cleanText(bodyCell.text()) || null
+    const bodyLink = bodyCell.find('a').first()
+    const bodyUrl = bodyLink && bodyLink.attr('href') ? `${BASE_URL}${bodyLink.attr('href')}` : null
+    const tooltipHtml = bodyTooltip ? bodyTooltip.attr('data-tooltiptext') : null
+    const tooltipDetails = parseTooltipDetails(tooltipHtml)
+
+    const bodyTypeCell = cells.eq(2)
+    const bodyType = cleanText(bodyTypeCell.text()) || tooltipDetails.bodyType || null
+
+    const bodyDistanceCell = cells.eq(3)
+    const bodyDistanceText = cleanText(bodyDistanceCell.text()) || null
+    const bodyDistanceOrder = parseNumber(bodyDistanceCell.attr('data-order'))
+    const bodyDistanceLs = Number.isFinite(bodyDistanceOrder) ? bodyDistanceOrder : parseDistance(bodyDistanceText)
+
+    const distanceCell = cells.eq(4)
+    const distanceClone = distanceCell.clone()
+    distanceClone.find('.pictofont').remove()
+    const distanceText = cleanText(distanceClone.text()) || null
+    const distanceOrder = parseNumber(distanceCell.attr('data-order'))
+    const distanceLy = Number.isFinite(distanceOrder) ? distanceOrder : parseDistance(distanceText)
+
+    bodies.push({
+      system: systemName,
+      systemUrl,
+      body: bodyName,
+      bodyUrl,
+      bodyType,
+      ringType: tooltipDetails.ringType || null,
+      reservesLevel: tooltipDetails.reservesLevel || null,
+      bodyDistanceText,
+      bodyDistanceLs,
+      distanceText,
+      distanceLy,
+      isTargetSystem: normalizedTarget && systemName
+        ? systemName.trim().toLowerCase() === normalizedTarget
+        : false
+    })
+  })
+
+  return bodies
+}
+
+export default async function handler (req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  try {
+    const system = typeof req.body?.system === 'string' ? req.body.system.trim() : ''
+    const targetSystem = system || 'Sol'
+    const url = buildInaraUrl(targetSystem)
+
+    const response = await fetch(url, {
+      agent: ipv4HttpsAgent,
+      headers: INARA_REQUEST_HEADERS
+    })
+    if (!response.ok) {
+      throw new Error(`INARA request failed with status ${response.status}`)
+    }
+
+    const html = await response.text()
+    const locations = parseBodies(html, targetSystem)
+
+    res.status(200).json({
+      locations,
+      targetSystem,
+      sourceUrl: url,
+      message: `Showing pristine mining locations within ${MAX_DISTANCE_LY} Ly of ${targetSystem}.`
+    })
+  } catch (error) {
+    res.status(500).json({
+      error: error.message || 'Failed to fetch pristine mining locations.'
+    })
+  }
+}

--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -1569,12 +1569,213 @@ function TradeRoutesPanel () {
   )
 }
 
+function PristineMiningPanel () {
+  const {
+    currentSystem,
+    system,
+    systemSelection,
+    systemInput,
+    systemOptions,
+    handleSystemChange,
+    handleManualSystemChange
+  } = useSystemSelector({ autoSelectCurrent: true })
+  const [locations, setLocations] = useState([])
+  const [status, setStatus] = useState('idle')
+  const [error, setError] = useState('')
+  const [message, setMessage] = useState('')
+  const [sourceUrl, setSourceUrl] = useState('')
+
+  const trimmedSystem = useMemo(() => {
+    if (typeof system === 'string') {
+      const value = system.trim()
+      if (value) return value
+    }
+    return ''
+  }, [system])
+
+  const displaySystemName = useMemo(() => {
+    if (trimmedSystem) return trimmedSystem
+    if (systemSelection && systemSelection !== '__manual') return systemSelection
+    if (systemInput && systemInput.trim()) return systemInput.trim()
+    if (currentSystem?.name) return currentSystem.name
+    return ''
+  }, [trimmedSystem, systemSelection, systemInput, currentSystem])
+
+  useEffect(() => {
+    if (!trimmedSystem) {
+      setLocations([])
+      setStatus('idle')
+      setError('')
+      setMessage('')
+      setSourceUrl('')
+      return
+    }
+
+    let cancelled = false
+
+    setStatus('loading')
+    setError('')
+    setMessage('')
+
+    fetch('/api/inara-pristine-mining', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ system: trimmedSystem })
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (cancelled) return
+
+        const nextLocations = Array.isArray(data?.locations)
+          ? data.locations
+          : Array.isArray(data?.bodies)
+            ? data.bodies
+            : []
+
+        const nextError = typeof data?.error === 'string' ? data.error : ''
+        const nextMessage = typeof data?.message === 'string' ? data.message : ''
+        const nextSourceUrl = typeof data?.sourceUrl === 'string' ? data.sourceUrl : ''
+
+        setLocations(nextLocations)
+        setError(nextError)
+        setMessage(nextMessage)
+        setSourceUrl(nextSourceUrl)
+
+        if (nextError && nextLocations.length === 0) {
+          setStatus('error')
+        } else if (nextLocations.length === 0) {
+          setStatus('empty')
+        } else {
+          setStatus('populated')
+        }
+      })
+      .catch(err => {
+        if (cancelled) return
+        setLocations([])
+        setError(err.message || 'Unable to fetch pristine mining locations.')
+        setMessage('')
+        setSourceUrl('')
+        setStatus('error')
+      })
+
+    return () => { cancelled = true }
+  }, [trimmedSystem])
+
+  return (
+    <div>
+      <h2>Pristine Mining Locations</h2>
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-end', gap: '2rem', margin: '2rem 0 1.5rem 0' }}>
+        <SystemSelect
+          label='System'
+          systemSelection={systemSelection}
+          systemOptions={systemOptions}
+          onSystemChange={handleSystemChange}
+          systemInput={systemInput}
+          onManualSystemChange={handleManualSystemChange}
+          placeholder='Enter system name...'
+        />
+        {sourceUrl && (
+          <div style={{ marginBottom: '.75rem', fontSize: '0.95rem' }}>
+            <a
+              href={sourceUrl}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-secondary'
+            >
+              View results on INARA
+            </a>
+          </div>
+        )}
+      </div>
+      <p style={{ color: '#aaa', marginTop: '-0.5rem' }}>
+        Location data is provided by INARA community submissions.
+      </p>
+      {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
+      <div style={{ marginTop: '1.5rem', border: '1px solid #333', background: '#101010', overflow: 'hidden' }}>
+        <div className='scrollable' style={{ maxHeight: 'calc(100vh - 360px)', overflowY: 'auto' }}>
+          {message && status !== 'idle' && status !== 'loading' && (
+            <div style={{ color: '#aaa', padding: '1.25rem 2rem', borderBottom: status === 'populated' ? '1px solid #222' : 'none' }}>
+              {message}
+            </div>
+          )}
+          {status === 'idle' && (
+            <div style={{ color: '#aaa', padding: '2rem' }}>
+              Select a system to discover nearby pristine mining locations.
+            </div>
+          )}
+          {status === 'loading' && (
+            <div style={{ color: '#aaa', padding: '2rem' }}>Searching for pristine mining locations...</div>
+          )}
+          {status === 'error' && !error && (
+            <div style={{ color: '#ff4d4f', padding: '2rem' }}>Unable to load pristine mining locations.</div>
+          )}
+          {status === 'empty' && (
+            <div style={{ color: '#aaa', padding: '2rem' }}>
+              No pristine mining locations found near {displaySystemName || 'the selected system'}.
+            </div>
+          )}
+          {status === 'populated' && locations.length > 0 && (
+            <table style={{ width: '100%', borderCollapse: 'collapse', color: '#fff' }}>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: 'left', padding: '.75rem 1rem' }}>Body</th>
+                  <th style={{ textAlign: 'left', padding: '.75rem 1rem' }}>System</th>
+                  <th className='hidden-small text-right' style={{ padding: '.75rem 1rem' }}>Body Distance</th>
+                  <th className='text-right' style={{ padding: '.75rem 1rem' }}>Distance</th>
+                </tr>
+              </thead>
+              <tbody>
+                {locations.map((location, index) => {
+                  const key = `${location.system || 'unknown'}-${location.body || 'body'}-${index}`
+                  const detailParts = []
+                  if (location.bodyType) detailParts.push(location.bodyType)
+                  if (location.ringType) detailParts.push(`${location.ringType} ring`)
+                  if (location.reservesLevel) detailParts.push(`${location.reservesLevel} reserves`)
+                  const detailText = detailParts.join(' · ')
+                  const bodyDistanceDisplay = formatStationDistance(location.bodyDistanceLs, location.bodyDistanceText)
+                  const distanceDisplay = formatSystemDistance(location.distanceLy, location.distanceText)
+
+                  return (
+                    <tr key={key} style={{ animationDelay: `${index * 0.03}s` }}>
+                      <td style={{ padding: '.65rem 1rem' }}>
+                        <div style={{ display: 'flex', flexDirection: 'column' }}>
+                          <span className='text-primary'>{location.body || '--'}</span>
+                          {detailText && (
+                            <span style={{ color: '#aaa', fontSize: '0.95rem', marginTop: '.25rem' }}>{detailText}</span>
+                          )}
+                        </div>
+                      </td>
+                      <td style={{ padding: '.65rem 1rem' }}>
+                        <div className='text-no-wrap' style={{ display: 'flex', alignItems: 'center' }}>
+                          {location.isTargetSystem ? (
+                            <i className='icon system-object-icon icarus-terminal-location-filled text-primary' style={{ marginRight: '.5rem' }} />
+                          ) : (
+                            <i className='icon system-object-icon icarus-terminal-location' style={{ marginRight: '.5rem', color: '#888' }} />
+                          )}
+                          <span className='text-primary'>{location.system || '--'}</span>
+                        </div>
+                      </td>
+                      <td className='hidden-small text-right text-no-wrap' style={{ padding: '.65rem 1rem' }}>{bodyDistanceDisplay || '--'}</td>
+                      <td className='text-right text-no-wrap' style={{ padding: '.65rem 1rem' }}>{distanceDisplay || '--'}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function InaraPage() {
   const [activeTab, setActiveTab] = useState('tradeRoutes')
 
   const navigationItems = useMemo(() => ([
     { name: 'Trade Routes', icon: 'route', active: activeTab === 'tradeRoutes', onClick: () => setActiveTab('tradeRoutes') },
     { name: 'Missions', icon: 'table-rows', active: activeTab === 'missions', onClick: () => setActiveTab('missions') },
+    { name: 'Pristine Mining Locations', icon: 'planet-ringed', active: activeTab === 'pristineMining', onClick: () => setActiveTab('pristineMining') },
     { name: 'Search', icon: 'search', type: 'SEARCH', active: false },
     { name: 'Ships', icon: 'ship', active: activeTab === 'ships', onClick: () => setActiveTab('ships') }
 
@@ -1589,6 +1790,9 @@ export default function InaraPage() {
           </div>
           <div style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
             <MissionsPanel />
+          </div>
+          <div style={{ display: activeTab === 'pristineMining' ? 'block' : 'none' }}>
+            <PristineMiningPanel />
           </div>
           <div style={{ display: activeTab === 'ships' ? 'block' : 'none' }}>
             <ShipsPanel />


### PR DESCRIPTION
## Summary
- add a backend API that proxies INARA's nearest-bodies search for pristine mining rings
- surface a new "Pristine Mining Locations" tab on the INARA page with system filtering and result rendering
- expose INARA source links and highlight ring/reserve details for each location

## Testing
- npm run lint:javascript *(fails: existing lint issues across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d987914718832384119f8dace2a531