### PR TITLE
Refine GhostNet navigation styling

### DIFF
--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -23,8 +23,8 @@ const NAV_BUTTONS = [
     path: '/eng'
   },
   {
-    name: 'INARA',
-    abbr: 'INARA',
+    name: 'GhostNet',
+    abbr: 'GNet',
     path: '/inara'
   },
   {
@@ -155,20 +155,28 @@ export default function Header ({ connected, active }) {
       </div>
       <hr />
       <div id='primaryNavigation' className='button-group'>
-        {NAV_BUTTONS.filter(button => button).map((button, i) =>
-          <button
-            key={button.name}
-            data-primary-navigation={i+1}
-            tabIndex='1'
-            disabled={button.path === currentPath}
-            className={button.path === currentPath ? 'button--active' : ''}
-            onClick={() => router.push(button.path)}
-            style={{ fontSize: '1.5rem' }}
-          >
-            <span className='visible-small'>{button.abbr}</span>
-            <span className='hidden-small'>{button.name}</span>
-          </button>
-        )}
+        {NAV_BUTTONS.filter(button => button).map((button, i) => {
+          const isActive = button.path === currentPath
+          const isGhostNet = button.path === '/inara'
+          return (
+            <button
+              key={button.name}
+              data-primary-navigation={i + 1}
+              tabIndex='1'
+              disabled={isActive}
+              aria-current={isActive ? 'page' : undefined}
+              className={[
+                isActive ? 'button--active' : '',
+                isGhostNet ? 'ghostnet-nav-button' : ''
+              ].filter(Boolean).join(' ')}
+              onClick={() => router.push(button.path)}
+              style={{ fontSize: '1.5rem' }}
+            >
+              <span className='visible-small'>{button.abbr}</span>
+              <span className='hidden-small'>{button.name}</span>
+            </button>
+          )
+        })}
       </div>
       <hr className='bold' />
       <Settings visible={settingsVisible} toggleVisible={() => setSettingsVisible(!settingsVisible)} />

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -453,3 +453,78 @@ hr.bold {
   box-shadow: 0 .03rem .5rem var(--color-primary), 0 0rem .7rem -.03rem var(--color-primary), 0 0rem 1rem -.01rem var(--color-primary-dark) !important;
   opacity: 1;
 }
+
+body.ghostnet-theme #secondaryNavigation {
+  --ghostnet-nav-primary: rgb(216, 180, 254);
+  --ghostnet-nav-primary-dark: rgb(44, 18, 68);
+  background: linear-gradient(180deg, rgba(28, 11, 43, 0.96), rgba(81, 27, 128, 0.85));
+  border-right: 1px solid rgba(216, 180, 254, 0.25);
+  box-shadow: 1.5rem 0 3rem rgba(10, 5, 20, 0.65);
+}
+
+body.ghostnet-theme #secondaryNavigation .button--icon {
+  border-radius: 0.45rem;
+  border: 1px solid rgba(216, 180, 254, 0.32);
+  background: rgba(27, 11, 43, 0.6);
+  box-shadow: inset 0 0 1.5rem 0.4rem rgba(73, 27, 115, 0.35);
+  color: rgb(216, 180, 254);
+  text-shadow: 0 0 0.85rem rgba(216, 180, 254, 0.45);
+}
+
+body.ghostnet-theme #secondaryNavigation .button--icon.button--active {
+  background: rgba(216, 180, 254, 0.25);
+  color: rgb(44, 18, 68);
+  text-shadow: 0 0 1rem rgba(44, 18, 68, 0.65);
+  box-shadow: 0 0 1.35rem rgba(216, 180, 254, 0.6), inset 0 0 0.35rem rgba(216, 180, 254, 0.85);
+  border-right: 0;
+}
+
+body.ghostnet-theme #secondaryNavigation .button--icon:hover:not([disabled]):not(.button--active),
+body.ghostnet-theme #secondaryNavigation .button--icon:focus:not([disabled]):not(.button--active) {
+  background: rgba(216, 180, 254, 0.12);
+  box-shadow: 0 0 1.25rem rgba(216, 180, 254, 0.4), inset 0 0 0.35rem rgba(216, 180, 254, 0.6);
+  color: rgb(216, 180, 254);
+}
+
+body.ghostnet-theme #secondaryNavigation .button--icon.button--selected,
+body.ghostnet-theme #secondaryNavigation .button--icon.button--secondary {
+  background: rgba(216, 180, 254, 0.2);
+  color: rgb(44, 18, 68);
+  border-color: rgba(216, 180, 254, 0.55);
+  box-shadow: 0 0 1.35rem rgba(216, 180, 254, 0.5), inset 0 0 0.45rem rgba(216, 180, 254, 0.65);
+  border-right: 0;
+}
+
+#primaryNavigation .ghostnet-nav-button {
+  --ghostnet-nav-accent: rgb(216, 180, 254);
+  --ghostnet-nav-depth: rgba(73, 27, 115, 0.35);
+  background: linear-gradient(180deg, rgba(44, 18, 68, 0.95), rgba(81, 27, 128, 0.85));
+  border: 1px solid rgba(216, 180, 254, 0.3);
+  box-shadow: inset 0 0 1.5rem var(--ghostnet-nav-depth);
+  color: var(--ghostnet-nav-accent);
+  text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
+  filter: none;
+  transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+#primaryNavigation .ghostnet-nav-button .visible-small,
+#primaryNavigation .ghostnet-nav-button .hidden-small {
+  text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
+}
+
+#primaryNavigation .ghostnet-nav-button.button--active {
+  background: linear-gradient(180deg, rgba(57, 22, 88, 0.95), rgba(95, 35, 150, 0.85));
+  border-color: rgba(216, 180, 254, 0.45);
+  box-shadow: 0 0 1.45rem rgba(216, 180, 254, 0.7), inset 0 0 0.55rem rgba(216, 180, 254, 0.9);
+  color: var(--ghostnet-nav-accent);
+  text-shadow: 0 0 1.3rem rgba(216, 180, 254, 0.75);
+  filter: none;
+}
+
+#primaryNavigation .ghostnet-nav-button:hover:not([disabled]):not(.button--active),
+#primaryNavigation .ghostnet-nav-button:focus:not([disabled]):not(.button--active) {
+  background: linear-gradient(180deg, rgba(54, 21, 84, 0.95), rgba(88, 31, 139, 0.9));
+  box-shadow: 0 0 1.35rem rgba(216, 180, 254, 0.45), inset 0 0 0.45rem rgba(216, 180, 254, 0.65);
+  color: var(--ghostnet-nav-accent);
+  transform: translateY(-1px);
+}

