### PR TITLE
Update Mining Missions nav icon for INARA page

### DIFF
--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -1808,7 +1808,7 @@ export default function InaraPage() {
   const [activeTab, setActiveTab] = useState('tradeRoutes')
   const navigationItems = useMemo(() => ([
     { name: 'Trade Routes', icon: 'route', active: activeTab === 'tradeRoutes', onClick: () => setActiveTab('tradeRoutes') },
-    { name: 'Missions', icon: 'table-rows', active: activeTab === 'missions', onClick: () => setActiveTab('missions') },
+    { name: 'Missions', icon: 'materials-raw', active: activeTab === 'missions', onClick: () => setActiveTab('missions') },
     { name: 'Pristine Mining Locations', icon: 'planet-ringed', active: activeTab === 'pristineMining', onClick: () => setActiveTab('pristineMining') },
     { name: 'Search', icon: 'search', type: 'SEARCH', active: false },
     { name: 'Ships', icon: 'ship', active: activeTab === 'ships', onClick: () => setActiveTab('ships') }


### PR DESCRIPTION
## Summary
- switch the INARA Mining Missions navigation button to use the raw materials glyph for a more mining-focused icon

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d98fbf087883238dfa6b4abf75ca36