### PR TITLE
Add detailed inspector to INARA pristine mining rows

### DIFF
--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -23,6 +23,7 @@
 @import "panels/navigation-panel.css";
 @import "panels/ship-panel.css";
 @import "panels/engineering-panel.css";
+@import "pages/inara.css";
 
 @import "overrides/safari.css";
 @import "overrides/firefox.css";

--- a/src/client/css/pages/inara.css
+++ b/src/client/css/pages/inara.css
@@ -1,0 +1,184 @@
+.pristine-mining__container {
+  position: relative;
+}
+
+.pristine-mining__results {
+  transition: margin-right 0.35s ease;
+}
+
+.pristine-mining__results--inspector {
+  margin-right: 23rem;
+}
+
+.pristine-mining__inspector {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 21.5rem;
+  padding: 1rem 1rem 1rem 0;
+  box-sizing: border-box;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  display: flex;
+}
+
+.pristine-mining__inspector--reserved {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.pristine-mining__inspector-status {
+  align-self: flex-start;
+  width: 100%;
+  background: rgba(12, 15, 24, 0.92);
+  border: 1px solid #1f2430;
+  border-radius: 0.65rem;
+  padding: 1rem 1.25rem;
+  color: #bbb;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.pristine-mining__inspector-status--error {
+  color: #ffb347;
+  border-color: #553211;
+  background: rgba(38, 18, 6, 0.55);
+}
+
+.pristine-mining__inspector .navigation-panel__inspector {
+  position: relative;
+  right: auto;
+  top: auto;
+  bottom: auto;
+  width: 100%;
+  max-width: 21.5rem;
+}
+
+.pristine-mining__inspector .navigation-panel__inspector .scrollable {
+  max-height: calc(100vh - 360px);
+}
+
+.pristine-mining__detail {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  padding-top: 1.25rem;
+  align-items: flex-start;
+}
+
+.pristine-mining__detail-info {
+  flex: 1 1 260px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  color: #bbb;
+  font-size: 0.95rem;
+}
+
+.pristine-mining__detail-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+}
+
+.pristine-mining__detail-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+}
+
+.pristine-mining__detail-status {
+  color: #aaa;
+  font-size: 0.95rem;
+}
+
+.pristine-mining__detail-status--error {
+  color: #ffb347;
+}
+
+.pristine-mining__detail-artwork {
+  flex: 0 0 auto;
+  min-width: 180px;
+}
+
+.pristine-mining__artwork {
+  width: 240px;
+  height: 240px;
+  max-width: 100%;
+}
+
+.pristine-mining__artwork-svg,
+.pristine-mining__artwork-svg--belt {
+  width: 100%;
+  height: 100%;
+}
+
+.pristine-mining__artwork--belt {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 260px;
+  max-width: 100%;
+}
+
+.pristine-mining__artwork-svg--belt {
+  height: auto;
+}
+
+.pristine-mining__belt-ring {
+  fill: rgba(255, 124, 34, 0.25);
+}
+
+.pristine-mining__belt-ring--inner {
+  fill: rgba(255, 124, 34, 0.18);
+}
+
+.pristine-mining__belt-dust {
+  fill: rgba(255, 124, 34, 0.08);
+}
+
+.inara-link-button {
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  text-decoration: underline;
+  transition: color 0.2s ease;
+}
+
+.inara-link-button:hover,
+.inara-link-button:focus {
+  color: #ffb347;
+}
+
+.inara-link-button:focus-visible {
+  outline: 1px dashed var(--color-secondary);
+  outline-offset: 3px;
+}
+
+@media (max-width: 1200px) {
+  .pristine-mining__results--inspector {
+    margin-right: 0;
+  }
+
+  .pristine-mining__inspector {
+    position: static;
+    width: 100%;
+    padding: 1.5rem 1.25rem 0;
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .pristine-mining__inspector .navigation-panel__inspector {
+    max-width: none;
+  }
+}

--- a/src/client/css/pages/inara.css
+++ b/src/client/css/pages/inara.css
@@ -140,31 +140,6 @@
   fill: rgba(255, 124, 34, 0.08);
 }
 
