### PR TITLE
Remove extra padding from pristine mining list

### DIFF
--- a/src/client/css/pages/inara.css
+++ b/src/client/css/pages/inara.css
@@ -58,7 +58,7 @@
   display: flex;
   align-items: stretch;
   gap: 0;
-  padding: 1.25rem;
+  padding: 0;
   border-radius: 0;
   box-sizing: border-box;
   border: 1px solid #333;
@@ -276,7 +276,7 @@
 @media (max-width: 1200px) {
   .pristine-mining__container {
     gap: 1rem;
-    padding: 1rem;
+    padding: 0;
   }
 
   .pristine-mining__container--inspector {


### PR DESCRIPTION
## Summary
- remove the padding from the pristine mining results container to align the list with the mining missions layout
- ensure responsive styles no longer reintroduce the container padding on smaller viewports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daac03917c8323b690acea4f166c1a