### PR TITLE
Align GhostNet table styling with theme

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -659,7 +659,7 @@ const FILTER_SUMMARY_STYLE = {
 }
 
 const FILTER_SUMMARY_TEXT_STYLE = {
-  color: '#ffa45b',
+  color: 'var(--ghostnet-accent)',
   fontSize: '0.85rem',
   fontWeight: 500,
   whiteSpace: 'nowrap',
@@ -708,7 +708,7 @@ function getStationIconName (localInfo = {}, remoteInfo = {}) {
   return stationIconFromType(candidates[0])
 }
 
-function StationIcon ({ icon, size = 26, color = '#ffb347' }) {
+function StationIcon ({ icon, size = 26, color = 'var(--ghostnet-accent)' }) {
   if (!icon) return null
   const paths = Icons[icon]
   if (!paths) return null

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -583,7 +583,7 @@
   padding: 0.6rem 0.35rem;
   text-align: center;
   vertical-align: top;
-  color: #ffb347;
+  color: var(--ghostnet-accent);
   font-size: 1.1rem;
   line-height: 1;
 }
@@ -609,20 +609,20 @@
 }
 
 .tableRowInteractive:hover {
-  background: rgba(127, 233, 255, 0.2);
+  background: rgba(93, 46, 255, 0.2);
 }
 
 .tableRowExpanded {
-  background: rgba(127, 233, 255, 0.16) !important;
+  background: rgba(93, 46, 255, 0.16) !important;
 }
 
 .tableRowExpanded:hover {
-  background: rgba(127, 233, 255, 0.22) !important;
+  background: rgba(93, 46, 255, 0.22) !important;
 }
 
 .tableDetailRow td {
   background: rgba(5, 8, 13, 0.88);
-  border-top: 1px solid rgba(127, 233, 255, 0.18);
+  border-top: 1px solid rgba(140, 92, 255, 0.25);
   padding: 0 1.5rem 1.5rem;
 }
 
@@ -656,7 +656,7 @@
 }
 
 .tableMessageBorder {
-  border-bottom: 1px solid rgba(127, 233, 255, 0.18);
+  border-bottom: 1px solid rgba(140, 92, 255, 0.25);
 }
 
 .tableIdleState {
@@ -687,7 +687,7 @@
 }
 
 .tableWarning {
-  color: #ffb347;
+  color: #ff5fc1;
   font-size: 0.78rem;
   margin-top: 0.35rem;
 }
@@ -776,7 +776,7 @@
 }
 
 .tableBadgeWarning {
-  color: #ff7c22;
+  color: #ff5fc1;
 }
 
 .tableBadgeSuccess {
@@ -818,7 +818,7 @@
 }
 
 .metricValueWarning {
-  color: #ff7c22;
+  color: #ff5fc1;
 }
 
 .metricValueSuccess {
@@ -828,7 +828,7 @@
 .notice {
   margin-bottom: 0.75rem;
   font-size: 0.9rem;
-  color: #ffb347;
+  color: var(--ghostnet-accent);
 }
 
 .noticeMuted {


### PR DESCRIPTION
## Summary
- replace remaining yellow table accents with GhostNet accent colors across table elements
- shift table interaction states and dividers to GhostNet purple treatments
- update filter summary and station icon defaults to rely on GhostNet accent variables

## Testing
- `npm test -- --runInBand` *(fails: jest binary missing because dependencies could not be installed without external download)*
- `npm run build:client` *(fails: Next.js binary missing for the same reason)*
- `npm run start` *(fails: dotenv module missing after dependency installation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68de863e70b483239f32580f7a2b8e9b