### PR TITLE
Add experimental HID input mapping support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "icarus",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "icarus",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "ISC",
       "dependencies": {
         "async-retry": "^1.3.3",
@@ -17,6 +17,7 @@
         "glob": "^7.1.7",
         "http-proxy": "^1.18.1",
         "nedb-promises": "^5.0.2",
+        "node-hid": "^2.2.0",
         "one-time": "^0.0.4",
         "say": "^0.16.0",
         "serve-static": "^1.14.1",
@@ -1733,7 +1734,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1762,7 +1762,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -1771,7 +1770,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1912,7 +1910,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3311,7 +3308,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -3414,6 +3410,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.982423",
@@ -3591,7 +3596,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4584,6 +4588,15 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ext-list": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
@@ -4785,8 +4798,7 @@
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/filelist": {
       "version": "1.0.2",
@@ -5025,8 +5037,7 @@
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-extra": {
       "version": "10.0.0",
@@ -5231,6 +5242,12 @@
         "image-q": "^1.1.1",
         "omggif": "^1.0.10"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.1.7",
@@ -5701,7 +5718,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5818,8 +5834,7 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -6868,8 +6883,7 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "3.1.5",
@@ -6989,8 +7003,7 @@
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/move-file": {
       "version": "2.1.0",
@@ -7076,6 +7089,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7571,6 +7590,36 @@
         }
       }
     },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -7625,6 +7674,24 @@
       },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-hid": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-2.2.0.tgz",
+      "integrity": "sha512-vj48zh9j555DZzUhMc8tk/qw6xPFrDyPBH1ST1Z/hWaA/juBJw7IuSxPeOgpzNFNU36mGYj+THioRMt1xOdm/g==",
+      "hasInstallScript": true,
+      "license": "(MIT OR X11)",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^3.0.2",
+        "prebuild-install": "^7.1.1"
+      },
+      "bin": {
+        "hid-showdevices": "src/show-devices.js"
       },
       "engines": {
         "node": ">=10"
@@ -8789,6 +8856,32 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8892,7 +8985,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -9013,7 +9105,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -9077,7 +9168,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -9351,8 +9441,7 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -9588,6 +9677,78 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
       "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-get/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/simple-get/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -10208,7 +10369,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -10217,7 +10377,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10347,7 +10506,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10654,7 +10812,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -10665,14 +10822,12 @@
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/tar-fs/node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -10991,7 +11146,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -11371,8 +11525,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -12992,8 +13145,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -13005,7 +13157,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -13014,7 +13165,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -13127,7 +13277,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -14218,8 +14367,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -14300,6 +14448,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-libc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw=="
     },
     "devtools-protocol": {
       "version": "0.0.982423",
@@ -14437,7 +14590,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -15183,6 +15335,11 @@
         }
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "ext-list": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
@@ -15344,8 +15501,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filelist": {
       "version": "1.0.2",
@@ -15534,8 +15690,7 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "10.0.0",
@@ -15696,6 +15851,11 @@
         "image-q": "^1.1.1",
         "omggif": "^1.0.10"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "glob": {
       "version": "7.1.7",
@@ -16044,8 +16204,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.1.9",
@@ -16127,8 +16286,7 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -16940,8 +17098,7 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "3.1.5",
@@ -17029,8 +17186,7 @@
     "mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "move-file": {
       "version": "2.1.0",
@@ -17087,6 +17243,11 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -17456,6 +17617,26 @@
         "styled-jsx": "5.0.1"
       }
     },
+    "node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "requires": {
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+          "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
+        }
+      }
+    },
+    "node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -17492,6 +17673,16 @@
             "lru-cache": "^6.0.0"
           }
         }
+      }
+    },
+    "node-hid": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-2.2.0.tgz",
+      "integrity": "sha512-vj48zh9j555DZzUhMc8tk/qw6xPFrDyPBH1ST1Z/hWaA/juBJw7IuSxPeOgpzNFNU36mGYj+THioRMt1xOdm/g==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^3.0.2",
+        "prebuild-install": "^7.1.1"
       }
     },
     "nodemon": {
@@ -18382,6 +18573,25 @@
         "source-map-js": "^1.0.1"
       }
     },