-.inara-link-button {
-  appearance: none;
-  border: none;
-  background: none;
-  padding: 0;
-  font: inherit;
-  color: var(--color-secondary);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  cursor: pointer;
-  text-decoration: underline;
-  transition: color 0.2s ease;
-}
-
-.inara-link-button:hover,
-.inara-link-button:focus {
-  color: #ffb347;
-}
-
-.inara-link-button:focus-visible {
-  outline: 1px dashed var(--color-secondary);
-  outline-offset: 3px;
-}
-
 @media (max-width: 1200px) {
   .pristine-mining__results--inspector {
     margin-right: 0;

--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -4,6 +4,7 @@ import Panel from '../components/panel'
 import Icons from '../lib/icons'
 import { useSocket, sendEvent } from '../lib/socket'
 import NavigationInspectorPanel from '../components/panels/nav/navigation-inspector-panel'
+import animateTableEffect from '../lib/animate-table-effect'
 
 function formatSystemDistance (value, fallback) {
   if (typeof value === 'number' && !Number.isNaN(value)) {
@@ -1742,6 +1743,8 @@ function PristineMiningPanel () {
   const detailRequestRef = useRef({ id: 0, key: null })
   const inspectorReserved = Boolean(expandedLocationKey)
   const inspectorVisible = inspectorReserved && !detailError && !!expandedSystemObject
+
+  useEffect(() => animateTableEffect(), [locations, expandedLocationKey])
 
   const trimmedSystem = useMemo(() => {
     if (typeof system === 'string') {

--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -766,6 +766,17 @@ function MissionsPanel () {
   const [sourceUrl, setSourceUrl] = useState('')
   const [factionStandings, setFactionStandings] = useState({})
 
+  const displayMessage = useMemo(() => {
+    if (typeof message !== 'string') return ''
+    const trimmed = message.trim()
+    if (!trimmed) return ''
+    const lower = trimmed.toLowerCase()
+    if (lower.startsWith('showing nearby mining mission factions near') || lower.startsWith('shwoing nearby mining mission factions near')) {
+      return ''
+    }
+    return trimmed
+  }, [message])
+
   useEffect(() => {
     let cancelled = false
 
@@ -914,9 +925,9 @@ function MissionsPanel () {
       {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
       <div style={{ marginTop: '1.5rem', border: '1px solid #333', background: '#101010', overflow: 'hidden' }}>
         <div className='scrollable' style={{ maxHeight: 'calc(100vh - 360px)', overflowY: 'auto' }}>
-          {message && status !== 'idle' && status !== 'loading' && (
+          {displayMessage && status !== 'idle' && status !== 'loading' && (
             <div style={{ color: '#aaa', padding: '1.25rem 2rem', borderBottom: status === 'populated' ? '1px solid #222' : 'none' }}>
-              {message}
+              {displayMessage}
             </div>
           )}
           {status === 'idle' && (
@@ -936,7 +947,7 @@ function MissionsPanel () {
             </div>
           )}
           {status === 'populated' && missions.length > 0 && (
-            <table style={{ width: '100%', borderCollapse: 'collapse', color: '#fff' }}>
+            <table className='table--animated fx-fade-in' style={{ width: '100%', borderCollapse: 'collapse', color: '#fff' }}>
               <thead>
                 <tr>
                   <th style={{ textAlign: 'left', padding: '.75rem 1rem' }}>Faction</th>


### PR DESCRIPTION
## Summary
- add helper utilities and state to support expanding pristine mining locations
- load system telemetry on demand and reuse the navigation inspector for detailed body views
- show INARA links and inline status messaging inside the expanded row

## Testing
- npm run lint *(fails: existing repository lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d99082526c8323921652f42c75eeeb