### PR TITLE
Add sliding Ghostnet listings drawer for commodity trade panel

### DIFF
--- a/src/client/pages/api/ghostnet-commodity-values.js
+++ b/src/client/pages/api/ghostnet-commodity-values.js
@@ -815,6 +815,7 @@ export default async function handler (req, res) {
       count: commodity.count,
       market: marketEntry,
       ghostnet: bestGhostnetListing,
+      ghostnetListings: Array.isArray(resolvedEntry.listings) ? resolvedEntry.listings : [],
       localHistory: {
         best: historyBestEntry,
         entries: historyEntries

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -1620,10 +1620,11 @@ function CommodityTradePanel () {
 
   const handleRowActivate = useCallback(row => {
     if (!row) return
-    if (selectedCommodityKey === row.key && listingsDrawerOpen) {
-      setListingsDrawerOpen(false)
-      setSelectedCommodityKey('')
-      setMinListingPrice(0)
+
+    if (selectedCommodityKey === row.key) {
+      if (!listingsDrawerOpen) {
+        setListingsDrawerOpen(true)
+      }
       return
     }
 
@@ -1733,7 +1734,7 @@ function CommodityTradePanel () {
   const historyStatus = valuation?.metadata?.historyStatus || 'idle'
 
   return (
-    <div>
+    <div className={styles.commodityTrade}>
       <h2>Commodity Trade</h2>
       <div className={styles.metricGrid}>
         <div className={styles.metricItem}>

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -1759,61 +1759,64 @@ function CommodityTradePanel () {
         </div>
       </div>
 
-      {(ghostnetStatus === 'error' || ghostnetStatus === 'partial') && (
-        <div className={styles.notice}>
-          {ghostnetStatus === 'error'
-            ? 'Unable to retrieve GHOSTNET price data at this time.'
-            : 'Some commodities are missing GHOSTNET price data. Displayed values use local market prices where available.'}
-        </div>
-      )}
+      <div className={styles.commodityTradeContent}>
+        {(ghostnetStatus === 'error' || ghostnetStatus === 'partial') && (
+          <div className={styles.notice}>
+            {ghostnetStatus === 'error'
+              ? 'Unable to retrieve GHOSTNET price data at this time.'
+              : 'Some commodities are missing GHOSTNET price data. Displayed values use local market prices where available.'}
+          </div>
+        )}
 
-      {marketStatus === 'missing' && (
-        <div className={styles.notice}>
-          Local market prices are unavailable. Dock at a station and reopen this panel to import in-game price data.
-        </div>
-      )}
+        {marketStatus === 'missing' && (
+          <div className={styles.notice}>
+            Local market prices are unavailable. Dock at a station and reopen this panel to import in-game price data.
+          </div>
+        )}
 
-      {historyStatus === 'missing' && (
-        <div className={styles.notice}>
-          Unable to locate Elite Dangerous journal logs to build local market history. Confirm your log directory settings and reopen this panel.
-        </div>
-      )}
+        {historyStatus === 'missing' && (
+          <div className={styles.notice}>
+            Unable to locate Elite Dangerous journal logs to build local market history. Confirm your log directory settings and reopen this panel.
+          </div>
+        )}
 
-      {historyStatus === 'error' && (
-        <div className={styles.notice}>
-          Local market history could not be parsed. Try reopening the commodities market in-game to refresh the data.
-        </div>
-      )}
+        {historyStatus === 'error' && (
+          <div className={styles.notice}>
+            Local market history could not be parsed. Try reopening the commodities market in-game to refresh the data.
+          </div>
+        )}
 
-      {historyStatus === 'empty' && (
-        <div className={styles.noticeMuted}>
-          No nearby market history has been recorded yet. Visit commodity markets to capture additional local price data.
-        </div>
-      )}
+        {historyStatus === 'empty' && (
+          <div className={styles.noticeMuted}>
+            No nearby market history has been recorded yet. Visit commodity markets to capture additional local price data.
+          </div>
+        )}
 
-      {renderStatusBanner()}
+        {renderStatusBanner()}
 
-      {status === 'ready' && hasCargo && hasRows && (
-        <div className={styles.dataTableContainer}>
-          <table className={`${styles.dataTable} ${styles.dataTableFixed} ${styles.dataTableDense} table--animated fx-fade-in`}>
-            <colgroup>
-              <col style={{ width: '32%' }} />
-              <col style={{ width: '8%' }} />
-              <col style={{ width: '20%' }} />
-              <col style={{ width: '24%' }} />
-              <col style={{ width: '16%' }} />
-            </colgroup>
-            <thead>
-              <tr>
-                <th>Commodity</th>
-                <th className='text-right'>Qty</th>
-                <th>Local Data</th>
-                <th>GHOSTNET Max</th>
-                <th className='text-right'>Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row, index) => {
+        {status === 'ready' && hasCargo && hasRows && (
+          <div className={styles.commodityTradeTableRegion}>
+            <div className={`${styles.dataTableContainer} ${styles.commodityTradeTableContainer}`}>
+              <div className={styles.commodityTradeTableScroll}>
+                <table className={`${styles.dataTable} ${styles.dataTableFixed} ${styles.dataTableDense} table--animated fx-fade-in`}>
+                  <colgroup>
+                    <col style={{ width: '32%' }} />
+                    <col style={{ width: '8%' }} />
+                    <col style={{ width: '20%' }} />
+                    <col style={{ width: '24%' }} />
+                    <col style={{ width: '16%' }} />
+                  </colgroup>
+                  <thead>
+                    <tr>
+                      <th>Commodity</th>
+                      <th className='text-right'>Qty</th>
+                      <th>Local Data</th>
+                      <th>GHOSTNET Max</th>
+                      <th className='text-right'>Value</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((row, index) => {
               const {
                 item,
                 entry,
@@ -1940,11 +1943,18 @@ function CommodityTradePanel () {
                   </td>
                 </tr>
               )
-            })}
-            </tbody>
-          </table>
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className={styles.tableFootnote}>
+          In-game prices are sourced from your latest Market data when available. GHOSTNET prices are community submitted and may not reflect real-time market conditions.
         </div>
-      )}
+      </div>
 
       <div
         className={[styles.listingDrawerOverlay, listingsDrawerOpen ? styles.listingDrawerOverlayVisible : '']
@@ -2061,10 +2071,6 @@ function CommodityTradePanel () {
               )}
         </div>
       </aside>
-
-      <div className={styles.tableFootnote}>
-        In-game prices are sourced from your latest Market data when available. GHOSTNET prices are community submitted and may not reflect real-time market conditions.
-      </div>
     </div>
   )
 }
@@ -3424,16 +3430,16 @@ export default function GhostnetPage() {
               </aside>
             </section>
             <div className={styles.tabPanels}>
-              <div style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
+              <div className={styles.tabPanel} style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
                 <TradeRoutesPanel />
               </div>
-              <div style={{ display: activeTab === 'commodityTrade' ? 'block' : 'none' }}>
+              <div className={styles.tabPanel} style={{ display: activeTab === 'commodityTrade' ? 'block' : 'none' }}>
                 <CommodityTradePanel />
               </div>
-              <div style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
+              <div className={styles.tabPanel} style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
                 <MissionsPanel />
               </div>
-              <div style={{ display: activeTab === 'pristineMining' ? 'block' : 'none' }}>
+              <div className={styles.tabPanel} style={{ display: activeTab === 'pristineMining' ? 'block' : 'none' }}>
                 <PristineMiningPanel />
               </div>
             </div>

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -1642,9 +1642,16 @@ function CommodityTradePanel () {
 
   const handleCloseListingsDrawer = useCallback(() => {
     setListingsDrawerOpen(false)
+  }, [])
+
+  useEffect(() => {
+    if (!selectedCommodityKey) return
+    if (selectedCommodityRow) return
+
     setSelectedCommodityKey('')
     setMinListingPrice(0)
-  }, [])
+    setListingsDrawerOpen(false)
+  }, [selectedCommodityKey, selectedCommodityRow])
 
   useEffect(() => {
     if (!listingsDrawerOpen) return
@@ -3430,16 +3437,32 @@ export default function GhostnetPage() {
               </aside>
             </section>
             <div className={styles.tabPanels}>
-              <div className={styles.tabPanel} style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
+              <div
+                className={styles.tabPanel}
+                hidden={activeTab !== 'tradeRoutes'}
+                aria-hidden={activeTab !== 'tradeRoutes'}
+              >
                 <TradeRoutesPanel />
               </div>
-              <div className={styles.tabPanel} style={{ display: activeTab === 'commodityTrade' ? 'block' : 'none' }}>
+              <div
+                className={styles.tabPanel}
+                hidden={activeTab !== 'commodityTrade'}
+                aria-hidden={activeTab !== 'commodityTrade'}
+              >
                 <CommodityTradePanel />
               </div>
-              <div className={styles.tabPanel} style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
+              <div
+                className={styles.tabPanel}
+                hidden={activeTab !== 'missions'}
+                aria-hidden={activeTab !== 'missions'}
+              >
                 <MissionsPanel />
               </div>
-              <div className={styles.tabPanel} style={{ display: activeTab === 'pristineMining' ? 'block' : 'none' }}>
+              <div
+                className={styles.tabPanel}
+                hidden={activeTab !== 'pristineMining'}
+                aria-hidden={activeTab !== 'pristineMining'}
+              >
                 <PristineMiningPanel />
               </div>
             </div>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -352,10 +352,26 @@
 
 .tableRowInteractive {
   cursor: pointer;
+  transition: background 180ms ease, box-shadow 180ms ease;
 }
 
 .tableRowInteractive:hover {
-  background: rgba(127, 233, 255, 0.2);
+  background: rgba(93, 46, 255, 0.16);
+}
+
+.tableRowInteractive:focus-visible {
+  outline: 2px solid #29f3c3;
+  outline-offset: -2px;
+  background: rgba(93, 46, 255, 0.18);
+}
+
+.tableRowSelected {
+  background: rgba(93, 46, 255, 0.22) !important;
+  box-shadow: inset 0 0 0 1px rgba(140, 92, 255, 0.4);
+}
+
+.tableRowSelected:hover {
+  background: rgba(93, 46, 255, 0.28) !important;
 }
 
 .tableRowExpanded {
@@ -539,6 +555,7 @@
   color: rgba(140, 160, 188, 0.75);
   font-size: 0.85rem;
   line-height: 1.6;
+  text-align: center;
 }
 
 .metricGrid {
@@ -984,6 +1001,227 @@
     box-shadow: 0 1.75rem 3.5rem rgba(3, 7, 11, 0.8);
     filter: none;
     transform: none;
+  }
+}
+
+.listingDrawerOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 8, 13, 0.58);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 240ms ease;
+  z-index: 60;
+}
+
+.listingDrawerOverlayVisible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.listingDrawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(420px, 92vw);
+  background: linear-gradient(185deg, rgba(32, 20, 58, 0.95), rgba(9, 10, 25, 0.96));
+  border-left: 1px solid rgba(140, 92, 255, 0.35);
+  box-shadow: -1rem 0 3rem rgba(5, 8, 13, 0.65);
+  transform: translateX(105%);
+  transition: transform 280ms cubic-bezier(0.22, 0.61, 0.36, 1), box-shadow 280ms ease;
+  z-index: 70;
+  display: flex;
+  flex-direction: column;
+  backdrop-filter: blur(14px);
+}
+
+.listingDrawerOpen {
+  transform: translateX(0);
+}
+
+.listingDrawerHeader {
+  padding: 1.5rem 1.75rem 1.25rem;
+  border-bottom: 1px solid rgba(140, 92, 255, 0.28);
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.listingDrawerKicker {
+  font-size: 0.72rem;
+  letter-spacing: 0.38em;
+  text-transform: uppercase;
+  color: var(--ghostnet-accent);
+  margin-bottom: 0.5rem;
+}
+
+.listingDrawerTitle {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ghostnet-ink);
+}
+
+.listingDrawerSubtitle {
+  margin-top: 0.35rem;
+  color: rgba(245, 241, 255, 0.72);
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+.listingDrawerMeta {
+  margin-top: 0.6rem;
+  font-size: 0.8rem;
+  color: var(--ghostnet-subdued);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.listingDrawerClose {
+  background: rgba(93, 46, 255, 0.26);
+  color: var(--ghostnet-ink);
+  border: 1px solid rgba(140, 92, 255, 0.45);
+  border-radius: 999px;
+  width: 2.25rem;
+  height: 2.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 180ms ease, box-shadow 180ms ease;
+}
+
+.listingDrawerClose:hover {
+  background: rgba(93, 46, 255, 0.38);
+  box-shadow: 0 0 1rem rgba(93, 46, 255, 0.45);
+}
+
+.listingDrawerClose:focus-visible {
+  outline: 2px solid #29f3c3;
+  outline-offset: 2px;
+}
+
+.listingDrawerFilters {
+  padding: 1rem 1.75rem 1.25rem;
+  border-bottom: 1px solid rgba(140, 92, 255, 0.24);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.listingDrawerFilterLabel {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  color: var(--ghostnet-subdued);
+}
+
+.listingDrawerFilterControl {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ghostnet-ink);
+}
+
+.listingDrawerFilterControl input[type='range'] {
+  flex: 1;
+  accent-color: #5d2eff;
+  cursor: pointer;
+}
+
+.listingDrawerFilterControl input[type='range']:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.listingDrawerFilterValue {
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+  font-size: 0.95rem;
+  color: var(--ghostnet-ink);
+}
+
+.listingDrawerBody {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.25rem 1.75rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.listingCard {
+  background: rgba(10, 15, 27, 0.88);
+  border: 1px solid rgba(140, 92, 255, 0.28);
+  border-radius: 1rem;
+  padding: 1.1rem 1.25rem;
+  box-shadow: 0 1.5rem 3rem rgba(5, 8, 13, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.listingCardHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.listingCardTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+}
+
+.listingCardSubtitle {
+  font-size: 0.85rem;
+  color: var(--ghostnet-muted);
+}
+
+.listingCardPrice {
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+  font-size: 1.05rem;
+  color: var(--ghostnet-accent);
+  white-space: nowrap;
+}
+
+.listingCardMetaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.82rem;
+  color: rgba(245, 241, 255, 0.74);
+}
+
+.listingCardFooter {
+  font-size: 0.78rem;
+  color: var(--ghostnet-subdued);
+}
+
+.listingDrawerEmpty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: rgba(245, 241, 255, 0.76);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  .listingDrawerHeader {
+    padding: 1.25rem 1.4rem 1.1rem;
+  }
+
+  .listingDrawerFilters {
+    padding: 0.85rem 1.4rem 1.1rem;
+  }
+
+  .listingDrawerBody {
+    padding: 1.1rem 1.4rem 1.75rem;
   }
 }
 

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -565,6 +565,10 @@
   margin-bottom: 1.25rem;
 }
 
+.commodityTrade {
+  position: relative;
+}
+
 .metricItem {
   display: flex;
   flex-direction: column;
@@ -1005,7 +1009,7 @@
 }
 
 .listingDrawerOverlay {
-  position: fixed;
+  position: absolute;
   inset: 0;
   background: rgba(5, 8, 13, 0.58);
   opacity: 0;
@@ -1020,11 +1024,12 @@
 }
 
 .listingDrawer {
-  position: fixed;
+  position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
-  width: min(420px, 92vw);
+  width: min(420px, 100%);
+  max-width: 100%;
   background: linear-gradient(185deg, rgba(32, 20, 58, 0.95), rgba(9, 10, 25, 0.96));
   border-left: 1px solid rgba(140, 92, 255, 0.35);
   box-shadow: -1rem 0 3rem rgba(5, 8, 13, 0.65);

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1,6 +1,8 @@
 .ghostnet {
   position: relative;
-  min-height: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   padding: 2.5rem 3rem 3.5rem;
   background: radial-gradient(circle at 20% 15%, rgba(216, 180, 254, 0.14), transparent 55%),
     radial-gradient(circle at 85% 10%, rgba(167, 139, 250, 0.22), transparent 60%),
@@ -87,6 +89,8 @@
   z-index: 1;
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   gap: 2.75rem;
 }
 
@@ -189,6 +193,17 @@
 .tabPanels {
   position: relative;
   z-index: 1;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.tabPanel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .sectionFrame {
@@ -551,7 +566,8 @@
 }
 
 .tableFootnote {
-  margin-top: 1.5rem;
+  margin-top: auto;
+  padding-top: 1.5rem;
   color: rgba(140, 160, 188, 0.75);
   font-size: 0.85rem;
   line-height: 1.6;
@@ -567,6 +583,38 @@
 
 .commodityTrade {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.commodityTradeContent {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 0;
+}
+
+.commodityTradeTableRegion {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.commodityTradeTableContainer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.commodityTradeTableScroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
 }
 
 .metricItem {

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1,6 +1,7 @@
 .ghostnet {
   position: relative;
   min-height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
   padding: 2.5rem 3rem 3.5rem;
@@ -587,6 +588,7 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  height: 100%;
 }
 
 .commodityTradeContent {


### PR DESCRIPTION
## Summary
- expose complete GhostNET commodity listings from the API so the client can display station results
- add an interactive drawer on the Commodity Trade tab with distance sorting and a minimum-price slider filter
- refresh GhostNET styling for selectable rows and the new drawer layout

## Testing
- npm test -- --runInBand
- npm run build:client
- npm run start


------
https://chatgpt.com/codex/tasks/task_e_68ddee185d208323a4979c7adace49b7