### PR TITLE
Keep Pristine Mining inspector docked on the right

### DIFF
--- a/src/client/css/pages/inara.css
+++ b/src/client/css/pages/inara.css
@@ -92,6 +92,7 @@
   align-items: stretch;
   justify-content: flex-end;
   min-width: 0;
+  align-self: stretch;
 }
 
 .pristine-mining__inspector--reserved {
@@ -110,6 +111,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 100%;
   border: 1px solid #1f2430;
   border-radius: 0.75rem;
   background: rgba(8, 10, 16, 0.94) var(--linear-gradient-background);
@@ -173,10 +175,13 @@
   bottom: auto;
   width: 100%;
   max-width: none;
+  display: flex;
+  flex-direction: column;
 }
 
 .pristine-mining__inspector .navigation-panel__inspector .scrollable {
   max-height: calc(100vh - 360px);
+  flex: 1 1 auto;
 }
 
 .pristine-mining__detail {
@@ -270,36 +275,32 @@
 
 @media (max-width: 1200px) {
   .pristine-mining__container {
-    flex-direction: column;
-    gap: 1.25rem;
+    gap: 1rem;
     padding: 1rem;
   }
 
   .pristine-mining__container--inspector {
-    gap: 1.25rem;
+    gap: 1rem;
   }
 
   .pristine-mining__results,
   .pristine-mining__results--inspector {
-    padding-right: 0;
+    padding-right: 0.5rem;
   }
 
   .pristine-mining__container--inspector .pristine-mining__inspector {
-    width: 100%;
-    flex-basis: auto;
+    flex: 0 0 min(23rem, 45vw);
+    width: min(23rem, 45vw);
     padding: 0;
   }
 
   .pristine-mining__inspector .navigation-panel__inspector {
     max-width: none;
+    height: 100%;
   }
 
   .pristine-mining__inspector .navigation-panel__inspector .scrollable {
     max-height: none;
-  }
-
-  .pristine-mining__inspector .inspector {
-    border-left: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the Pristine Mining inspector docked on the right edge across breakpoints
- stretch the inspector to match the results column height and keep its contents scrollable on smaller screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da9a737a688323942ab89ecca48034