### PR TITLE
Tweak pristine mining inspector layout

### DIFF
--- a/src/client/css/pages/inara.css
+++ b/src/client/css/pages/inara.css
@@ -22,6 +22,7 @@
   opacity: 0;
   transition: opacity 0.3s ease;
   display: flex;
+  align-items: flex-start;
 }
 
 .pristine-mining__inspector--reserved {
@@ -100,28 +101,32 @@
 }
 
 .pristine-mining__detail-artwork {
-  flex: 0 0 auto;
-  min-width: 180px;
+  flex: 0 1 220px;
+  min-width: 0;
 }
 
 .pristine-mining__artwork {
-  width: 240px;
-  height: 240px;
-  max-width: 100%;
+  width: 100%;
+  max-width: 200px;
+  aspect-ratio: 1 / 1;
+  height: auto;
+  margin: 0 auto;
 }
 
 .pristine-mining__artwork-svg,
 .pristine-mining__artwork-svg--belt {
+  display: block;
   width: 100%;
-  height: 100%;
+  height: auto;
 }
 
 .pristine-mining__artwork--belt {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 260px;
-  max-width: 100%;
+  width: 100%;
+  max-width: 220px;
+  aspect-ratio: 5 / 3;
 }
 
 .pristine-mining__artwork-svg--belt {

--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -2276,7 +2276,7 @@ function PristineMiningPanel () {
             </div>
           )}
           {status === 'populated' && locations.length > 0 && (
-            <table style={{ width: '100%', borderCollapse: 'collapse', color: '#fff' }}>
+            <table className='table--animated fx-fade-in' style={{ width: '100%', borderCollapse: 'collapse', color: '#fff' }}>
               <thead>
                 <tr>
                   <th style={{ textAlign: 'left', padding: '.75rem 1rem' }}>Body</th>


### PR DESCRIPTION
## Summary
- scale down the pristine mining artwork and ensure the SVG previews shrink without cropping
- adjust the inspector flex alignment so the close button stays anchored at the top of the panel

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9d43a8c30832386ef589658eacffe