### PR TITLE
Add GhostNet exit transition overlay

### DIFF
--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -6,6 +6,7 @@ import { eliteDateTime } from 'lib/format'
 import { Settings } from 'components/settings'
 import notification from 'lib/notification'
 import { initiateGhostnetAssimilation, isGhostnetAssimilationActive } from 'lib/ghostnet-assimilation'
+import { initiateGhostnetExitTransition, isGhostnetExitTransitionActive } from 'lib/ghostnet-exit-transition'
 
 const NAV_BUTTONS = [
   {
@@ -117,6 +118,11 @@ export default function Header ({ connected, active }) {
       initiateGhostnetAssimilation(() => router.push(path))
       return
     }
+    if (currentPath === '/ghostnet') {
+      if (isGhostnetExitTransitionActive()) return
+      initiateGhostnetExitTransition(() => router.push(path))
+      return
+    }
     router.push(path)
   }
 
@@ -168,12 +174,13 @@ export default function Header ({ connected, active }) {
         {NAV_BUTTONS.filter(button => button).map((button, i) => {
           const isActive = button.path === currentPath
           const isGhostNet = button.path === '/ghostnet'
+          const exitActive = isGhostnetExitTransitionActive()
           return (
             <button
               key={button.name}
               data-primary-navigation={i + 1}
               tabIndex='1'
-              disabled={isActive || (isGhostNet && isGhostnetAssimilationActive())}
+              disabled={isActive || (isGhostNet && isGhostnetAssimilationActive()) || exitActive}
               aria-current={isActive ? 'page' : undefined}
               className={[
                 isActive ? 'button--active' : '',

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -676,38 +676,22 @@ body.ghostnet-exit-transition-active {
   inset: 0;
   z-index: 12000;
   display: flex;
-  align-items: flex-end;
-  justify-content: flex-end;
-  padding: 3.5rem;
-  background: radial-gradient(circle at 85% 10%, rgba(93, 46, 255, 0.25), transparent 48%),
-    radial-gradient(circle at 12% 85%, rgba(255, 95, 193, 0.22), rgba(13, 11, 26, 0.85));
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.75rem, 5vw, 4rem);
   pointer-events: auto;
 }
 
-.ghostnet-exit-overlay::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: rgba(13, 11, 26, 0.65);
-  z-index: 0;
-  pointer-events: none;
-}
-
-.ghostnet-exit-overlay > * {
-  position: relative;
-  z-index: 1;
-}
-
 .ghostnet-exit-dialog {
-  width: min(420px, 90vw);
+  width: min(620px, 92vw);
   border: 1px solid rgba(140, 92, 255, 0.4);
   background: linear-gradient(145deg, rgba(16, 12, 34, 0.96), rgba(24, 18, 46, 0.92));
   box-shadow: 0 0 36px rgba(93, 46, 255, 0.25), 0 0 12px rgba(13, 11, 26, 0.65);
   border-radius: 1.2rem;
-  padding: 1.8rem;
+  padding: clamp(1.8rem, 3vw, 2.35rem);
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: clamp(1.2rem, 2vw, 1.65rem);
   pointer-events: auto;
   overflow: hidden;
 }
@@ -794,8 +778,8 @@ body.ghostnet-exit-transition-active {
 .ghostnet-exit-dialog__log {
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
-  padding: 1rem;
+  gap: clamp(0.7rem, 1.5vw, 1rem);
+  padding: clamp(1.1rem, 2vw, 1.4rem) clamp(1.2rem, 2.5vw, 1.65rem);
   background: rgba(19, 15, 34, 0.78);
   border-radius: 0.9rem;
   border: 1px solid rgba(93, 46, 255, 0.38);
@@ -807,16 +791,16 @@ body.ghostnet-exit-transition-active {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  font-size: 0.95rem;
-  color: rgba(245, 241, 255, 0.82);
-  letter-spacing: 0.02em;
+  gap: clamp(0.9rem, 2vw, 1.25rem);
+  font-size: clamp(1.02rem, 2vw, 1.16rem);
+  color: rgba(245, 241, 255, 0.86);
+  letter-spacing: 0.03em;
 }
 
 .ghostnet-exit-line__text {
   position: relative;
   flex: 1;
-  min-height: 1.25rem;
+  min-height: 1.45rem;
 }
 
 .ghostnet-exit-line__text::before {
@@ -842,10 +826,10 @@ body.ghostnet-exit-transition-active {
 }
 
 .ghostnet-exit-line__status {
-  font-size: 0.85rem;
-  letter-spacing: 0.2rem;
+  font-size: clamp(0.88rem, 1.6vw, 0.98rem);
+  letter-spacing: 0.24rem;
   text-transform: uppercase;
-  color: rgba(245, 241, 255, 0.58);
+  color: rgba(245, 241, 255, 0.62);
   opacity: 0;
   transform: translateY(4px);
   transition: opacity 160ms ease, transform 160ms ease;
@@ -866,10 +850,10 @@ body.ghostnet-exit-transition-active {
 
 .ghostnet-exit-dialog__footnote {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: clamp(0.82rem, 1.8vw, 0.9rem);
   line-height: 1.4;
-  color: rgba(245, 241, 255, 0.62);
-  letter-spacing: 0.04em;
+  color: rgba(245, 241, 255, 0.68);
+  letter-spacing: 0.05em;
 }
 
 .ghostnet-exit-overlay--closing {
@@ -877,16 +861,49 @@ body.ghostnet-exit-transition-active {
   transition: opacity 220ms ease;
 }
 
+.ghostnet-exit-dissolve {
+  pointer-events: none;
+  transition: opacity 420ms cubic-bezier(0.55, 0, 0.45, 1), filter 420ms cubic-bezier(0.55, 0, 0.45, 1), transform 420ms cubic-bezier(0.55, 0, 0.45, 1);
+}
+
+.ghostnet-exit-dissolve--active {
+  opacity: 0;
+  filter: saturate(0.55) blur(1.8px);
+  transform: scale(0.985);
+}
+
+.ghostnet-exit-dissolve--active button,
+.ghostnet-exit-dissolve--active .button,
+.ghostnet-exit-dissolve--active [role='button'] {
+  animation: ghostnet-exit-button-dissolve 340ms cubic-bezier(0.6, 0.04, 0.98, 0.335) forwards;
+}
+
+@keyframes ghostnet-exit-button-dissolve {
+  0% {
+    opacity: 1;
+    transform: translateY(0);
+    filter: none;
+  }
+  60% {
+    opacity: 0.35;
+    transform: translateY(-4px);
+    filter: saturate(0.8);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-8px);
+    filter: blur(2px) saturate(0.4);
+  }
+}
+
 @media (max-width: 600px) {
   .ghostnet-exit-overlay {
     padding: 1.5rem;
-    align-items: center;
-    justify-content: center;
   }
 
   .ghostnet-exit-dialog {
-    width: min(90vw, 360px);
-    padding: 1.4rem;
+    width: min(94vw, 480px);
+    padding: 1.6rem;
   }
 
   .ghostnet-exit-dialog__badge {

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -664,3 +664,241 @@ body.ghostnet-assimilation-mode::after {
     filter: blur(3px) hue-rotate(12deg);
   }
 }
+
+/* GhostNet exit transition */
+
+body.ghostnet-exit-transition-active {
+  cursor: wait;
+}
+
+.ghostnet-exit-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 12000;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 3.5rem;
+  background: radial-gradient(circle at 85% 10%, rgba(93, 46, 255, 0.25), transparent 48%),
+    radial-gradient(circle at 12% 85%, rgba(255, 95, 193, 0.22), rgba(13, 11, 26, 0.85));
+  pointer-events: auto;
+}
+
+.ghostnet-exit-overlay::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(13, 11, 26, 0.65);
+  z-index: 0;
+  pointer-events: none;
+}
+
+.ghostnet-exit-overlay > * {
+  position: relative;
+  z-index: 1;
+}
+
+.ghostnet-exit-dialog {
+  width: min(420px, 90vw);
+  border: 1px solid rgba(140, 92, 255, 0.4);
+  background: linear-gradient(145deg, rgba(16, 12, 34, 0.96), rgba(24, 18, 46, 0.92));
+  box-shadow: 0 0 36px rgba(93, 46, 255, 0.25), 0 0 12px rgba(13, 11, 26, 0.65);
+  border-radius: 1.2rem;
+  padding: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  pointer-events: auto;
+  overflow: hidden;
+}
+
+.ghostnet-exit-dialog::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(255, 95, 193, 0.16);
+  border-radius: 1.2rem;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.ghostnet-exit-dialog__header {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.ghostnet-exit-dialog__badge {
+  width: 3.4rem;
+  height: 3.4rem;
+  border-radius: 1.2rem;
+  background: radial-gradient(circle at 50% 35%, rgba(255, 95, 193, 0.55), rgba(255, 95, 193, 0.12) 58%, transparent 100%);
+  border: 1px solid rgba(255, 95, 193, 0.45);
+  display: grid;
+  place-items: center;
+  box-shadow: 0 0 18px rgba(255, 95, 193, 0.35);
+}
+
+.ghostnet-exit-dialog__badge-shape {
+  position: relative;
+  width: 0;
+  height: 0;
+  border-left: 1.15rem solid transparent;
+  border-right: 1.15rem solid transparent;
+  border-bottom: 2rem solid #ff5fc1;
+  filter: drop-shadow(0 0 10px rgba(255, 95, 193, 0.65));
+}
+
+.ghostnet-exit-dialog__badge-bar {
+  position: absolute;
+  top: 0.45rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0.3rem;
+  height: 0.95rem;
+  border-radius: 0.3rem;
+  background: #0d0b1a;
+}
+
+.ghostnet-exit-dialog__badge-dot {
+  position: absolute;
+  bottom: -1.6rem;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: #0d0b1a;
+}
+
+.ghostnet-exit-dialog__text {
+  flex: 1;
+}
+
+.ghostnet-exit-dialog__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.12rem;
+  text-transform: uppercase;
+  color: #f5f1ff;
+}
+
+.ghostnet-exit-dialog__subtitle {
+  margin: 0.3rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.35;
+  color: rgba(245, 241, 255, 0.76);
+}
+
+.ghostnet-exit-dialog__log {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1rem;
+  background: rgba(19, 15, 34, 0.78);
+  border-radius: 0.9rem;
+  border: 1px solid rgba(93, 46, 255, 0.38);
+  box-shadow: inset 0 0 12px rgba(93, 46, 255, 0.25);
+  font-family: 'IBM Plex Mono', 'Menlo', 'Consolas', monospace;
+}
+
+.ghostnet-exit-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+  color: rgba(245, 241, 255, 0.82);
+  letter-spacing: 0.02em;
+}
+
+.ghostnet-exit-line__text {
+  position: relative;
+  flex: 1;
+  min-height: 1.25rem;
+}
+
+.ghostnet-exit-line__text::before {
+  content: '> ';
+  color: rgba(255, 95, 193, 0.58);
+}
+
+.ghostnet-exit-line--active .ghostnet-exit-line__text::after {
+  content: '▌';
+  position: absolute;
+  right: -0.55rem;
+  animation: ghostnet-exit-caret 0.5s steps(2, end) infinite;
+  color: rgba(255, 95, 193, 0.9);
+}
+
+@keyframes ghostnet-exit-caret {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.ghostnet-exit-line__status {
+  font-size: 0.85rem;
+  letter-spacing: 0.2rem;
+  text-transform: uppercase;
+  color: rgba(245, 241, 255, 0.58);
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.ghostnet-exit-line[data-tone='warning'] .ghostnet-exit-line__status {
+  color: #ff5fc1;
+}
+
+.ghostnet-exit-line[data-tone='success'] .ghostnet-exit-line__status {
+  color: #29f3c3;
+}
+
+.ghostnet-exit-line--status .ghostnet-exit-line__status {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.ghostnet-exit-dialog__footnote {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: rgba(245, 241, 255, 0.62);
+  letter-spacing: 0.04em;
+}
+
+.ghostnet-exit-overlay--closing {
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+@media (max-width: 600px) {
+  .ghostnet-exit-overlay {
+    padding: 1.5rem;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .ghostnet-exit-dialog {
+    width: min(90vw, 360px);
+    padding: 1.4rem;
+  }
+
+  .ghostnet-exit-dialog__badge {
+    width: 3rem;
+    height: 3rem;
+  }
+
+  .ghostnet-exit-dialog__title {
+    font-size: 1rem;
+  }
+
+  .ghostnet-exit-line {
+    font-size: 0.88rem;
+  }
+}

--- a/src/client/lib/ghostnet-exit-transition.js
+++ b/src/client/lib/ghostnet-exit-transition.js
@@ -1,0 +1,311 @@
+const TERMINAL_LINES = [
+  {
+    text: 'Dumping volatile memory sectors',
+    status: 'FLUSHED',
+    tone: 'warning'
+  },
+  {
+    text: "Sanitizing ship's logs",
+    status: 'SCRUBBED',
+    tone: 'warning'
+  },
+  {
+    text: 'Kernel trace sweep',
+    status: 'CLEAR',
+    tone: 'info'
+  },
+  {
+    text: 'ATLAS protocol handshake',
+    status: 'CONFIRMED',
+    tone: 'success'
+  },
+  {
+    text: 'Terminating GhostNet process tree',
+    status: 'PURGED',
+    tone: 'warning'
+  }
+]
+
+const TYPE_INTERVAL = 14
+const INITIAL_LINE_DELAY = 120
+const BETWEEN_LINE_DELAY = 80
+const STATUS_REVEAL_DELAY = 70
+const FINAL_HOLD_DURATION = 260
+const NAVIGATION_TRIGGER_DELAY = 1080
+
+let exitInProgress = false
+let overlayElement = null
+let hostElement = null
+let navigationInvoked = false
+
+const activeTimers = new Set()
+
+function schedule (fn, delay) {
+  const id = window.setTimeout(() => {
+    activeTimers.delete(id)
+    fn()
+  }, delay)
+  activeTimers.add(id)
+  return id
+}
+
+function clearScheduledTimers () {
+  activeTimers.forEach((id) => window.clearTimeout(id))
+  activeTimers.clear()
+}
+
+function wait (duration) {
+  return new Promise((resolve) => {
+    schedule(resolve, duration)
+  })
+}
+
+function buildOverlay () {
+  const overlay = document.createElement('div')
+  overlay.className = 'ghostnet-exit-overlay'
+  overlay.setAttribute('role', 'presentation')
+
+  const dialog = document.createElement('div')
+  dialog.className = 'ghostnet-exit-dialog'
+  dialog.setAttribute('role', 'alertdialog')
+  dialog.setAttribute('aria-live', 'assertive')
+  dialog.setAttribute('aria-label', 'GhostNet disengaging')
+
+  const header = document.createElement('div')
+  header.className = 'ghostnet-exit-dialog__header'
+
+  const badge = document.createElement('div')
+  badge.className = 'ghostnet-exit-dialog__badge'
+  badge.setAttribute('aria-hidden', 'true')
+
+  const badgeShape = document.createElement('span')
+  badgeShape.className = 'ghostnet-exit-dialog__badge-shape'
+
+  const badgeBar = document.createElement('span')
+  badgeBar.className = 'ghostnet-exit-dialog__badge-bar'
+
+  const badgeDot = document.createElement('span')
+  badgeDot.className = 'ghostnet-exit-dialog__badge-dot'
+
+  badgeShape.appendChild(badgeBar)
+  badgeShape.appendChild(badgeDot)
+  badge.appendChild(badgeShape)
+
+  const headerText = document.createElement('div')
+  headerText.className = 'ghostnet-exit-dialog__text'
+
+  const title = document.createElement('p')
+  title.className = 'ghostnet-exit-dialog__title'
+  title.textContent = 'ATLAS PROTOCOL // EXIT'
+
+  const subtitle = document.createElement('p')
+  subtitle.className = 'ghostnet-exit-dialog__subtitle'
+  subtitle.textContent = 'Hard disconnect requested — securing GhostNet state.'
+
+  headerText.appendChild(title)
+  headerText.appendChild(subtitle)
+
+  header.appendChild(badge)
+  header.appendChild(headerText)
+
+  const log = document.createElement('div')
+  log.className = 'ghostnet-exit-dialog__log'
+  log.setAttribute('role', 'log')
+  log.setAttribute('aria-live', 'assertive')
+
+  const footnote = document.createElement('p')
+  footnote.className = 'ghostnet-exit-dialog__footnote'
+  footnote.textContent = 'Residual spectral links will be locked by ATLAS if reconnection is attempted.'
+
+  dialog.appendChild(header)
+  dialog.appendChild(log)
+  dialog.appendChild(footnote)
+  overlay.appendChild(dialog)
+
+  return { overlay, log }
+}
+
+function buildTerminalRows (logElement) {
+  return TERMINAL_LINES.map((line) => {
+    const row = document.createElement('div')
+    row.className = 'ghostnet-exit-line'
+    if (line.tone) {
+      row.dataset.tone = line.tone
+    }
+
+    const text = document.createElement('span')
+    text.className = 'ghostnet-exit-line__text'
+    text.textContent = ''
+
+    row.appendChild(text)
+
+    let statusElement = null
+    if (line.status) {
+      statusElement = document.createElement('span')
+      statusElement.className = 'ghostnet-exit-line__status'
+      statusElement.textContent = line.status
+      statusElement.setAttribute('aria-hidden', 'true')
+      row.appendChild(statusElement)
+    }
+
+    logElement.appendChild(row)
+
+    return { line, element: row, textElement: text, statusElement }
+  })
+}
+
+function typeLine ({ line, element, textElement, statusElement }) {
+  return new Promise((resolve) => {
+    let index = 0
+
+    element.classList.add('ghostnet-exit-line--active')
+    textElement.textContent = ''
+
+    const revealStatus = () => {
+      if (statusElement) {
+        statusElement.setAttribute('aria-hidden', 'false')
+        element.classList.add('ghostnet-exit-line--status')
+      }
+      resolve()
+    }
+
+    const step = () => {
+      textElement.textContent = line.text.slice(0, index + 1)
+      index += 1
+      if (index < line.text.length) {
+        schedule(step, TYPE_INTERVAL)
+      } else {
+        element.classList.remove('ghostnet-exit-line--active')
+        element.classList.add('ghostnet-exit-line--complete')
+        schedule(revealStatus, STATUS_REVEAL_DELAY)
+      }
+    }
+
+    step()
+  })
+}
+
+async function playTerminalSequence (rows) {
+  await wait(INITIAL_LINE_DELAY)
+  for (let i = 0; i < rows.length; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await typeLine(rows[i])
+    if (i < rows.length - 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await wait(BETWEEN_LINE_DELAY)
+    }
+  }
+  await wait(FINAL_HOLD_DURATION)
+}
+
+function applyDissolveEffect () {
+  const host = document.querySelector('.layout__main')
+  if (!host) return null
+
+  host.dataset.ghostnetExitOpacity = host.style.opacity || ''
+  host.dataset.ghostnetExitTransform = host.style.transform || ''
+  host.dataset.ghostnetExitFilter = host.style.filter || ''
+  host.dataset.ghostnetExitTransition = host.style.transition || ''
+
+  host.style.transition = 'opacity 320ms cubic-bezier(0.55, 0, 0.45, 1), transform 320ms cubic-bezier(0.55, 0, 0.45, 1), filter 320ms cubic-bezier(0.55, 0, 0.45, 1)'
+  schedule(() => {
+    host.style.opacity = '0'
+    host.style.transform = 'scale(0.985)'
+    host.style.filter = 'saturate(0.65) blur(1.6px)'
+  }, 16)
+
+  return host
+}
+
+function restoreHost () {
+  if (!hostElement) return
+
+  if (hostElement.dataset.ghostnetExitOpacity !== undefined) {
+    hostElement.style.opacity = hostElement.dataset.ghostnetExitOpacity
+  }
+  if (hostElement.dataset.ghostnetExitTransform !== undefined) {
+    hostElement.style.transform = hostElement.dataset.ghostnetExitTransform
+  }
+  if (hostElement.dataset.ghostnetExitFilter !== undefined) {
+    hostElement.style.filter = hostElement.dataset.ghostnetExitFilter
+  }
+  if (hostElement.dataset.ghostnetExitTransition !== undefined) {
+    hostElement.style.transition = hostElement.dataset.ghostnetExitTransition
+  }
+
+  delete hostElement.dataset.ghostnetExitOpacity
+  delete hostElement.dataset.ghostnetExitTransform
+  delete hostElement.dataset.ghostnetExitFilter
+  delete hostElement.dataset.ghostnetExitTransition
+
+  hostElement = null
+}
+
+function cleanup () {
+  const targetOverlay = overlayElement
+  overlayElement = null
+
+  clearScheduledTimers()
+
+  if (targetOverlay) {
+    targetOverlay.classList.add('ghostnet-exit-overlay--closing')
+    window.setTimeout(() => {
+      if (targetOverlay.parentElement) {
+        targetOverlay.parentElement.removeChild(targetOverlay)
+      }
+    }, 260)
+  }
+
+  restoreHost()
+  document.body.classList.remove('ghostnet-exit-transition-active')
+  exitInProgress = false
+  navigationInvoked = false
+}
+
+export function initiateGhostnetExitTransition (callback) {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    if (typeof callback === 'function') callback()
+    return
+  }
+
+  if (exitInProgress) return
+
+  exitInProgress = true
+  navigationInvoked = false
+
+  document.body.classList.add('ghostnet-exit-transition-active')
+
+  const { overlay, log } = buildOverlay()
+  overlayElement = overlay
+  const rows = buildTerminalRows(log)
+
+  hostElement = applyDissolveEffect()
+
+  document.body.appendChild(overlay)
+
+  const ensureNavigation = () => {
+    if (navigationInvoked) return
+    navigationInvoked = true
+    if (typeof callback === 'function') {
+      callback()
+    }
+  }
+
+  schedule(ensureNavigation, NAVIGATION_TRIGGER_DELAY)
+
+  playTerminalSequence(rows)
+    .catch(() => {})
+    .finally(() => {
+      schedule(() => {
+        if (!navigationInvoked) {
+          ensureNavigation()
+        }
+        cleanup()
+      }, 280)
+    })
+}
+
+export function isGhostnetExitTransitionActive () {
+  return exitInProgress
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated GhostNet exit transition that animates terminal-style shutdown copy before routing away
- hook the navigation header into the new transition so leaving GhostNet plays the effect and disables buttons during the sequence
- layer in styles for the warning overlay, hazard badge, and status typing animation to match the GhostNet theme

## Testing
- npm test -- --runInBand *(fails: jest not found because dependencies could not be installed in the container)*
- npm run build:client *(fails: next not found because dependencies could not be installed in the container)*
- npm run start *(fails: module dotenv missing because dependencies could not be installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf0be4b508323b4b30c1192328be4