--- a/src/client/pages/inara.js
+++ b/src/client/pages/inara.js
@@ -3096,6 +3096,15 @@ function PristineMiningPanel () {
 export default function InaraPage() {
   const [activeTab, setActiveTab] = useState('tradeRoutes')
   const { connected, ready, active: socketActive } = useSocket()
+  useEffect(() => {
+    if (typeof document === 'undefined' || !document.body) return undefined
+
+    document.body.classList.add('ghostnet-theme')
+
+    return () => {
+      document.body.classList.remove('ghostnet-theme')
+    }
+  }, [])
   const navigationItems = useMemo(() => ([
     { name: 'Trade Routes', icon: 'route', active: activeTab === 'tradeRoutes', onClick: () => setActiveTab('tradeRoutes') },
     { name: 'Commodity Trade', icon: 'cargo', active: activeTab === 'commodityTrade', onClick: () => setActiveTab('commodityTrade') },


### PR DESCRIPTION
## Summary
- tint the GhostNet entry in the primary navigation so it stays on-brand
- restyle the secondary navigation when the GhostNet view is active to match the purple palette
- keep the GhostNet button’s hover and active states in the purple palette while surfacing `aria-current` for accessibility

## Testing
- npm test -- --runInBand *(fails: `jest` is unavailable because npm install could not download dependencies in this environment)*
- npm run build:client *(fails: `next` is unavailable for the same reason)*
- npm run start *(fails: missing runtime dependencies such as `dotenv` after install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9f52ebec8323bcb0e151eda00548