### PR TITLE
Default INARA landing pad filter to ship

### DIFF
--- a/src/client/lib/ship-pad-sizes.js
+++ b/src/client/lib/ship-pad-sizes.js
@@ -1,0 +1,99 @@
+export const SHIP_PAD_SIZES_BY_NAME = {
+  'Adder': '1',
+  'Alliance Challenger': '2',
+  'Alliance Chieftain': '2',
+  'Alliance Crusader': '2',
+  'Anaconda': '3',
+  'Asp Explorer': '2',
+  'Asp Scout': '2',
+  'Beluga Liner': '3',
+  'Cobra MkIII': '1',
+  'Cobra MkIV': '1',
+  'Diamondback Explorer': '1',
+  'Diamondback Scout': '1',
+  'Dolphin': '1',
+  'Eagle': '1',
+  'Federal Assault Ship': '2',
+  'Federal Corvette': '3',
+  'Federal Dropship': '2',
+  'Federal Gunship': '2',
+  'Fer-de-Lance': '2',
+  'Hauler': '1',
+  'Imperial Clipper': '3',
+  'Imperial Courier': '1',
+  'Imperial Cutter': '3',
+  'Imperial Eagle': '1',
+  'Keelback': '2',
+  'Krait MkII': '2',
+  'Krait Phantom': '2',
+  'Mamba': '2',
+  'Orca': '3',
+  'Python': '2',
+  'Sidewinder': '1',
+  'Type-10 Defender': '3',
+  'Type-6 Transporter': '2',
+  'Type-7 Transporter': '3',
+  'Type-9 Heavy': '3',
+  'Viper MkIII': '1',
+  'Viper MkIV': '1',
+  'Vulture': '1'
+}
+
+export const SHIP_PAD_SIZES_BY_SYMBOL = {
+  SideWinder: '1',
+  Eagle: '1',
+  Hauler: '1',
+  Adder: '1',
+  Viper: '1',
+  CobraMkIII: '1',
+  Type6: '2',
+  Dolphin: '1',
+  Type7: '3',
+  Asp: '2',
+  Vulture: '1',
+  Empire_Trader: '3',
+  Federation_Dropship: '2',
+  Orca: '3',
+  Type9: '3',
+  Python: '2',
+  BelugaLiner: '3',
+  FerDeLance: '2',
+  Anaconda: '3',
+  Federation_Corvette: '3',
+  Cutter: '3',
+  DiamondBack: '1',
+  Empire_Courier: '1',
+  DiamondBackXL: '1',
+  Empire_Eagle: '1',
+  Federation_Dropship_MkII: '2',
+  Federation_Gunship: '2',
+  Viper_MkIV: '1',
+  CobraMkIV: '1',
+  Independant_Trader: '2',
+  Asp_Scout: '2',
+  Type9_Military: '3',
+  Krait_MkII: '2',
+  TypeX: '2',
+  TypeX_2: '2',
+  TypeX_3: '2',
+  Krait_Light: '2',
+  Mamba: '2'
+}
+
+export function getShipLandingPadSize (ship = {}) {
+  if (!ship || typeof ship !== 'object') return null
+
+  const type = typeof ship.type === 'string' ? ship.type.trim() : ''
+  if (type) {
+    const matched = SHIP_PAD_SIZES_BY_NAME[type]
+    if (matched) return matched
+  }
+
+  const symbol = typeof ship.symbol === 'string' ? ship.symbol.trim() : ''
+  if (symbol) {
+    const matched = SHIP_PAD_SIZES_BY_SYMBOL[symbol]
+    if (matched) return matched
+  }
+
+  return null
+}

--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -3,6 +3,7 @@ import Layout from '../components/layout'
 import Panel from '../components/panel'
 import Icons from '../lib/icons'
 import { useSocket, sendEvent } from '../lib/socket'
