### PR TITLE
Add floating GhostNet terminal overlay

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -3073,6 +3073,84 @@ function PristineMiningPanel () {
   )
 }
 
+function GhostnetTerminalOverlay () {
+  const [collapsed, setCollapsed] = useState(false)
+  const [offset, setOffset] = useState(0)
+
+  const terminalLines = useMemo(() => ([
+    { type: 'command', label: 'ghostnet@ship', text: 'uplink --channel "VEGA-9" --handshake mesh://relay-04' },
+    { type: 'response', label: 'mesh', text: 'Handshake acknowledged · encryption lattice stable · latency 42ms' },
+    { type: 'command', label: 'ghostnet@ship', text: 'stream manifest ping://drydock --burst 32kb --checksum' },
+    { type: 'response', label: 'ship', text: 'Payload queued · 12 telemetry frames buffered for dispatch' },
+    { type: 'command', label: 'ghostnet@ship', text: 'listen mesh://syndicate.radar --filter "convoy:aurora"' },
+    { type: 'response', label: 'mesh', text: 'Intercepted 3 convoy packets · decrypting spectral bands' },
+    { type: 'response', label: 'mesh', text: 'Return vector mapped · ghost corridor aligned to Perseus Reach' },
+    { type: 'command', label: 'ghostnet@ship', text: 'send burst://outpost-ix --file navmap.dat --repeat 2' },
+    { type: 'response', label: 'ship', text: 'Uplink thrusters trimming · data stream locked at 8.4 kb/s' },
+    { type: 'response', label: 'mesh', text: 'Outpost IX confirms receipt · requesting follow-on diagnostics' },
+    { type: 'command', label: 'ghostnet@ship', text: 'monitor relay://ghostnet.delta --mode passive --squelch 3' },
+    { type: 'response', label: 'mesh', text: 'Passive net cast · spectral noise floor nominal' }
+  ]), [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const interval = window.setInterval(() => {
+      setOffset(previous => (previous + 1) % terminalLines.length)
+    }, 3200)
+
+    return () => {
+      window.clearInterval(interval)
+    }
+  }, [terminalLines.length])
+
+  const visibleLines = useMemo(() => {
+    const windowSize = 7
+    return Array.from({ length: windowSize }).map((_, index) => {
+      const currentIndex = (offset + index) % terminalLines.length
+      return { ...terminalLines[currentIndex], id: `${currentIndex}-${index}` }
+    })
+  }, [offset, terminalLines])
+
+  const toggleCollapsed = useCallback(() => {
+    setCollapsed(previous => !previous)
+  }, [])
+
+  return (
+    <div className={`${styles.terminal} ${collapsed ? styles.terminalCollapsed : ''}`}>
+      <div className={styles.terminalShell} role='region' aria-label='Ghost Net ship uplink activity log'>
+        <div className={styles.terminalHeader}>
+          <div className={styles.terminalHeaderContent}>
+            <span className={styles.terminalTitle}>Ship Uplink Console</span>
+            <span className={styles.terminalStatus}>Channel mesh://ghostnet</span>
+          </div>
+          <button
+            type='button'
+            className={styles.terminalToggle}
+            onClick={toggleCollapsed}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? 'Expand uplink console' : 'Minimize uplink console'}
+          >
+            {collapsed ? 'Expand' : 'Minimize'}
+          </button>
+        </div>
+        <div className={styles.terminalBody}>
+          <ul className={styles.terminalFeed}>
+            {visibleLines.map(line => (
+              <li key={line.id} className={styles.terminalLine}>
+                <span className={`${styles.terminalPrompt} ${line.type === 'command' ? styles.terminalPromptCommand : styles.terminalPromptResponse}`}>
+                  {line.label}
+                </span>
+                <span className={styles.terminalText}>{line.text}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function GhostnetPage() {
   const [activeTab, setActiveTab] = useState('tradeRoutes')
   const [arrivalMode, setArrivalMode] = useState(false)
@@ -3192,6 +3270,7 @@ export default function GhostnetPage() {
               </div>
             </div>
           </div>
+          <GhostnetTerminalOverlay />
         </div>
       </Panel>
     </Layout>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1,7 +1,8 @@
 .ghostnet {
   position: relative;
   min-height: 100%;
-  padding: 2.5rem 3rem 3.5rem;
+  --ghostnet-terminal-height: clamp(180px, 18vh, 220px);
+  padding: 2.5rem 3rem calc(3.5rem + var(--ghostnet-terminal-height));
   background: radial-gradient(circle at 20% 15%, rgba(216, 180, 254, 0.14), transparent 55%),
     radial-gradient(circle at 85% 10%, rgba(167, 139, 250, 0.22), transparent 60%),
     #05080d;
@@ -195,6 +196,169 @@
 .tabPanels {
   position: relative;
   z-index: 1;
+}
+
+.terminal {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  height: var(--ghostnet-terminal-height);
+  pointer-events: none;
+  z-index: 20;
+  transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.terminalCollapsed {
+  transform: translateY(calc(var(--ghostnet-terminal-height) - 3.25rem));
+}
+
+.terminalShell {
+  width: min(960px, calc(100% - 2.5rem));
+  background: linear-gradient(180deg, rgba(28, 22, 51, 0.92) 0%, rgba(13, 11, 26, 0.94) 100%);
+  border: 1px solid rgba(140, 92, 255, 0.35);
+  border-bottom: none;
+  border-radius: 1.5rem 1.5rem 0 0;
+  color: var(--ghostnet-ink);
+  pointer-events: auto;
+  box-shadow: 0 -1.25rem 2.75rem rgba(5, 8, 13, 0.68), 0 0 1.75rem rgba(93, 46, 255, 0.36);
+  backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.terminalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem 0.75rem 1.5rem;
+  background: rgba(93, 46, 255, 0.12);
+  border-bottom: 1px solid rgba(140, 92, 255, 0.28);
+}
+
+.terminalHeaderContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.terminalTitle {
+  font-size: 0.9rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: #f5f1ff;
+}
+
+.terminalStatus {
+  font-size: 0.8rem;
+  color: rgba(245, 241, 255, 0.68);
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+}
+
+.terminalToggle {
+  background: rgba(93, 46, 255, 0.24);
+  border: 1px solid rgba(93, 46, 255, 0.55);
+  color: #f5f1ff;
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  cursor: pointer;
+  transition: background 200ms ease, transform 200ms ease;
+}
+
+.terminalToggle:hover,
+.terminalToggle:focus-visible {
+  background: rgba(93, 46, 255, 0.45);
+  transform: translateY(-1px);
+}
+
+.terminalToggle:focus-visible {
+  outline: 2px solid #29f3c3;
+  outline-offset: 2px;
+}
+
+.terminalToggle:active {
+  background: rgba(42, 14, 130, 0.62);
+  transform: translateY(1px);
+}
+
+.terminalBody {
+  flex: 1;
+  padding: 1.25rem 1.5rem 1.5rem;
+  background: radial-gradient(circle at 20% 0%, rgba(93, 46, 255, 0.18), transparent 55%);
+  overflow: hidden;
+  display: flex;
+}
+
+.terminalFeed {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  align-content: end;
+  width: 100%;
+  gap: 0.45rem;
+}
+
+.terminalLine {
+  display: grid;
+  grid-template-columns: minmax(0, auto) 1fr;
+  gap: 0.85rem;
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+  font-size: 0.85rem;
+  color: rgba(245, 241, 255, 0.78);
+  opacity: 0;
+  animation: terminalLineReveal 320ms ease forwards;
+}
+
+.terminalPrompt {
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  padding-top: 0.2rem;
+}
+
+.terminalPromptCommand {
+  color: #29f3c3;
+}
+
+.terminalPromptResponse {
+  color: rgba(140, 92, 255, 0.75);
+}
+
+.terminalText {
+  color: rgba(245, 241, 255, 0.82);
+}
+
+@keyframes terminalLineReveal {
+  from {
+    transform: translateY(0.35rem);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 720px) {
+  .terminalShell {
+    width: calc(100% - 1.5rem);
+  }
+
+  .terminal {
+    align-items: stretch;
+  }
+
+  .terminalCollapsed {
+    transform: translateY(calc(var(--ghostnet-terminal-height) - 3rem));
+  }
 }
 
 .sectionFrame {


### PR DESCRIPTION
## Summary
- add a decorative GhostNet ship uplink console that cycles immersive command logs at the bottom of the page
- apply GhostNet-themed styling for the fixed overlay, maintain viewport height limits, and leave room in the layout

## Testing
- npm test -- --runInBand *(fails: jest not found in environment)*
- npm run build:client *(fails: next not found in environment)*
- npm run start *(fails: missing dotenv dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de68088d308323962438f017fe87f4