### PR TITLE
feat: restyle GhostNet tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Ensure every UI adjustment remains responsive and accessible across a wide range of device sizes.
 - Where it adds value, introduce tasteful animations and micro-interactions to help the interface feel vibrant and alive.
 - Mirror the structural patterns and layout conventions of other Icarus pages so the product feels cohesive, while still honoring GhostNet's unique identity.
+- Keep data tables outside of `SectionFrame` containers; tables should rely on GhostNet table shells (`dataTableContainer`, `dataTable`) for structure instead of being nested inside section frames.
 
 ### GhostNet Purple Theme Specification
 - **Primary hue:** GhostNet surfaces should lean on a rich royal purple (`#5D2EFF`) for primary actions, interactive accents, and key highlights.

--- a/src/client/css/pages/ghostnet.css
+++ b/src/client/css/pages/ghostnet.css
@@ -67,11 +67,13 @@
   align-items: stretch;
   gap: 0;
   padding: 0;
-  border-radius: 0;
+  border-radius: 1.25rem;
   box-sizing: border-box;
-  border: 1px solid #333;
-  background: #101010;
-  margin-top: 1.5rem;
+  border: 1px solid rgba(216, 180, 254, 0.24);
+  background: rgba(7, 10, 18, 0.9);
+  box-shadow: 0 1.65rem 3.75rem rgba(3, 7, 12, 0.78);
+  backdrop-filter: blur(12px);
+  overflow: hidden;
 }
 
 .pristine-mining__container--inspector {
@@ -120,9 +122,10 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
-  border: 1px solid #1f2430;
-  border-radius: 0.75rem;
-  background: rgba(8, 10, 16, 0.94) var(--linear-gradient-background);
+  border: 1px solid rgba(216, 180, 254, 0.28);
+  border-radius: 1rem;
+  background: linear-gradient(180deg, rgba(12, 16, 26, 0.95) 0%, rgba(7, 11, 20, 0.92) 100%);
+  box-shadow: 0 1.35rem 3rem rgba(3, 7, 12, 0.72);
   overflow: hidden;
   padding: 0;
   box-sizing: border-box;
@@ -134,10 +137,10 @@
   width: 100%;
   height: auto;
   padding: 0.75rem 1rem 0.75rem 2.75rem;
-  background: rgba(30, 20, 14, 0.9);
-  color: var(--color-primary);
-  border-bottom: 1px solid rgba(255, 124, 34, 0.25);
-  border-radius: 0.75rem 0.75rem 0 0;
+  background: rgba(41, 24, 89, 0.85);
+  color: var(--ghostnet-ink);
+  border-bottom: 1px solid rgba(140, 92, 255, 0.35);
+  border-radius: 1rem 1rem 0 0;
 }
 
 .pristine-mining__inspector .inspector__close-button {
@@ -161,19 +164,19 @@
 .pristine-mining__inspector-status {
   align-self: flex-start;
   width: 100%;
-  background: rgba(12, 15, 24, 0.92);
-  border: 1px solid #1f2430;
-  border-radius: 0.75rem;
+  background: rgba(5, 8, 13, 0.88);
+  border: 1px solid rgba(140, 92, 255, 0.28);
+  border-radius: 1rem;
   padding: 1rem 1.25rem;
-  color: #bbb;
+  color: var(--ghostnet-muted);
   font-size: 0.95rem;
   line-height: 1.45;
 }
 
 .pristine-mining__inspector-status--error {
-  color: #ffb347;
-  border-color: #553211;
-  background: rgba(38, 18, 6, 0.55);
+  color: #ff5fc1;
+  border-color: rgba(255, 95, 193, 0.45);
+  background: rgba(255, 95, 193, 0.12);
 }
 
 .pristine-mining__inspector .navigation-panel__inspector {
@@ -206,7 +209,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
-  color: #bbb;
+  color: var(--ghostnet-muted);
   font-size: 0.95rem;
 }
 
@@ -223,12 +226,12 @@
 }
 
 .pristine-mining__detail-status {
-  color: #aaa;
+  color: var(--ghostnet-subdued);
   font-size: 0.95rem;
 }
 
 .pristine-mining__detail-status--error {
-  color: #ffb347;
+  color: #ff5fc1;
 }
 
 .pristine-mining__detail-artwork {
@@ -270,15 +273,15 @@
 }
 
 .pristine-mining__belt-ring {
-  fill: rgba(255, 124, 34, 0.25);
+  fill: rgba(93, 46, 255, 0.35);
 }
 
 .pristine-mining__belt-ring--inner {
-  fill: rgba(255, 124, 34, 0.18);
+  fill: rgba(140, 92, 255, 0.28);
 }
 
 .pristine-mining__belt-dust {
-  fill: rgba(255, 124, 34, 0.08);
+  fill: rgba(93, 46, 255, 0.18);
 }
 
 @media (max-width: 1200px) {

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -345,13 +345,16 @@ function getFactionStandingDisplay(factionName, standings) {
 
   const normalizedStanding = typeof info.standing === 'string' ? info.standing.trim().toLowerCase() : ''
   let className = null
-  let color = '#ffb347'
+  let color = 'var(--ghostnet-subdued)'
   if (normalizedStanding === 'ally') {
-    className = 'text-success'
-    color = 'var(--color-success)'
+    className = styles.tableTextSuccess
+    color = '#29f3c3'
   } else if (normalizedStanding === 'hostile') {
-    className = 'text-danger'
-    color = 'var(--color-danger)'
+    className = styles.tableTextDanger
+    color = '#ff5fc1'
+  } else if (normalizedStanding) {
+    className = styles.tableTextNeutral
+    color = 'var(--ghostnet-accent)'
   }
 
   const reputationLabel = typeof info.reputation === 'number'
@@ -1179,25 +1182,27 @@ function MissionsPanel () {
   }, [status, missions])
 
   return (
-    <div className={`${styles.sectionFrame} ${styles.sectionPadding}`}>
-      <h2>Mining Missions</h2>
-      <p className={styles.sectionHint}>Ghost Net decrypts volunteer GHOSTNET manifests to shortlist mining opportunities aligned to your current system.</p>
-      <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
-        <div>
-          <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
-          <div className='text-primary' style={CURRENT_SYSTEM_NAME_STYLE}>{displaySystemName || 'Unknown'}</div>
-        </div>
-        {sourceUrl && (
-          <div className='ghostnet__data-source ghostnet-muted'>
-            Ghost Net intercept feed compiled from GHOSTNET community relays.
+    <div className={styles.sectionGroup}>
+      <div className={`${styles.sectionFrame} ${styles.sectionPadding}`}>
+        <h2>Mining Missions</h2>
+        <p className={styles.sectionHint}>Ghost Net decrypts volunteer GHOSTNET manifests to shortlist mining opportunities aligned to your current system.</p>
+        <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
+          <div>
+            <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
+            <div className='text-primary' style={CURRENT_SYSTEM_NAME_STYLE}>{displaySystemName || 'Unknown'}</div>
           </div>
-        )}
+          {sourceUrl && (
+            <div className='ghostnet__data-source ghostnet-muted'>
+              Ghost Net intercept feed compiled from GHOSTNET community relays.
+            </div>
+          )}
+        </div>
+        <p style={{ color: 'var(--ghostnet-muted)', marginTop: '-0.5rem' }}>
+          Availability signals originate from GHOSTNET contributors and may trail live mission boards.
+        </p>
+        {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
       </div>
-      <p style={{ color: 'var(--ghostnet-muted)', marginTop: '-0.5rem' }}>
-        Availability signals originate from GHOSTNET contributors and may trail live mission boards.
-      </p>
-      {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
-      <div className='ghostnet-panel-table' style={{ marginTop: '1.5rem', overflow: 'hidden' }}>
+      <div className='ghostnet-panel-table' style={{ overflow: 'hidden' }}>
         <div className='scrollable' style={{ maxHeight: 'calc(100vh - 360px)', overflowY: 'auto' }}>
           {displayMessage && status !== 'idle' && status !== 'loading' && (
             <div className={`${styles.tableMessage} ${status === 'populated' ? styles.tableMessageBorder : ''}`}>
@@ -1250,10 +1255,10 @@ function MissionsPanel () {
                   const factionKey = normaliseFactionKey(mission.faction)
                   const factionInfo = factionKey ? factionStandings[factionKey] : null
                   const standingClass = factionInfo?.standing === 'ally'
-                    ? 'text-success'
+                    ? styles.tableTextSuccess
                     : factionInfo?.standing === 'hostile'
-                      ? 'text-danger'
-                      : 'text-primary'
+                      ? styles.tableTextDanger
+                      : styles.tableTextNeutral
                   const standingLabel = factionInfo?.relation || (factionInfo?.standing
                     ? `${factionInfo.standing.charAt(0).toUpperCase()}${factionInfo.standing.slice(1)}`
                     : null)
@@ -2523,23 +2528,24 @@ function TradeRoutesPanel () {
   )
 
   return (
-    <div className={`${styles.sectionFrame} ${styles.sectionPadding}`}>
-      <h2>Find Trade Routes</h2>
-      <p className={styles.sectionHint}>Cross-reference GHOSTNET freight whispers to surface lucrative corridors suited to your ship profile.</p>
-      <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
-        <div>
-          <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
-          <div className='text-primary' style={CURRENT_SYSTEM_NAME_STYLE}>
-            {selectedSystemName || 'Unknown'}
+    <div className={styles.sectionGroup}>
+      <div className={`${styles.sectionFrame} ${styles.sectionPadding}`}>
+        <h2>Find Trade Routes</h2>
+        <p className={styles.sectionHint}>Cross-reference GHOSTNET freight whispers to surface lucrative corridors suited to your ship profile.</p>
+        <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
+          <div>
+            <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
+            <div className='text-primary' style={CURRENT_SYSTEM_NAME_STYLE}>
+              {selectedSystemName || 'Unknown'}
+            </div>
           </div>
         </div>
-      </div>
-      <form onSubmit={handleSubmit} style={FILTER_FORM_STYLE}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '.85rem', marginBottom: filtersCollapsed ? '.75rem' : '1.5rem' }}>
-          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '.85rem', flexGrow: 1 }}>
-            <button
-              type='button'
-              onClick={() => setFiltersCollapsed(prev => !prev)}
+        <form onSubmit={handleSubmit} style={FILTER_FORM_STYLE}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '.85rem', marginBottom: filtersCollapsed ? '.75rem' : '1.5rem' }}>
+            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '.85rem', flexGrow: 1 }}>
+              <button
+                type='button'
+                onClick={() => setFiltersCollapsed(prev => !prev)}
               style={FILTER_TOGGLE_BUTTON_STYLE}
               aria-expanded={!filtersCollapsed}
               aria-controls='trade-route-filters'
