### PR TITLE
Ensure INARA data source notice uses consistent grey styling

### DIFF
--- a/src/client/css/pages/inara.css
+++ b/src/client/css/pages/inara.css
@@ -47,6 +47,12 @@
   font-size: 0.85rem;
 }
 
+.inara__data-source {
+  color: #bbb;
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
 @keyframes inara-spinner-rotate {
   to {
     transform: rotate(360deg);

--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -1146,7 +1146,7 @@ function MissionsPanel () {
           <div className='text-primary' style={{ fontSize: '1.1rem' }}>{displaySystemName || 'Unknown'}</div>
         </div>
         {sourceUrl && (
-          <div style={{ marginBottom: '.75rem', fontSize: '0.95rem' }} className='text-secondary'>
+          <div className='inara__data-source'>
             Data sourced from INARA community submissions
           </div>
         )}
@@ -2308,7 +2308,7 @@ function PristineMiningPanel () {
           <div className='text-primary' style={{ fontSize: '1.1rem' }}>{displaySystemName || 'Unknown'}</div>
         </div>
         {sourceUrl && (
-          <div style={{ marginBottom: '.75rem', fontSize: '0.95rem', color: '#bbb' }}>
+          <div className='inara__data-source'>
             Data sourced from INARA community submissions
           </div>
         )}


### PR DESCRIPTION
## Summary
- add a shared `.inara__data-source` style for the INARA community submissions notice
- use the shared style wherever the notice is rendered so it always appears in grey text

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daab001a0c8323913f94e54409cf88