+import { getShipLandingPadSize } from '../lib/ship-pad-sizes'
 
 function formatSystemDistance (value, fallback) {
   if (typeof value === 'number' && !Number.isNaN(value)) {
@@ -912,10 +913,11 @@ function TradeRoutesPanel () {
     handleManualSystemChange
   } = useSystemSelector({ autoSelectCurrent: true })
   const [cargoCapacity, setCargoCapacity] = useState('')
-  const [initialCapacityLoaded, setInitialCapacityLoaded] = useState(false)
+  const [initialShipInfoLoaded, setInitialShipInfoLoaded] = useState(false)
   const [routeDistance, setRouteDistance] = useState('30')
   const [priceAge, setPriceAge] = useState('8')
   const [padSize, setPadSize] = useState('2')
+  const [padSizeAutoDetected, setPadSizeAutoDetected] = useState(false)
   const [minSupply, setMinSupply] = useState('500')
   const [minDemand, setMinDemand] = useState('0')
   const [stationDistance, setStationDistance] = useState('0')
@@ -935,11 +937,11 @@ function TradeRoutesPanel () {
   const [expandedRouteKey, setExpandedRouteKey] = useState(null)
 
   useEffect(() => {
-    if (!connected || initialCapacityLoaded) return
+    if (!connected || initialShipInfoLoaded) return
 
     let cancelled = false
 
-    const loadCapacityFromShip = async () => {
+    const loadShipInfo = async () => {
       try {
         const shipStatus = await sendEvent('getShipStatus')
         if (cancelled) return
@@ -948,17 +950,23 @@ function TradeRoutesPanel () {
         if (Number.isFinite(capacityNumber) && capacityNumber >= 0) {
           setCargoCapacity(String(Math.round(capacityNumber)))
         }
+
+        const landingPadSize = getShipLandingPadSize(shipStatus)
+        if (landingPadSize) {
+          setPadSize(landingPadSize)
+          setPadSizeAutoDetected(true)
+        }
       } catch (err) {
         // Ignore errors fetching ship status; the UI will fall back to showing an unknown hold size.
       } finally {
-        if (!cancelled) setInitialCapacityLoaded(true)
+        if (!cancelled) setInitialShipInfoLoaded(true)
       }
     }
 
-    loadCapacityFromShip()
+    loadShipInfo()
 
     return () => { cancelled = true }
-  }, [connected, ready, initialCapacityLoaded])
+  }, [connected, ready, initialShipInfoLoaded])
 
   const routeDistanceOptions = useMemo(() => ([
     { value: '10', label: '10 Ly' },
@@ -1048,8 +1056,8 @@ function TradeRoutesPanel () {
     if (Number.isFinite(capacityNumber) && capacityNumber >= 0) {
       return `${Math.round(capacityNumber).toLocaleString()} t`
     }
-    return initialCapacityLoaded ? 'Unknown' : 'Detecting…'
-  }, [cargoCapacity, initialCapacityLoaded])
+    return initialShipInfoLoaded ? 'Unknown' : 'Detecting…'
+  }, [cargoCapacity, initialShipInfoLoaded])
 
   const filtersSummary = useMemo(() => {
     const selectedSystem = (system && system.trim()) ||
@@ -1057,8 +1065,13 @@ function TradeRoutesPanel () {
       currentSystem?.name ||
       'Any System'
 
-    const padLabelRaw = pickOptionLabel(padSizeOptions, padSize, 'Any')
-    const padLabel = padLabelRaw === 'Medium' ? 'Med' : padLabelRaw
+    const padLabelRaw = initialShipInfoLoaded
+      ? pickOptionLabel(padSizeOptions, padSize, 'Unknown')
+      : 'Detecting…'
+    let padLabel = padLabelRaw === 'Medium' ? 'Med' : padLabelRaw
+    if (initialShipInfoLoaded && padSizeAutoDetected && padLabelRaw !== 'Detecting…' && padLabelRaw !== 'Unknown') {
+      padLabel = `${padLabel} (Ship)`
+    }
     const supplyLabel = simplifySupplyDemandLabel(pickOptionLabel(supplyOptions, minSupply, 'Any'))
     const demandLabel = simplifySupplyDemandLabel(pickOptionLabel(demandOptions, minDemand, 'Any'))
 
@@ -1069,7 +1082,7 @@ function TradeRoutesPanel () {
       `Min Supply: ${supplyLabel}`,
       `Min Demand: ${demandLabel}`
     ].join(' | ')
-  }, [system, systemSelection, currentSystem, cargoCapacityDisplay, padSize, minSupply, minDemand, padSizeOptions, supplyOptions, demandOptions, pickOptionLabel, simplifySupplyDemandLabel])
+  }, [system, systemSelection, currentSystem, cargoCapacityDisplay, padSize, minSupply, minDemand, padSizeOptions, supplyOptions, demandOptions, pickOptionLabel, simplifySupplyDemandLabel, initialShipInfoLoaded, padSizeAutoDetected])
 
   const filterRoutes = useCallback((list = []) => {
     if (!Array.isArray(list)) return []
@@ -1513,18 +1526,6 @@ function TradeRoutesPanel () {
                 style={{ ...FILTER_CONTROL_STYLE }}
               >
                 {priceAgeOptions.map(opt => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </select>
-            </div>
-            <div style={{ ...FILTER_FIELD_STYLE }}>
-              <label style={FILTER_LABEL_STYLE}>Min Landing Pad</label>
-              <select
-                value={padSize}
-                onChange={event => setPadSize(event.target.value)}
-                style={{ ...FILTER_CONTROL_STYLE }}
-              >
-                {padSizeOptions.map(opt => (
                   <option key={opt.value} value={opt.value}>{opt.label}</option>
                 ))}
               </select>

--- a/src/service/lib/event-handlers/ship-status.js
+++ b/src/service/lib/event-handlers/ship-status.js
@@ -250,6 +250,7 @@ class ShipStatus {
     const shipState = {
       timestamp: new Date().toISOString(),
       type: ship?.name ?? Loadout?.Ship ?? UNKNOWN_VALUE,
+      symbol: Loadout?.Ship ?? null,
       name: Loadout?.ShipName ?? UNKNOWN_VALUE,
       ident: Loadout?.ShipIdent ?? UNKNOWN_VALUE,
       pips: {


### PR DESCRIPTION
## Summary
- add a shared mapping that resolves ship types and symbols to landing pad classes
- populate the INARA trade route filters with the current ship's landing pad size and remove the manual selector
- include the ship symbol in the ship status payload so the client can fall back when mapping pad sizes

## Testing
- npm run lint:javascript *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d990eea2888323921b19b8813ceeec