### PR TITLE
Add configurable GhostNet assimilation transition duration

### DIFF
--- a/src/client/lib/ghostnet-assimilation.js
+++ b/src/client/lib/ghostnet-assimilation.js
@@ -1,3 +1,8 @@
+import {
+  getAssimilationDurationSeconds,
+  ASSIMILATION_DURATION_DEFAULT
+} from 'lib/ghostnet-settings'
+
 let assimilationInProgress = false
 let assimilationStartTime = 0
 
@@ -5,7 +10,8 @@ const ARRIVAL_FLAG_KEY = 'ghostnet.assimilationArrival'
 const JITTER_TIMER_FIELD = '__ghostnetAssimilationJitterTimer__'
 
 const EXCLUDED_TAGS = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT', 'TEMPLATE'])
-const EFFECT_DURATION = 4000
+const DEFAULT_EFFECT_DURATION = ASSIMILATION_DURATION_DEFAULT * 1000
+let effectDurationMs = DEFAULT_EFFECT_DURATION
 
 function clearJitterTimer (element) {
   if (!element) return
@@ -20,7 +26,7 @@ function scheduleJitter (element) {
   if (!element || !assimilationInProgress) return
 
   const elapsed = Math.max(0, performance.now() - assimilationStartTime)
-  const progress = Math.min(1, elapsed / EFFECT_DURATION)
+  const progress = Math.min(1, elapsed / effectDurationMs)
   const eased = Math.pow(progress, 1.45)
   const intensity = Math.max(0, 1 - eased)
 
@@ -109,7 +115,7 @@ function upgradeElement (element, baseDelay) {
     node.parentNode.replaceChild(spanWrapper, node)
   })
 
-  const safeWindow = Math.max(180, EFFECT_DURATION - baseDelay - 120)
+  const safeWindow = Math.max(180, effectDurationMs - baseDelay - 120)
   const removalDelay = Math.max(180, Math.min(safeWindow, 900 + Math.random() * 450))
 
   window.setTimeout(() => {
@@ -150,7 +156,7 @@ function beginAssimilationEffect () {
   document.body.classList.add('ghostnet-assimilation-mode')
 
   targets.forEach((element) => {
-    const delay = Math.random() * (EFFECT_DURATION * 0.55)
+    const delay = Math.random() * (effectDurationMs * 0.55)
     window.setTimeout(() => {
       upgradeElement(element, delay)
     }, delay)
@@ -187,6 +193,12 @@ export function initiateGhostnetAssimilation (callback) {
     return
   }
 
+  const configuredSeconds = getAssimilationDurationSeconds()
+  const configuredDurationMs = Math.round(configuredSeconds * 1000)
+  effectDurationMs = Number.isFinite(configuredDurationMs) && configuredDurationMs > 0
+    ? configuredDurationMs
+    : DEFAULT_EFFECT_DURATION
+
   assimilationInProgress = true
   const cleanup = beginAssimilationEffect()
 
@@ -205,7 +217,7 @@ export function initiateGhostnetAssimilation (callback) {
       cleanup()
       assimilationInProgress = false
     }, 600)
-  }, EFFECT_DURATION)
+  }, effectDurationMs)
 }
 
 export function isGhostnetAssimilationActive () {

--- a/src/client/lib/ghostnet-settings.js
+++ b/src/client/lib/ghostnet-settings.js
@@ -1,0 +1,37 @@
+export const ASSIMILATION_DURATION_STORAGE_KEY = 'ghostnetAssimilationDuration'
+export const ASSIMILATION_DURATION_DEFAULT = 4
+export const ASSIMILATION_DURATION_MIN = 2
+export const ASSIMILATION_DURATION_MAX = 8
+
+function clampDuration (value) {
+  if (!Number.isFinite(value)) return ASSIMILATION_DURATION_DEFAULT
+  if (value < ASSIMILATION_DURATION_MIN) return ASSIMILATION_DURATION_MIN
+  if (value > ASSIMILATION_DURATION_MAX) return ASSIMILATION_DURATION_MAX
+  return value
+}
+
+export function getAssimilationDurationSeconds () {
+  const fallback = ASSIMILATION_DURATION_DEFAULT
+  if (typeof window === 'undefined' || !window.localStorage) return fallback
+
+  try {
+    const stored = window.localStorage.getItem(ASSIMILATION_DURATION_STORAGE_KEY)
+    if (!stored) return fallback
+    const parsed = Number.parseFloat(stored)
+    return clampDuration(parsed)
+  } catch (error) {
+    return fallback
+  }
+}
+
+export function saveAssimilationDurationSeconds (value) {
+  const sanitized = clampDuration(Number.parseFloat(value))
+  if (typeof window !== 'undefined' && window.localStorage) {
+    try {
+      window.localStorage.setItem(ASSIMILATION_DURATION_STORAGE_KEY, String(sanitized))
+    } catch (error) {
+      // Ignore write failures (e.g. storage disabled)
+    }
+  }
+  return sanitized
+}


### PR DESCRIPTION
## Summary
- add a shared GhostNet settings helper for persisting assimilation duration bounds and defaults
- expose a slider in the GhostNet settings panel to adjust the assimilation transition length between 2s and 8s
- update the assimilation effect to respect the configured duration before launching the transition

## Testing
- npm test -- --runInBand *(fails: jest not found in environment)*
- npm run build:client *(fails: next not found in environment)*
- npm run start *(fails: service depends on dotenv which is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de004bb94883239f6fb49fc40a57ac