+    "prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -18469,7 +18679,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -18553,7 +18762,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -18601,7 +18809,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -18795,8 +19002,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -19000,6 +19206,36 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
       "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
     },
     "slash": {
       "version": "3.0.0",
@@ -19476,7 +19712,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
@@ -19484,8 +19719,7 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -19580,8 +19814,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "strip-outer": {
       "version": "1.0.1",
@@ -19818,7 +20051,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -19829,14 +20061,12 @@
         "chownr": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-          "dev": true
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "tar-stream": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
           "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-          "dev": true,
           "requires": {
             "bl": "^4.0.3",
             "end-of-stream": "^1.4.1",
@@ -20117,7 +20347,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -20417,8 +20646,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "glob": "^7.1.7",
     "http-proxy": "^1.18.1",
     "nedb-promises": "^5.0.2",
+    "node-hid": "^2.2.0",
     "one-time": "^0.0.4",
     "say": "^0.16.0",
     "serve-static": "^1.14.1",

--- a/scripts/build-service.js
+++ b/scripts/build-service.js
@@ -6,6 +6,8 @@ const UPX = require('upx')({ brute: false }) // Brute on service seems to hang
 const yargs = require('yargs')
 const commandLineArgs = yargs.argv
 
+const { ensureNodeHidBinary, TARGET_NODE_VERSION, TARGET_ARCH } = require('./lib/ensure-node-hid')
+
 const {
   DEVELOPMENT_BUILD: DEVELOPMENT_BUILD_DEFAULT,
   DEBUG_CONSOLE: DEBUG_CONSOLE_DEFAULT,
@@ -37,6 +39,7 @@ function clean () {
 }
 
 async function build () {
+  ensureNodeHidBinary({ nodeVersion: TARGET_NODE_VERSION, arch: TARGET_ARCH })
   await compile({
     name: 'ICARUS Service',
     ico: SERVICE_ICON,

--- a/scripts/build-standalone.js
+++ b/scripts/build-standalone.js
@@ -18,6 +18,8 @@ const {
   SERVICE_ICON
 } = require('./lib/build-options')
 
+const { ensureNodeHidBinary, TARGET_NODE_VERSION, TARGET_ARCH } = require('./lib/ensure-node-hid')
+
 const DEBUG_CONSOLE = commandLineArgs.debug || DEBUG_CONSOLE_DEFAULT
 const ENTRY_POINT = path.join(__dirname, '..', 'src', 'service', 'main.js')
 
@@ -33,6 +35,7 @@ function clean () {
 }
 
 async function build () {
+  ensureNodeHidBinary({ nodeVersion: TARGET_NODE_VERSION, arch: TARGET_ARCH })
   await compile({
     name: 'ICARUS Service',
     ico: SERVICE_ICON,

--- a/scripts/lib/ensure-node-hid.js
+++ b/scripts/lib/ensure-node-hid.js
@@ -1,0 +1,68 @@
+const fs = require('fs')
+const path = require('path')
+const { execSync } = require('child_process')
+
+const TARGET_NODE_VERSION = '14.15.3'
+const TARGET_ARCH = 'ia32'
+
+function hasExpectedBinary ({ modulePath, arch = TARGET_ARCH }) {
+  const binaryPath = path.join(modulePath, 'build', 'Release', 'hid.node')
+  if (!fs.existsSync(binaryPath)) return false
+
+  // node-hid ships prebuilds in per-arch folders as well – prefer those when present
+  const prebuildArchPath = path.join(modulePath, 'prebuilds')
+  if (fs.existsSync(prebuildArchPath)) {
+    const entries = fs.readdirSync(prebuildArchPath)
+    const matching = entries.find(entry => entry.toLowerCase().includes(`win32-${arch}`))
+    if (matching) {
+      const prebuildBinary = path.join(prebuildArchPath, matching, 'node.napi.node')
+      if (fs.existsSync(prebuildBinary)) return true
+    }
+  }
+
+  return true
+}
+
+function ensureNodeHidBinary ({ arch = TARGET_ARCH, nodeVersion = TARGET_NODE_VERSION } = {}) {
+  const modulePath = path.join(__dirname, '..', '..', 'node_modules', 'node-hid')
+  if (!fs.existsSync(modulePath)) {
+    console.warn('node-hid not installed – skipping HID rebuild step.')
+    return
+  }
+
+  if (process.platform !== 'win32') {
+    // Windows packaging handles the service build; other platforms run the dev server directly
+    console.log('Skipping node-hid rebuild on non-Windows platform.')
+    return
+  }
+
+  if (hasExpectedBinary({ modulePath, arch })) {
+    console.log(`Ensuring node-hid binary matches Node ${nodeVersion} (${arch}).`)
+  } else {
+    console.log('node-hid binary missing – triggering rebuild.')
+  }
+
+  try {
+    execSync(
+      `npm rebuild node-hid --runtime=node --target=${nodeVersion}`,
+      {
+        stdio: 'inherit',
+        env: {
+          ...process.env,
+          npm_config_arch: arch,
+          npm_config_target_arch: arch,
+          npm_config_disturl: process.env.npm_config_disturl || 'https://nodejs.org/download/release/'
+        }
+      }
+    )
+  } catch (error) {
+    console.error('Failed to rebuild node-hid for packaged service.')
+    throw error
+  }
+}
+
+module.exports = {
+  ensureNodeHidBinary,
+  TARGET_NODE_VERSION,
+  TARGET_ARCH
+}

--- a/src/client/pages/_app.js
+++ b/src/client/pages/_app.js
@@ -93,6 +93,13 @@ const handleKeyPress = (event) => {
   }
 }
 
+const triggerNavigationKey = (key) => {
+  handleKeyPress({
+    key,
+    getModifierState: () => false
+  })
+}
+
 export default class MyApp extends App {
   constructor (props) {
     super(props)
@@ -121,8 +128,22 @@ export default class MyApp extends App {
         }
       })
 
+      eventListener('inputAction', (event) => {
+        if (!event?.actionId) return
+        switch (event.actionId) {
+          case 'nativePanel.navigateUp':
+            triggerNavigationKey('ArrowUp')
+            break
+          case 'nativePanel.navigateDown':
+            triggerNavigationKey('ArrowDown')
+            break
+          default:
+            break
+        }
+      })
+
       document.addEventListener('keydown', handleKeyPress)
-    } 
+    }
   }
 
   render () {

--- a/src/client/pages/launcher.js
+++ b/src/client/pages/launcher.js
@@ -17,13 +17,24 @@ const defaultloadingStats = {
 
 export default function IndexPage () {
   const { connected } = useSocket()
-  const [hostInfo, setHostInfo] = useState()
+  const [hostInfo, setHostInfo] = useState({ urls: [] })
   const [update, setUpdate] = useState()
   const [downloadingUpdate, setDownloadingUpdate] = useState(false)
   const [loadingProgress, setLoadingProgress] = useState(defaultloadingStats)
 
   // Display URL (IP address/port) to connect from a browser
-  useEffect(async () => setHostInfo(await sendEvent('hostInfo')), [])
+  useEffect(() => {
+    let isMounted = true
+    ;(async () => {
+      try {
+        const info = await sendEvent('hostInfo')
+        if (isMounted && info) setHostInfo(info)
+      } catch (error) {
+        console.error('Failed to load host info', error)
+      }
+    })()
+    return () => { isMounted = false }
+  }, [])
 
   useEffect(async () => {
     const message = await sendEvent('getLoadingStatus')
@@ -85,15 +96,6 @@ export default function IndexPage () {
               <i style={{ position: 'relative', top: '.2rem', marginRight: '.2rem' }} className='icon icarus-terminal-download' /> Downloading update...
             </p>}
           </div>}
-        <div style={{ position: 'absolute', bottom: '.5rem', left: '1rem' }}>
-          <p className='text-muted'>Connect from a browser on</p>
-          {hostInfo?.urls?.[0] &&
-            <p>
-              <span className='text-info' onClick={() => openTerminalInBrowser()}>
-                {hostInfo.urls[0]}
-              </span>
-            </p>}
-        </div>
         <div
           className='scrollable text-right text-uppercase' style={{
             position: 'absolute',
@@ -123,6 +125,14 @@ export default function IndexPage () {
           </div>
         </div>
         <div style={{ position: 'absolute', bottom: '1rem', right: '1rem' }}>
+          <div style={{ marginBottom: '.75rem', textAlign: 'right' }}>
+            <p className='text-muted' style={{ marginBottom: '.2rem' }}>Connect from a browser on</p>
+            <p style={{ margin: 0 }}>
+              <span className='text-info' onClick={() => openTerminalInBrowser()}>
+                {hostInfo?.urls?.[0] || 'http://localhost:3300'}
+              </span>
+            </p>
+          </div>
           <button style={{ width: '20rem' }} onClick={newWindow}>New Terminal</button>
           <button
             style={{ width: '20rem', marginTop: '.5rem' }}

--- a/src/client/pages/launcher.js
+++ b/src/client/pages/launcher.js
@@ -82,7 +82,7 @@ export default function IndexPage () {
               ><i className='icon icarus-terminal-download' /> Install Update
               </button>}
             {downloadingUpdate && <p className='text-primary text-blink-slow'>
-              <i style={{position: 'relative', top: '.2rem', marginRight: '.2rem'}} className='icon icarus-terminal-download' /> Downloading update...
+              <i style={{ position: 'relative', top: '.2rem', marginRight: '.2rem' }} className='icon icarus-terminal-download' /> Downloading update...
             </p>}
           </div>}
         <div style={{ position: 'absolute', bottom: '.5rem', left: '1rem' }}>
@@ -124,6 +124,12 @@ export default function IndexPage () {
         </div>
         <div style={{ position: 'absolute', bottom: '1rem', right: '1rem' }}>
           <button style={{ width: '20rem' }} onClick={newWindow}>New Terminal</button>
+          <button
+            style={{ width: '20rem', marginTop: '.5rem' }}
+            onClick={() => { window.location.href = '/native/input-mapping' }}
+          >
+            Input Mapping
+          </button>
         </div>
       </div>
     </>

--- a/src/client/pages/native/input-mapping.js
+++ b/src/client/pages/native/input-mapping.js
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Head from 'next/head'
+
+import { sendEvent, eventListener, useSocket } from 'lib/socket'
+
+const { INPUT_ACTIONS, INPUT_GROUPS } = require('../../../shared/input-actions')
+
+const defaultStatus = {
+  supported: false,
+  listening: false,
+  devices: [],
+  mappings: {},
+  actions: INPUT_ACTIONS,
+  groups: INPUT_GROUPS
+}
+
+export default function InputMappingPage () {
+  const { connected } = useSocket()
+  const [status, setStatus] = useState(defaultStatus)
+  const [listeningAction, setListeningAction] = useState(null)
+  const [error, setError] = useState(null)
+
+  const actions = useMemo(() => status?.actions || INPUT_ACTIONS, [status])
+  const groups = useMemo(() => status?.groups || INPUT_GROUPS, [status])
+  const mappings = useMemo(() => status?.mappings || {}, [status])
+  const supported = status?.supported
+
+  const refreshStatus = useCallback(async () => {
+    const response = await sendEvent('inputGetStatus')
+    if (response) setStatus(prev => ({ ...prev, ...response }))
+  }, [])
+
+  useEffect(() => { refreshStatus() }, [refreshStatus])
+
+  useEffect(() => {
+    if (connected) refreshStatus()
+  }, [connected, refreshStatus])
+
+  useEffect(() => eventListener('inputStatus', (message) => {
+    if (message) setStatus(prev => ({ ...prev, ...message }))
+  }), [])
+
+  useEffect(() => eventListener('inputMappingUpdated', ({ actionId, binding }) => {
+    setStatus(prev => ({
+      ...prev,
+      mappings: {
+        ...(prev?.mappings || {}),
+        [actionId]: binding
+      }
+    }))
+  }), [])
+
+  const handleListen = async (actionId) => {
+    setListeningAction(actionId)
+    setError(null)
+    setStatus(prev => ({ ...prev, listening: true }))
+    const response = await sendEvent('inputListen', { actionId })
+    if (response?.error) {
+      switch (response.error) {
+        case 'HIDUnavailable':
+          setError('No compatible HID listener is available on this system.')
+          break
+        case 'HIDCaptureTimeout':
+          setError('Timed out waiting for input. Try pressing the button again.')
+          break
+        case 'CaptureInProgress':
+          setError('Another input capture is already in progress.')
+          break
+        default:
+          setError('Unable to capture input: ' + response.error)
+      }
+    } else if (response?.binding) {
+      setStatus(prev => ({
+        ...prev,
+        mappings: {
+          ...(prev?.mappings || {}),
+          [actionId]: response.binding
+        }
+      }))
+    }
+    setListeningAction(null)
+    setStatus(prev => ({ ...prev, listening: false }))
+  }
+
+  const handleClear = async (actionId) => {
+    setError(null)
+    const response = await sendEvent('inputClear', { actionId })
+    if (response?.error) {
+      setError('Unable to clear mapping: ' + response.error)
+    } else {
+      setStatus(prev => ({
+        ...prev,
+        mappings: {
+          ...(prev?.mappings || {}),
+          [actionId]: null
+        }
+      }))
+    }
+  }
+
+  const renderBinding = (binding) => {
+    if (!binding) return <span className='text-muted'>Not mapped</span>
+    const { device, dataHex } = binding
+    if (!device) return <span className='text-muted'>Unknown binding</span>
+    return (
+      <span>
+        <span className='text-info'>{device.product || 'Device'}</span>
+        <span className='text-muted'> · VID {device.vendorId?.toString(16) || '?'} / PID {device.productId?.toString(16) || '?'}</span>
+        <br />
+        <span className='text-muted'>Data: {dataHex}</span>
+      </span>
+    )
+  }
+
+  return (
+    <div className='container container--full-height'>
+      <Head>
+        <title>Input Mapping · ICARUS</title>
+      </Head>
+      <div className='panel panel--padded' style={{ margin: '2rem auto', maxWidth: '56rem' }}>
+        <div className='panel__header'>
+          <h1 className='text-info'>Input Mapping</h1>
+          <p className='text-muted'>Bind HOTAS and other Windows HID buttons to native ICARUS actions.</p>
+          <p className='text-muted'>
+            <a className='text-link' href='/launcher'>← Back to Launcher</a>
+          </p>
+        </div>
+        <div className='panel__content'>
+          {!connected && <p className='text-muted'>Connecting to service…</p>}
+          {error && <p className='text-warning'>{error}</p>}
+          <p className='text-muted'>
+            {supported
+              ? 'Press “Listen” for an action, then press a button on your controller to capture the binding.'
+              : 'HID listening is not currently available. Ensure ICARUS is running on Windows with node-hid installed.'}
+          </p>
+          {status?.listening && <p className='text-info text-blink-slow'>Listening for input…</p>}
+          {groups.map(group => (
+            <div key={group.id} style={{ marginTop: '2rem' }}>
+              <h2 className='text-primary'>{group.label}</h2>
+              <table className='table table--bordered table--compact' style={{ width: '100%' }}>
+                <thead>
+                  <tr>
+                    <th style={{ width: '35%' }}>Action</th>
+                    <th>Binding</th>
+                    <th style={{ width: '12rem' }}>&nbsp;</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {actions.filter(action => action.group === group.id).map(action => (
+                    <tr key={action.id}>
+                      <td>
+                        <strong>{action.label}</strong>
+                        <p className='text-muted' style={{ margin: 0 }}>{action.description}</p>
+                      </td>
+                      <td>{renderBinding(mappings[action.id])}</td>
+                      <td style={{ textAlign: 'right' }}>
+                        <button
+                          className='button'
+                          disabled={!supported || listeningAction === action.id}
+                          onClick={() => handleListen(action.id)}
+                          style={{ marginRight: '.5rem' }}
+                        >
+                          {listeningAction === action.id ? 'Listening…' : 'Listen'}
+                        </button>
+                        <button
+                          className='button button--secondary'
+                          disabled={!supported || !mappings[action.id]}
+                          onClick={() => handleClear(action.id)}
+                        >
+                          Clear
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))}
+          <div style={{ marginTop: '2rem' }}>
+            <h2 className='text-primary'>Connected Devices</h2>
+            {status?.devices?.length
+              ? (
+                <ul className='text-muted'>
+                  {status.devices.map(device => (
+                    <li key={device.path || `${device.vendorId}:${device.productId}`}>
+                      <span className='text-info'>{device.product || 'Unnamed Device'}</span>
+                      <span> · VID {device.vendorId?.toString(16) || '?'} / PID {device.productId?.toString(16) || '?'}</span>
+                    </li>
+                  ))}
+                </ul>
+                )
+              : <p className='text-muted'>No HID devices detected yet.</p>}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/client/pages/native/input-mapping.js
+++ b/src/client/pages/native/input-mapping.js
@@ -11,7 +11,8 @@ const defaultStatus = {
   devices: [],
   mappings: {},
   actions: INPUT_ACTIONS,
-  groups: INPUT_GROUPS
+  groups: INPUT_GROUPS,
+  reason: null
 }
 
 export default function InputMappingPage () {
@@ -131,7 +132,7 @@ export default function InputMappingPage () {
           <p className='text-muted'>
             {supported
               ? 'Press “Listen” for an action, then press a button on your controller to capture the binding.'
-              : 'HID listening is not currently available. Ensure ICARUS is running on Windows with node-hid installed.'}
+              : `HID listening is not currently available${status?.reason ? ` (${status.reason})` : ''}.`}
           </p>
           {status?.listening && <p className='text-info text-blink-slow'>Listening for input…</p>}
           {groups.map(group => (

--- a/src/service/lib/event-handlers.js
+++ b/src/service/lib/event-handlers.js
@@ -1,4 +1,3 @@
-const os = require('os')
 const fs = require('fs')
 const path = require('path')
 // const pjXML = require('pjxml')
@@ -9,6 +8,7 @@ const { UNKNOWN_VALUE } = require('../../shared/consts')
 const { BROADCAST_EVENT: broadcastEvent } = global
 
 // const TARGET_WINDOW_TITLE = 'Elite - Dangerous (CLIENT)'
+const os = require('os')
 const KEYBINDS_DIR = path.join(os.homedir(), 'AppData', 'Local', 'Frontier Developments', 'Elite Dangerous', 'Options', 'Bindings')
 
 // Prefer Keybinds v4 file
@@ -26,8 +26,7 @@ const KEYBINDS_MAP = {
 }
 
 // FIXME Refactor Preferences handling into a singleton
-const PREFERENCES_DIR = path.join(os.homedir(), 'AppData', 'Local', 'ICARUS Terminal')
-const PREFERENCES_FILE = path.join(PREFERENCES_DIR, 'Preferences.json')
+const { PREFERENCES_DIR, PREFERENCES_FILE, ensurePreferencesDir } = require('./preferences')
 
 const System = require('./event-handlers/system')
 const ShipStatus = require('./event-handlers/ship-status')
@@ -98,7 +97,7 @@ class EventHandlers {
           return fs.existsSync(PREFERENCES_FILE) ? JSON.parse(fs.readFileSync(PREFERENCES_FILE)) : {}
         },
         setPreferences: (preferences) => {
-          if (!fs.existsSync(PREFERENCES_DIR)) fs.mkdirSync(PREFERENCES_DIR, { recursive: true })
+          ensurePreferencesDir()
           fs.writeFileSync(PREFERENCES_FILE, JSON.stringify(preferences))
           broadcastEvent('syncMessage', { name: 'preferences' })
           return preferences
@@ -115,7 +114,7 @@ class EventHandlers {
         //     return null
         //   }
         // },
-        testMessage: ({name, message}) => {
+        testMessage: ({ name, message }) => {
           // Method to simulate messages, intended for developers
           if (name !== 'testMessage') broadcastEvent(name, message)
         },

--- a/src/service/lib/input/README.md
+++ b/src/service/lib/input/README.md
@@ -1,0 +1,69 @@
+# Experimental HID Input Support
+
+This document walks through the steps required to run the experimental Human Interface Device (HID) listener locally and map buttons from a joystick/HOTAS to the native panel navigation actions. Follow these instructions if you see the `HID support disabled – node-hid not available.` warning in the service logs or if the Input Mapping UI reports that HID is unavailable.
+
+## Prerequisites
+
+1. **Windows 10 or newer** – the listener currently targets the native Windows build of ICARUS.
+2. **Git** – to clone the repository.
+3. **Node.js 18.17.1 and npm 9.6.7** – the versions pinned in `package.json`. Install them from [nodejs.org](https://nodejs.org/) or with a version manager such as `nvm-windows`.
+4. **Build tools for native Node modules** – `node-hid` contains native code that must be compiled locally.
+   - Install the **"Desktop development with C++"** workload from [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/), or run `npm install --global --production windows-build-tools` from an elevated PowerShell prompt (requires Python 3).
+   - After the tools are installed, restart your terminal so that the `cl` compiler and other dependencies are on the `PATH`.
+
+## One-time setup
+
+```powershell
+# Clone the repository
+git clone https://github.com/acorrow/icarus.git
+cd icarus
+
+# Install dependencies (this compiles node-hid on Windows)
+npm install
+
+# Copy the environment file and point LOG_DIR at your Elite Dangerous save folder
+Copy-Item .env-example .env
+notepad .env   # change LOG_DIR if the default is wrong
+```
+
+> **Tip:** The Elite Dangerous journals normally live in `C:\Users\<you>\Saved Games\Frontier Developments\Elite Dangerous`. Leave `LOG_DIR` blank to accept that default.
+
+If you previously installed dependencies before adding the build tools and now see the HID warning, rebuild the module:
+
+```powershell
+npm rebuild node-hid
+```
+
+## Running the development stack
+
+```powershell
+# Start the Node service in development mode (port 3300)
+npm run dev
+```
+
+The command above starts the service, watches for journal updates, and automatically launches a Next.js dev server on port 3000. The service proxies HTTP requests, so you can load the UI at [http://localhost:3300](http://localhost:3300).
+
+To open the mapping interface directly, visit:
+
+```
+http://localhost:3300/native/input-mapping
+```
+
+Alternatively, use the **Input Mapping** tile on the native launcher page while the service is running.
+
+## Mapping a joystick button
+
+1. Connect your HOTAS/joystick before starting `npm run dev` so Windows exposes the HID device.
+2. Open the Input Mapping page and confirm that your device appears in the **Connected Devices** list.
+3. Select the **Navigate Up** or **Navigate Down** action, press **Listen for input**, then press the desired button on your controller.
+4. The binding is saved immediately. Test by pressing the button again—focus inside the native panel should move just like pressing the arrow keys.
+5. Use the **Clear binding** button if you want to remove the mapping.
+
+## Troubleshooting
+
+- **"HID support disabled – node-hid not available."** – The `node-hid` module failed to load. Re-run `npm install` after installing the Visual Studio build tools, then `npm rebuild node-hid`.
+- **`npm install` fails while building node-hid** – Ensure you are running the terminal as Administrator and that the Build Tools installer completed (including the Windows 10 SDK and MSVC toolchain).
+- **Device not listed** – Unplug/replug the controller and watch the service logs. Each detected device prints a register/unregister message. If it still does not appear, check that Windows recognises the device in `joy.cpl`.
+- **Need mock game data** – If you do not have Elite Dangerous logs, set `LOG_DIR` to `resources/mock-game-data` in your `.env` file so the UI can render with the bundled fixtures.
+
+With the steps above, the experimental HID listener should run locally and accept button mappings for the native panel navigation actions.

--- a/src/service/lib/input/README.md
+++ b/src/service/lib/input/README.md
@@ -2,6 +2,8 @@
 
 This document walks through the steps required to run the experimental Human Interface Device (HID) listener locally and map buttons from a joystick/HOTAS to the native panel navigation actions. Follow these instructions if you see the `HID support disabled – node-hid not available.` warning in the service logs or if the Input Mapping UI reports that HID is unavailable.
 
+> **Packaged builds:** Running `npm run build` (or the individual build steps) now automatically recompiles `node-hid` against the Node 14 runtime used inside the Windows service executable. A fresh installer generated after this change includes the working HID listener without requiring any manual setup.
+
 ## Prerequisites
 
 1. **Windows 10 or newer** – the listener currently targets the native Windows build of ICARUS.
@@ -28,7 +30,7 @@ notepad .env   # change LOG_DIR if the default is wrong
 
 > **Tip:** The Elite Dangerous journals normally live in `C:\Users\<you>\Saved Games\Frontier Developments\Elite Dangerous`. Leave `LOG_DIR` blank to accept that default.
 
-If you previously installed dependencies before adding the build tools and now see the HID warning, rebuild the module:
+If you previously installed dependencies before adding the build tools and now see the HID warning while developing locally, rebuild the module:
 
 ```powershell
 npm rebuild node-hid

--- a/src/service/lib/input/index.js
+++ b/src/service/lib/input/index.js
@@ -28,7 +28,8 @@ class InputManager extends EventEmitter {
       devices: this.listener.getDevices(),
       mappings: this.mappingStore.getMappings(),
       actions: INPUT_ACTIONS,
-      groups: INPUT_GROUPS
+      groups: INPUT_GROUPS,
+      reason: this.listener.getUnavailableReason()
     }
   }
 

--- a/src/service/lib/input/index.js
+++ b/src/service/lib/input/index.js
@@ -1,0 +1,74 @@
+const EventEmitter = require('events')
+
+const MappingStore = require('./mapping-store')
+const InputListener = require('./listener')
+const { INPUT_ACTIONS, INPUT_GROUPS } = require('../../../shared/input-actions')
+
+class InputManager extends EventEmitter {
+  constructor ({ broadcastEvent }) {
+    super()
+    this.broadcastEvent = broadcastEvent
+    this.mappingStore = new MappingStore()
+    this.listener = new InputListener()
+    this.listener.on('input', payload => this.handleInput(payload))
+    this.listener.on('deviceRegistered', device => this.broadcastState())
+    this.listener.on('deviceUnregistered', device => this.broadcastState())
+    this.listener.start()
+    this.broadcastState()
+  }
+
+  isSupported () {
+    return this.listener.isAvailable()
+  }
+
+  getStatus () {
+    return {
+      supported: this.isSupported(),
+      listening: this.listener.isCapturing(),
+      devices: this.listener.getDevices(),
+      mappings: this.mappingStore.getMappings(),
+      actions: INPUT_ACTIONS,
+      groups: INPUT_GROUPS
+    }
+  }
+
+  async listenForAction (actionId, { timeoutMs } = {}) {
+    if (!this.isSupported()) throw new Error('HIDUnavailable')
+    const capturePromise = this.listener.captureNextInput({ timeoutMs })
+    this.broadcastState()
+    try {
+      const payload = await capturePromise
+      const binding = this.mappingStore.setMapping(actionId, payload)
+      this.broadcastEvent('inputMappingUpdated', { actionId, binding })
+      this.broadcastState()
+      return { actionId, binding }
+    } catch (error) {
+      this.broadcastState()
+      throw error
+    }
+  }
+
+  clearMapping (actionId) {
+    const binding = this.mappingStore.clearMapping(actionId)
+    this.broadcastEvent('inputMappingUpdated', { actionId, binding })
+    this.broadcastState()
+    return { actionId, binding }
+  }
+
+  getMappings () {
+    return this.mappingStore.getMappings()
+  }
+
+  handleInput (payload) {
+    const actionId = this.mappingStore.findActionForPayload(payload)
+    if (!actionId) return
+    this.broadcastEvent('inputAction', { actionId, payload })
+    this.emit('action', { actionId, payload })
+  }
+
+  broadcastState () {
+    this.broadcastEvent('inputStatus', this.getStatus())
+  }
+}
+
+module.exports = InputManager

--- a/src/service/lib/input/listener.js
+++ b/src/service/lib/input/listener.js
@@ -63,7 +63,9 @@ class InputListener extends EventEmitter {
     if (this.deviceHandles.has(deviceId)) return
 
     try {
-      const handle = new HID.HID(deviceInfo.path || deviceInfo.vendorId, deviceInfo.productId)
+      const handle = deviceInfo.path
+        ? new HID.HID(deviceInfo.path)
+        : new HID.HID(deviceInfo.vendorId, deviceInfo.productId)
       handle.on('data', data => this.handleData(deviceInfo, data))
       handle.on('error', error => this.handleError(deviceInfo, error))
       this.deviceHandles.set(deviceId, { deviceInfo, handle })

--- a/src/service/lib/input/listener.js
+++ b/src/service/lib/input/listener.js
@@ -1,0 +1,163 @@
+const EventEmitter = require('events')
+
+let HID
+try {
+  HID = require('node-hid')
+} catch (error) {
+  HID = null
+  console.warn('HID support disabled – node-hid not available.', error?.message || error)
+}
+
+class InputListener extends EventEmitter {
+  constructor () {
+    super()
+    this.deviceHandles = new Map()
+    this.pendingCapture = null
+    this.available = Boolean(HID)
+    this.scanInterval = null
+  }
+
+  isAvailable () {
+    return this.available
+  }
+
+  start () {
+    if (!this.available) return
+    this.scanDevices()
+    if (!this.scanInterval) {
+      this.scanInterval = setInterval(() => this.scanDevices(), 10000)
+    }
+  }
+
+  isCapturing () {
+    return Boolean(this.pendingCapture)
+  }
+
+  scanDevices () {
+    if (!this.available) return
+    let devices = []
+    try {
+      devices = HID.devices()
+    } catch (error) {
+      console.error('ERROR_SCANNING_HID_DEVICES', error?.message || error)
+      return
+    }
+    devices.forEach(device => this.registerDevice(device))
+    // Remove handles for devices that are no longer present
+    Array.from(this.deviceHandles.values()).forEach(record => {
+      const stillPresent = devices.find(device => this.getDeviceId(device) === this.getDeviceId(record.deviceInfo))
+      if (!stillPresent) this.unregisterDevice(record.deviceInfo)
+    })
+  }
+
+  registerDevice (deviceInfo) {
+    if (!this.available) return
+    const deviceId = this.getDeviceId(deviceInfo)
+    if (this.deviceHandles.has(deviceId)) return
+
+    try {
+      const handle = new HID.HID(deviceInfo.path || deviceInfo.vendorId, deviceInfo.productId)
+      handle.on('data', data => this.handleData(deviceInfo, data))
+      handle.on('error', error => this.handleError(deviceInfo, error))
+      this.deviceHandles.set(deviceId, { deviceInfo, handle })
+      this.emit('deviceRegistered', this.sanitiseDevice(deviceInfo))
+    } catch (error) {
+      console.error('ERROR_REGISTERING_HID_DEVICE', deviceInfo?.product, error?.message || error)
+    }
+  }
+
+  unregisterDevice (deviceInfo) {
+    const deviceId = this.getDeviceId(deviceInfo)
+    const record = this.deviceHandles.get(deviceId)
+    if (!record) return
+    try {
+      record.handle.close()
+    } catch (error) {
+      console.error('ERROR_CLOSING_HID_DEVICE', deviceInfo?.product, error?.message || error)
+    }
+    this.deviceHandles.delete(deviceId)
+    this.emit('deviceUnregistered', this.sanitiseDevice(deviceInfo))
+  }
+
+  handleError (deviceInfo, error) {
+    console.error('HID_DEVICE_ERROR', deviceInfo?.product, error?.message || error)
+    this.unregisterDevice(deviceInfo)
+  }
+
+  handleData (deviceInfo, data) {
+    const payload = this.createPayload(deviceInfo, data)
+
+    if (this.pendingCapture) {
+      const { resolve, timer } = this.pendingCapture
+      clearTimeout(timer)
+      this.pendingCapture = null
+      resolve(payload)
+      return
+    }
+
+    this.emit('input', payload)
+  }
+
+  captureNextInput ({ timeoutMs = 10000 } = {}) {
+    if (!this.available) throw new Error('HIDUnavailable')
+    if (this.pendingCapture) throw new Error('CaptureInProgress')
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingCapture = null
+        reject(new Error('HIDCaptureTimeout'))
+      }, timeoutMs)
+      this.pendingCapture = { resolve, reject, timer }
+    })
+  }
+
+  getDevices () {
+    if (!this.available) return []
+    return Array.from(this.deviceHandles.values()).map(record => this.sanitiseDevice(record.deviceInfo))
+  }
+
+  sanitiseDevice (device) {
+    if (!device) return null
+    const {
+      path,
+      product,
+      manufacturer,
+      vendorId,
+      productId,
+      usage,
+      usagePage,
+      interface: interfaceNumber,
+      serialNumber
+    } = device
+    return {
+      path,
+      product,
+      manufacturer,
+      vendorId,
+      productId,
+      usage,
+      usagePage,
+      interface: interfaceNumber,
+      serialNumber
+    }
+  }
+
+  createPayload (deviceInfo, data) {
+    const serialisedDevice = this.sanitiseDevice(deviceInfo)
+    const dataHex = data?.length ? Buffer.from(data).toString('hex') : null
+    const reportId = data && data.length ? data[0] : null
+    return {
+      device: serialisedDevice,
+      dataHex,
+      reportId,
+      timestamp: Date.now()
+    }
+  }
+
+  getDeviceId (device) {
+    if (!device) return null
+    return device.path || `${device.vendorId}:${device.productId}`
+  }
+}
+
+module.exports = InputListener

--- a/src/service/lib/input/mapping-store.js
+++ b/src/service/lib/input/mapping-store.js
@@ -1,0 +1,79 @@
+const fs = require('fs')
+
+const { INPUT_ACTIONS } = require('../../../shared/input-actions')
+const { INPUT_MAPPINGS_FILE, ensurePreferencesDir } = require('../preferences')
+
+class MappingStore {
+  constructor () {
+    this.cache = null
+  }
+
+  getDefaultMappings () {
+    const defaults = {}
+    INPUT_ACTIONS.forEach(action => { defaults[action.id] = null })
+    return defaults
+  }
+
+  load () {
+    if (this.cache) return this.cache
+    try {
+      if (fs.existsSync(INPUT_MAPPINGS_FILE)) {
+        const mappings = JSON.parse(fs.readFileSync(INPUT_MAPPINGS_FILE))
+        this.cache = { ...this.getDefaultMappings(), ...mappings }
+      } else {
+        this.cache = this.getDefaultMappings()
+      }
+    } catch (error) {
+      console.error('ERROR_LOADING_INPUT_MAPPINGS', error)
+      this.cache = this.getDefaultMappings()
+    }
+    return this.cache
+  }
+
+  save (mappings) {
+    try {
+      ensurePreferencesDir()
+      fs.writeFileSync(INPUT_MAPPINGS_FILE, JSON.stringify(mappings, null, 2))
+      this.cache = mappings
+    } catch (error) {
+      console.error('ERROR_SAVING_INPUT_MAPPINGS', error)
+    }
+  }
+
+  getMappings () {
+    return this.load()
+  }
+
+  setMapping (actionId, binding) {
+    const mappings = { ...this.load(), [actionId]: binding }
+    this.save(mappings)
+    return mappings[actionId]
+  }
+
+  clearMapping (actionId) {
+    const mappings = { ...this.load(), [actionId]: null }
+    this.save(mappings)
+    return mappings[actionId]
+  }
+
+  findActionForPayload ({ device, dataHex }) {
+    const mappings = this.load()
+    return Object.entries(mappings).find(([, binding]) => this.bindingMatches(binding, device, dataHex))?.[0]
+  }
+
+  bindingMatches (binding, device, dataHex) {
+    if (!binding) return false
+    if (!binding.device) return false
+
+    if (binding.device.path && device.path) {
+      if (binding.device.path !== device.path) return false
+    } else {
+      if (binding.device.vendorId !== device.vendorId) return false
+      if (binding.device.productId !== device.productId) return false
+    }
+
+    return binding.dataHex === dataHex
+  }
+}
+
+module.exports = MappingStore

--- a/src/shared/input-actions.js
+++ b/src/shared/input-actions.js
@@ -1,0 +1,26 @@
+const INPUT_ACTIONS = [
+  {
+    id: 'nativePanel.navigateUp',
+    group: 'nativePanel',
+    label: 'Navigate Up',
+    description: 'Moves the selection up in the native ICARUS terminal panel.'
+  },
+  {
+    id: 'nativePanel.navigateDown',
+    group: 'nativePanel',
+    label: 'Navigate Down',
+    description: 'Moves the selection down in the native ICARUS terminal panel.'
+  }
+]
+
+const INPUT_GROUPS = [
+  {
+    id: 'nativePanel',
+    label: 'ICARUS Native Panel'
+  }
+]
+
+module.exports = {
+  INPUT_ACTIONS,
+  INPUT_GROUPS
+}


### PR DESCRIPTION
## Summary
- add a Windows HID listener powered by node-hid with an input manager that broadcasts native panel navigation actions
- persist controller bindings in the existing preferences directory and expose websocket endpoints for querying, listening, and clearing mappings
- add an input mapping UI page with a launcher shortcut and hook native panel navigation to the new input actions

## Testing
- npm run lint:javascript *(fails: existing standardjs violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68dae56a2ccc832387c4577ec3faaa62