@@ -2648,8 +2654,9 @@ function TradeRoutesPanel () {
             </div>
           </div>
         )}
-      </form>
-      <div className='ghostnet-panel-table' style={{ marginTop: '1.5rem', overflow: 'hidden' }}>
+        </form>
+      </div>
+      <div className='ghostnet-panel-table' style={{ overflow: 'hidden' }}>
         <div className='scrollable' style={{ maxHeight: 'calc(100vh - 360px)', overflowY: 'auto' }}>
           {message && status !== 'idle' && status !== 'loading' && (
             <div className={`${styles.tableMessage} ${status === 'populated' ? styles.tableMessageBorder : ''}`}>{message}</div>
@@ -2891,24 +2898,26 @@ function PristineMiningPanel () {
   }, [handleLocationToggle])
 
   return (
-    <div className={`${styles.sectionFrameElevated} ${styles.sectionPadding}`}>
-      <h2>Pristine Mining Locations</h2>
-      <p className={styles.sectionHint}>Ghost Net listens for rare reserve chatter across GHOSTNET to pinpoint high-value extraction sites.</p>
-      <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
-        <div>
-          <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
-          <div className='text-primary' style={CURRENT_SYSTEM_NAME_STYLE}>{displaySystemName || 'Unknown'}</div>
-        </div>
-        {sourceUrl && (
-          <div className='ghostnet__data-source ghostnet-muted'>
-            Ghost Net prospecting relays aligned with GHOSTNET survey intel.
+    <div className={styles.sectionGroup}>
+      <div className={`${styles.sectionFrameElevated} ${styles.sectionPadding}`}>
+        <h2>Pristine Mining Locations</h2>
+        <p className={styles.sectionHint}>Ghost Net listens for rare reserve chatter across GHOSTNET to pinpoint high-value extraction sites.</p>
+        <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
+          <div>
+            <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
+            <div className='text-primary' style={CURRENT_SYSTEM_NAME_STYLE}>{displaySystemName || 'Unknown'}</div>
           </div>
-        )}
+          {sourceUrl && (
+            <div className='ghostnet__data-source ghostnet-muted'>
+              Ghost Net prospecting relays aligned with GHOSTNET survey intel.
+            </div>
+          )}
+        </div>
+        <p style={{ color: 'var(--ghostnet-muted)', marginTop: '-0.5rem' }}>
+          Geological echoes are sourced from volunteer GHOSTNET submissions and may lag in-system discoveries.
+        </p>
+        {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
       </div>
-      <p style={{ color: 'var(--ghostnet-muted)', marginTop: '-0.5rem' }}>
-        Geological echoes are sourced from volunteer GHOSTNET submissions and may lag in-system discoveries.
-      </p>
-      {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
       <div
         className={`pristine-mining__container${inspectorReserved ? ' pristine-mining__container--inspector' : ''}`}
       >

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -15,6 +15,12 @@
   --ghostnet-subdued: #6c7c92;
   --ghostnet-accent: #d8b4fe;
   --ghostnet-highlight: rgba(216, 180, 254, 0.12);
+  --ghostnet-table-header: linear-gradient(
+    180deg,
+    rgba(93, 46, 255, 0.85) 0%,
+    rgba(42, 14, 130, 0.8) 75%,
+    rgba(140, 92, 255, 0.65) 100%
+  );
 }
 
 .ghostnet::before {
@@ -280,12 +286,13 @@
 }
 
 .dataTable thead {
-  background: linear-gradient(180deg, rgba(93, 46, 255, 0.85) 0%, rgba(42, 14, 130, 0.8) 75%, rgba(140, 92, 255, 0.65) 100%);
+  background: var(--ghostnet-table-header);
   box-shadow: inset 0 -1px 0 rgba(140, 92, 255, 0.38);
 }
 
 .dataTable thead tr {
   border-bottom: 1px solid rgba(140, 92, 255, 0.45);
+  background: var(--ghostnet-table-header);
 }
 
 .dataTable thead th {
@@ -707,8 +714,12 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead) {
-  background: linear-gradient(180deg, rgba(93, 46, 255, 0.85) 0%, rgba(42, 14, 130, 0.8) 75%, rgba(140, 92, 255, 0.65) 100%);
+  background: var(--ghostnet-table-header);
   box-shadow: inset 0 -1px 0 rgba(140, 92, 255, 0.38);
+}
+
+.ghostnet :global(.ghostnet-panel-table table thead tr) {
+  background: var(--ghostnet-table-header) !important;
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead tr th) {

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -254,9 +254,10 @@
 
 .dataTableContainer {
   position: relative;
-  border: 1px solid rgba(216, 180, 254, 0.24);
+  border: 1px solid rgba(140, 92, 255, 0.38);
   border-radius: 1.25rem;
-  background: rgba(7, 10, 18, 0.92);
+  background: radial-gradient(circle at 50% 0%, rgba(93, 46, 255, 0.18), transparent 65%),
+    linear-gradient(180deg, rgba(9, 8, 26, 0.95) 0%, rgba(7, 11, 20, 0.94) 100%);
   box-shadow: 0 1.65rem 3.75rem rgba(3, 7, 12, 0.78);
   overflow: hidden;
 }
@@ -279,11 +280,12 @@
 }
 
 .dataTable thead {
-  background: linear-gradient(180deg, rgba(12, 16, 26, 0.96) 0%, rgba(7, 11, 20, 0.94) 100%);
+  background: linear-gradient(180deg, rgba(93, 46, 255, 0.85) 0%, rgba(42, 14, 130, 0.8) 75%, rgba(140, 92, 255, 0.65) 100%);
+  box-shadow: inset 0 -1px 0 rgba(140, 92, 255, 0.38);
 }
 
 .dataTable thead tr {
-  border-bottom: 1px solid rgba(216, 180, 254, 0.22);
+  border-bottom: 1px solid rgba(140, 92, 255, 0.45);
 }
 
 .dataTable thead th {
@@ -291,17 +293,21 @@
   font-size: 0.72rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--ghostnet-subdued);
+  color: rgba(245, 241, 255, 0.88);
   font-weight: 600;
   text-align: left;
   white-space: nowrap;
 }
 
 .dataTable tbody tr {
-  background: rgba(5, 8, 13, 0.78);
-  border-bottom: 1px solid rgba(216, 180, 254, 0.14);
+  background: linear-gradient(180deg, rgba(13, 11, 26, 0.86) 0%, rgba(16, 9, 38, 0.76) 100%);
+  border-bottom: 1px solid rgba(140, 92, 255, 0.25);
   transition: background 0.25s ease, transform 0.25s ease;
   font-size: 0.95rem;
+}
+
+.dataTable tbody tr:nth-child(even) {
+  background: rgba(27, 16, 58, 0.45);
 }
 
 .dataTable tbody tr:last-child {
@@ -309,7 +315,7 @@
 }
 
 .dataTable tbody tr:hover {
-  background: rgba(127, 233, 255, 0.16);
+  background: rgba(93, 46, 255, 0.18);
 }
 
 .dataTable td {
@@ -668,8 +674,8 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table) {
-  background: var(--ghostnet-panel);
-  border: 1px solid var(--ghostnet-panel-border);
+  background: linear-gradient(180deg, rgba(13, 11, 26, 0.94) 0%, rgba(7, 11, 20, 0.92) 100%);
+  border: 1px solid rgba(140, 92, 255, 0.38);
   border-radius: 1.25rem;
   overflow: hidden;
   box-shadow: 0 1.75rem 3.5rem rgba(4, 9, 14, 0.75);
@@ -677,19 +683,49 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable) {
-  background: rgba(5, 8, 13, 0.4);
+  background: linear-gradient(180deg, rgba(9, 7, 24, 0.78) 0%, rgba(7, 11, 20, 0.9) 100%);
+  scrollbar-color: rgba(140, 92, 255, 0.6) rgba(13, 11, 26, 0.85);
+}
+
+.ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar) {
+  width: 0.65rem;
+}
+
+.ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-track) {
+  background: rgba(13, 11, 26, 0.75);
+  border-radius: 0.65rem;
+}
+
+.ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-thumb) {
+  background: linear-gradient(180deg, rgba(93, 46, 255, 0.75) 0%, rgba(42, 14, 130, 0.85) 100%);
+  border-radius: 0.65rem;
+  box-shadow: 0 0 0 2px rgba(13, 11, 26, 0.55) inset;
+}
+
+.ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-thumb:hover) {
+  background: linear-gradient(180deg, rgba(117, 70, 255, 0.85) 0%, rgba(42, 14, 130, 0.9) 100%);
+}
+
+.ghostnet :global(.ghostnet-panel-table table thead) {
+  background: linear-gradient(180deg, rgba(93, 46, 255, 0.85) 0%, rgba(42, 14, 130, 0.8) 75%, rgba(140, 92, 255, 0.65) 100%);
+  box-shadow: inset 0 -1px 0 rgba(140, 92, 255, 0.38);
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead tr th) {
-  border-bottom: 1px solid rgba(216, 180, 254, 0.2);
+  border-bottom: 1px solid rgba(140, 92, 255, 0.45);
+  color: rgba(245, 241, 255, 0.88);
+}
+
+.ghostnet :global(.ghostnet-panel-table tbody tr) {
+  border-bottom: 1px solid rgba(140, 92, 255, 0.25);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr:nth-child(even)) {
-  background: rgba(216, 180, 254, 0.06);
+  background: rgba(27, 16, 58, 0.45);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr:hover) {
-  background: rgba(216, 180, 254, 0.14) !important;
+  background: rgba(93, 46, 255, 0.18) !important;
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail) {

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -199,6 +199,12 @@
   backdrop-filter: blur(12px);
 }
 
