### PR TITLE
Disable trade route search without system selection

### DIFF
--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -933,6 +933,7 @@ function TradeRoutesPanel () {
   const [sortDirection, setSortDirection] = useState('asc')
   const [filtersCollapsed, setFiltersCollapsed] = useState(true)
   const [expandedRouteKey, setExpandedRouteKey] = useState(null)
+  const isSearchDisabled = status === 'loading' || !(system && system.trim())
 
   useEffect(() => {
     if (!connected || initialCapacityLoaded) return
@@ -1463,7 +1464,7 @@ function TradeRoutesPanel () {
             type='submit'
             className='button--active button--secondary'
             style={{ ...FILTER_SUBMIT_BUTTON_STYLE }}
-            disabled={status === 'loading'}
+            disabled={isSearchDisabled}
           >
             {status === 'loading' ? 'Refreshing…' : 'Refresh Trade Routes'}
           </button>


### PR DESCRIPTION
## Summary
- disable the trade route refresh button until a system has been selected
- prevent users from submitting the trade route form without a valid target system

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d99044223483239de8a1def1f9f0c5