### PR TITLE
Update updater repo and ensure host info fallback

### DIFF
--- a/src/app/consts.go
+++ b/src/app/consts.go
@@ -6,7 +6,7 @@ const TERMINAL_WINDOW_TITLE = "ICARUS Terminal"
 const LPSZ_CLASS_NAME = "IcarusTerminalWindowClass"
 const SERVICE_EXECUTABLE = "ICARUS Service.exe"
 const TERMINAL_EXECUTABLE = "ICARUS Terminal.exe"
-const RELEASE_NOTES_URL = "https://github.com/iaincollins/icarus/releases"
+const RELEASE_NOTES_URL = "https://github.com/acorrow/icarus/releases"
 const DEBUGGER = true
 
 const defaultLauncherWindowWidth = int32(900)

--- a/src/app/updater.go
+++ b/src/app/updater.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-const LATEST_RELEASE_URL = "https://api.github.com/repos/iaincollins/icarus/releases/latest"
+const LATEST_RELEASE_URL = "https://api.github.com/repos/acorrow/icarus/releases/latest"
 
 type Release struct {
 	InstalledVersion string `json:"installedVersion"`

--- a/src/service/lib/events.js
+++ b/src/service/lib/events.js
@@ -24,10 +24,14 @@ const gameStateChangeHandler = () => _eventHandlers.gameStateChangeHandler()
 
 // Extend game logic related event handlers with app logic related handlers
 eventHandlers.hostInfo = () => {
-  const urls = Object.values(os.networkInterfaces())
+  const interfaces = Object.values(os.networkInterfaces())
+    .filter(Boolean)
     .flat()
+  const interfaceUrls = interfaces
     .filter(({ family, internal }) => family === 'IPv4' && !internal)
     .map(({ address }) => `http://${address}:${PORT}`)
+  const fallbackUrls = [`http://localhost:${PORT}`, `http://127.0.0.1:${PORT}`]
+  const urls = [...new Set([...interfaceUrls, ...fallbackUrls])]
   return { urls }
 }
 eventHandlers.getLoadingStatus = () => getLoadingStatus()


### PR DESCRIPTION
## Summary
- update the Windows updater and release notes links to use the acorrow/icarus repository
- ensure the host info event always returns at least localhost URLs so the launcher shows a connection address

## Testing
- npm run lint:javascript *(fails: existing lint warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dabcd124308323b67818b86dbb6138