+.sectionGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
 .sectionFrameElevated {
   border-radius: 1.5rem;
   background: var(--ghostnet-panel);
@@ -382,6 +388,18 @@
 
 .tableDetailSection span {
   line-height: 1.4;
+}
+
+.tableTextNeutral {
+  color: var(--ghostnet-accent);
+}
+
+.tableTextSuccess {
+  color: #29f3c3;
+}
+
+.tableTextDanger {
+  color: #ff5fc1;
 }
 
 .tableStatusBar {
@@ -684,11 +702,11 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail-links span) {
-  color: var(--ghostnet-ink);
+  color: var(--ghostnet-accent);
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail-status--error) {
-  color: #ff7b7b;
+  color: #ff5fc1;
 }
 
 .ghostnet :global(.ghostnet-panel-table .text-primary) {


### PR DESCRIPTION
## Summary
- restyle GhostNet mission, trade route, and mining tables with the repository table shell and keep them out of SectionFrame containers
- refresh pristine mining inspector/detail styling and add GhostNet-flavoured text treatments for standing indicators
- document the table/SectionFrame rule in the contributor guidance

## Testing
- npm test -- --runInBand
- npm run build:client
- npm run start


------
https://chatgpt.com/codex/tasks/task_e_68de061bbe1083238fbf1e4f3caa46e9