### PR TITLE
Update pristine mining header to show relative timestamp

### DIFF
--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -2201,6 +2201,7 @@ function PristineMiningPanel () {
   const [error, setError] = useState('')
   const [message, setMessage] = useState('')
   const [sourceUrl, setSourceUrl] = useState('')
+  const [lastUpdatedAt, setLastUpdatedAt] = useState(null)
   const [expandedLocationKey, setExpandedLocationKey] = useState(null)
   const [expandedSystemData, setExpandedSystemData] = useState(null)
   const [expandedSystemObject, setExpandedSystemObject] = useState(null)
@@ -2242,6 +2243,7 @@ function PristineMiningPanel () {
     setStatus('loading')
     setError('')
     setMessage('')
+    setLastUpdatedAt(null)
 
     fetch('/api/inara-pristine-mining', {
       method: 'POST',
@@ -2266,6 +2268,7 @@ function PristineMiningPanel () {
         setError(nextError)
         setMessage(nextMessage)
         setSourceUrl(nextSourceUrl)
+        setLastUpdatedAt(Date.now())
 
         if (nextError && nextLocations.length === 0) {
           setStatus('error')
@@ -2282,10 +2285,17 @@ function PristineMiningPanel () {
         setMessage('')
         setSourceUrl('')
         setStatus('error')
+        setLastUpdatedAt(null)
       })
 
     return () => { cancelled = true }
   }, [trimmedSystem])
+
+  const displayMessage = useMemo(() => {
+    if (!message) return ''
+    if (/^Showing pristine mining locations within /i.test(message)) return ''
+    return message
+  }, [message])
 
   const resetExpandedState = useCallback(() => {
     setExpandedLocationKey(null)
@@ -2417,9 +2427,27 @@ function PristineMiningPanel () {
           className={`scrollable pristine-mining__results${inspectorReserved ? ' pristine-mining__results--inspector' : ''}`}
           style={{ maxHeight: 'calc(100vh - 360px)', overflowY: 'auto' }}
         >
-          {message && status !== 'idle' && status !== 'loading' && (
+          {(status === 'populated' || status === 'empty') && lastUpdatedAt && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '.75rem',
+                color: '#888',
+                padding: '.75rem 1rem',
+                borderBottom: '1px solid #222',
+                fontSize: '.9rem',
+                background: '#0b0b0b'
+              }}
+            >
+              <span style={{ marginLeft: 'auto', fontSize: '.85rem' }}>
+                Updated {formatRelativeTime(lastUpdatedAt)}
+              </span>
+            </div>
+          )}
+          {displayMessage && status !== 'idle' && status !== 'loading' && (
             <div style={{ color: '#aaa', padding: '1.25rem 2rem', borderBottom: status === 'populated' ? '1px solid #222' : 'none' }}>
-              {message}
+              {displayMessage}
             </div>
           )}
           {status === 'idle' && (


### PR DESCRIPTION
## Summary
- add a last-updated timestamp to the pristine mining locations results panel
- hide the default distance message while preserving other informative messages

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d9df574574832392feae46b5f89d57