### PR TITLE
Refactor trade route details into full page view

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -1901,7 +1901,7 @@ function TradeRoutesPanel () {
   const [sortField, setSortField] = useState('distance')
   const [sortDirection, setSortDirection] = useState('asc')
   const [filtersCollapsed, setFiltersCollapsed] = useState(true)
-  const [expandedRouteKey, setExpandedRouteKey] = useState(null)
+  const [selectedRouteContext, setSelectedRouteContext] = useState(null)
   const factionStandings = useFactionStandings()
   const lastAutoRefreshSystem = useRef('')
   const isMountedRef = useRef(true)
@@ -2263,19 +2263,23 @@ function TradeRoutesPanel () {
   }, [applyResults, cargoCapacity, routeDistance, priceAge, padSize, minSupply, minDemand, stationDistance, surfacePreference, status])
 
   useEffect(() => {
-    setExpandedRouteKey(null)
+    setSelectedRouteContext(null)
   }, [rawRoutes])
 
-  const handleRowToggle = useCallback(rowId => {
-    setExpandedRouteKey(prev => (prev === rowId ? null : rowId))
+  const handleRouteSelect = useCallback((route, index) => {
+    setSelectedRouteContext({ route, index })
   }, [])
 
-  const handleRowKeyDown = useCallback((event, rowId) => {
+  const handleRouteKeyDown = useCallback((event, route, index) => {
     if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
       event.preventDefault()
-      handleRowToggle(rowId)
+      handleRouteSelect(route, index)
     }
-  }, [handleRowToggle])
+  }, [handleRouteSelect])
+
+  const handleDetailClose = useCallback(() => {
+    setSelectedRouteContext(null)
+  }, [])
 
   const renderQuantityIndicator = (entry, type) => {
     if (!entry) return null
@@ -2313,7 +2317,7 @@ function TradeRoutesPanel () {
     refreshRoutes(currentName)
   }, [currentSystem?.name, refreshRoutes])
 
-  useEffect(() => animateTableEffect(), [routes, expandedRouteKey])
+  useEffect(() => animateTableEffect(), [routes])
 
   const renderRoutesTable = () => (
     <div className={styles.dataTableContainer}>
@@ -2414,26 +2418,23 @@ function TradeRoutesPanel () {
           const updatedDisplay = formatRelativeTime(route?.summary?.updated || route?.updatedAt || route?.lastUpdated || route?.timestamp)
 
           const rowKey = `route-${index}`
-          const detailsId = `${rowKey}-details`
-          const isExpanded = expandedRouteKey === rowKey
           const originIconName = getStationIconName(originLocal, route?.origin)
           const destinationIconName = getStationIconName(destinationLocal, route?.destination)
-          const expansionSymbol = isExpanded ? String.fromCharCode(0x25B2) : String.fromCharCode(0x25BC)
+          const caretSymbol = String.fromCharCode(0x203A)
 
           return (
             <React.Fragment key={rowKey}>
               <tr
-                className={`${styles.tableRowInteractive} ${isExpanded ? styles.tableRowExpanded : ''}`}
+                className={styles.tableRowInteractive}
                 data-ghostnet-table-row='pending'
-                onClick={() => handleRowToggle(rowKey)}
-                onKeyDown={event => handleRowKeyDown(event, rowKey)}
+                onClick={() => handleRouteSelect(route, index)}
+                onKeyDown={event => handleRouteKeyDown(event, route, index)}
                 role='button'
                 tabIndex={0}
-                aria-expanded={isExpanded}
-                aria-controls={isExpanded ? detailsId : undefined}
+                aria-label={`View trade route details for ${originStation} to ${destinationStation}`}
               >
                 <td className={styles.tableCellCaret} aria-hidden='true'>
-                  {expansionSymbol}
+                  {caretSymbol}
                 </td>
                 <td className={`${styles.tableCellTop} ${styles.tableCellWrap}`}>
                   <div className={styles.tableCellInline}>
@@ -2472,115 +2473,6 @@ function TradeRoutesPanel () {
                 <td className={`hidden-small text-right text-no-transform ${styles.tableCellTop} ${styles.tableCellTight}`}>{systemDistanceDisplay || '--'}</td>
                 <td className={`hidden-small text-right text-no-transform ${styles.tableCellTop} ${styles.tableCellTight}`}>{updatedDisplay || '--'}</td>
               </tr>
-              {isExpanded && (
-                <tr
-                  id={detailsId}
-                  className={styles.tableDetailRow}
-                  data-ghostnet-table-row='pending'
-                >
-                  <td style={{ borderTop: '1px solid rgba(127, 233, 255, 0.18)' }} aria-hidden='true' />
-                  <td style={{ padding: '.5rem .65rem .7rem', borderTop: '1px solid rgba(127, 233, 255, 0.18)', verticalAlign: 'top' }}>
-                    <div className={styles.tableDetailSection}>
-                      <span
-                        style={originStationClassName ? undefined : { color: 'var(--ghostnet-subdued)' }}
-                        className={originStationClassName}
-                        title={originStationTitle}
-                      >
-                        {originSystemName || 'Unknown system'}
-                      </span>
-                      <span style={{ color: 'var(--ghostnet-subdued)' }}>
-                        Faction:&nbsp;
-                        <span
-                          className={originFactionName ? originStationClassName : undefined}
-                          style={originFactionName ? { fontWeight: 600, color: originStationColor } : { fontWeight: 600, color: 'var(--ghostnet-subdued)' }}
-                          title={originStationTitle}
-                        >
-                          {originFactionName || 'Unknown faction'}
-                        </span>
-                      </span>
-                      <span style={{ color: 'var(--ghostnet-subdued)' }}>
-                        Standing:&nbsp;
-                        {originStandingStatusText
-                          ? (
-                            <span
-                              className={originStationClassName}
-                              title={originStationTitle}
-                              style={{ fontWeight: 600, color: originStationColor }}
-                            >
-                              {originStandingStatusText}
-                            </span>
-                            )
-                          : (
-                            <span style={{ color: 'var(--ghostnet-subdued)', fontWeight: 600 }}>
-                              {originFactionName ? 'No local standing data' : 'Not available'}
-                            </span>
-                          )}
-                      </span>
-                      <span>Outbound supply:&nbsp;{outboundSupplyIndicator || indicatorPlaceholder}</span>
-                      <span>Return demand:&nbsp;{returnDemandIndicator || indicatorPlaceholder}</span>
-                    </div>
-                  </td>
-                  <td style={{ padding: '.5rem .65rem .7rem', borderTop: '1px solid rgba(127, 233, 255, 0.18)', verticalAlign: 'top' }}>
-                    <div className={styles.tableDetailSection}>
-                      <span
-                        style={destinationStationClassName ? undefined : { color: 'var(--ghostnet-subdued)' }}
-                        className={destinationStationClassName}
-                        title={destinationStationTitle}
-                      >
-                        {destinationSystemName || 'Unknown system'}
-                      </span>
-                      <span style={{ color: 'var(--ghostnet-subdued)' }}>
-                        Faction:&nbsp;
-                        <span
-                          className={destinationFactionName ? destinationStationClassName : undefined}
-                          style={destinationFactionName ? { fontWeight: 600, color: destinationStationColor } : { fontWeight: 600, color: 'var(--ghostnet-subdued)' }}
-                          title={destinationStationTitle}
-                        >
-                          {destinationFactionName || 'Unknown faction'}
-                        </span>
-                      </span>
-                      <span style={{ color: 'var(--ghostnet-subdued)' }}>
-                        Standing:&nbsp;
-                        {destinationStandingStatusText
-                          ? (
-                            <span
-                              className={destinationStationClassName}
-                              title={destinationStationTitle}
-                              style={{ fontWeight: 600, color: destinationStationColor }}
-                            >
-                              {destinationStandingStatusText}
-                            </span>
-                            )
-                          : (
-                            <span style={{ color: 'var(--ghostnet-subdued)', fontWeight: 600 }}>
-                              {destinationFactionName ? 'No local standing data' : 'Not available'}
-                            </span>
-                          )}
-                      </span>
-                      <span>Outbound demand:&nbsp;{outboundDemandIndicator || indicatorPlaceholder}</span>
-                      <span>Return supply:&nbsp;{returnSupplyIndicator || indicatorPlaceholder}</span>
-                    </div>
-                  </td>
-                  <td className='hidden-small' style={{ padding: '.5rem .65rem .7rem', borderTop: '1px solid rgba(127, 233, 255, 0.18)', verticalAlign: 'top', fontSize: '0.82rem', color: 'var(--ghostnet-muted)' }}>
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                      <span>Buy: {outboundBuy?.priceText || '--'}</span>
-                      <span>Sell: {outboundSell?.priceText || '--'}</span>
-                    </div>
-                  </td>
-                  <td className='hidden-small' style={{ padding: '.5rem .65rem .7rem', borderTop: '1px solid rgba(127, 233, 255, 0.18)', verticalAlign: 'top', fontSize: '0.82rem', color: 'var(--ghostnet-muted)' }}>
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                      <span>Buy: {returnBuy?.priceText || '--'}</span>
-                      <span>Sell: {returnSell?.priceText || '--'}</span>
-                    </div>
-                  </td>
-                  <td className='hidden-small' style={{ borderTop: '1px solid rgba(127, 233, 255, 0.18)' }} aria-hidden='true' />
-                  <td className='hidden-small' style={{ borderTop: '1px solid rgba(127, 233, 255, 0.18)' }} aria-hidden='true' />
-                  <td className='hidden-small' style={{ borderTop: '1px solid rgba(127, 233, 255, 0.18)' }} aria-hidden='true' />
-                  <td className='hidden-small' style={{ borderTop: '1px solid rgba(127, 233, 255, 0.18)' }} aria-hidden='true' />
-                  <td className='hidden-small' style={{ borderTop: '1px solid rgba(127, 233, 255, 0.18)' }} aria-hidden='true' />
-                  <td className='hidden-small' style={{ borderTop: '1px solid rgba(127, 233, 255, 0.18)' }} aria-hidden='true' />
-                </tr>
-              )}
             </React.Fragment>
           )
         })}
@@ -2589,154 +2481,382 @@ function TradeRoutesPanel () {
     </div>
   )
 
+  const renderRouteDetailView = () => {
+    if (!selectedRouteContext?.route) return null
+
+    const { route } = selectedRouteContext
+    const originLocal = route?.origin?.local
+    const destinationLocal = route?.destination?.local
+    const originStation = originLocal?.station || route?.origin?.stationName || route?.originStation || route?.sourceStation || route?.startStation || route?.fromStation || route?.station || '--'
+    const originSystemName = originLocal?.system || route?.origin?.systemName || route?.originSystem || route?.sourceSystem || route?.startSystem || route?.fromSystem || route?.system || ''
+    const destinationStation = destinationLocal?.station || route?.destination?.stationName || route?.destinationStation || route?.targetStation || route?.endStation || route?.toStation || '--'
+    const destinationSystemName = destinationLocal?.system || route?.destination?.systemName || route?.destinationSystem || route?.targetSystem || route?.endSystem || route?.toSystem || ''
+
+    const originFactionName = resolveRouteFactionName(originLocal, route?.origin)
+    const destinationFactionName = resolveRouteFactionName(destinationLocal, route?.destination)
+    const originStandingDisplay = getFactionStandingDisplay(originFactionName, factionStandings)
+    const destinationStandingDisplay = getFactionStandingDisplay(destinationFactionName, factionStandings)
+    const originStationClassName = originStandingDisplay.className || undefined
+    const destinationStationClassName = destinationStandingDisplay.className || undefined
+    const originStationColor = originStandingDisplay.color
+    const destinationStationColor = destinationStandingDisplay.color
+    const originStationTitle = originStandingDisplay.title
+    const destinationStationTitle = destinationStandingDisplay.title
+    const originStandingStatusText = originStandingDisplay.statusDescription || null
+    const destinationStandingStatusText = destinationStandingDisplay.statusDescription || null
+
+    const outboundBuy = route?.origin?.buy || null
+    const outboundSell = route?.destination?.sell || null
+    const returnBuy = route?.destination?.buyReturn || null
+    const returnSell = route?.origin?.sellReturn || null
+
+    const outboundCommodity = outboundBuy?.commodity || outboundSell?.commodity || route?.commodity || '--'
+    const returnCommodity = returnBuy?.commodity || returnSell?.commodity || '--'
+
+    const outboundSupplyIndicator = renderQuantityIndicator(outboundBuy, 'supply')
+    const outboundDemandIndicator = renderQuantityIndicator(outboundSell, 'demand')
+    const returnSupplyIndicator = renderQuantityIndicator(returnBuy, 'supply')
+    const returnDemandIndicator = renderQuantityIndicator(returnSell, 'demand')
+    const indicatorPlaceholder = <span className={styles.tableIndicatorPlaceholder}>--</span>
+
+    const profitPerTon = formatCredits(route?.summary?.profitPerUnit ?? route?.profitPerUnit, route?.summary?.profitPerUnitText || route?.profitPerUnitText)
+    const profitPerTrip = formatCredits(route?.summary?.profitPerTrip, route?.summary?.profitPerTripText)
+    const profitPerHour = formatCredits(route?.summary?.profitPerHour, route?.summary?.profitPerHourText)
+    const routeDistanceDisplay = formatSystemDistance(route?.summary?.routeDistanceLy ?? route?.summary?.distanceLy ?? route?.distanceLy ?? route?.distance, route?.summary?.routeDistanceText || route?.summary?.distanceText || route?.distanceDisplay)
+    const systemDistanceDisplay = formatSystemDistance(route?.summary?.distanceLy ?? route?.distanceLy ?? route?.distance, route?.summary?.distanceText || route?.distanceDisplay)
+    const updatedDisplay = formatRelativeTime(route?.summary?.updated || route?.updatedAt || route?.lastUpdated || route?.timestamp)
+
+    const originIconName = getStationIconName(originLocal, route?.origin)
+    const destinationIconName = getStationIconName(destinationLocal, route?.destination)
+
+    const standingFallback = text => (
+      <span style={{ color: 'var(--ghostnet-subdued)', fontWeight: 600 }}>{text}</span>
+    )
+
+    const originStanding = originStandingStatusText
+      ? (
+        <span
+          className={originStationClassName}
+          title={originStationTitle}
+          style={{ fontWeight: 600, color: originStationColor }}
+        >
+          {originStandingStatusText}
+        </span>
+        )
+      : standingFallback(originFactionName ? 'No local standing data' : 'Not available')
+
+    const destinationStanding = destinationStandingStatusText
+      ? (
+        <span
+          className={destinationStationClassName}
+          title={destinationStationTitle}
+          style={{ fontWeight: 600, color: destinationStationColor }}
+        >
+          {destinationStandingStatusText}
+        </span>
+        )
+      : standingFallback(destinationFactionName ? 'No local standing data' : 'Not available')
+
+    const metrics = [
+      { label: 'Profit/Ton', value: profitPerTon || '--' },
+      { label: 'Profit/Trip', value: profitPerTrip || '--' },
+      { label: 'Profit/Hour', value: profitPerHour || '--' },
+      { label: 'Route Distance', value: routeDistanceDisplay || '--' },
+      { label: 'System Distance', value: systemDistanceDisplay || '--' },
+      { label: 'Updated', value: updatedDisplay || '--' }
+    ]
+
+    return (
+      <div className={styles.routeDetailContainer}>
+        <div className={styles.routeDetailHeader}>
+          <button type='button' className={styles.routeDetailBackButton} onClick={handleDetailClose}>
+            <span aria-hidden='true'>{String.fromCharCode(0x2039)}</span>
+            <span>Back to routes</span>
+          </button>
+          <div className={styles.routeDetailHeading}>
+            <span className={styles.routeDetailLabel}>Trade Route Intel</span>
+            <h3 className={styles.routeDetailTitle}>
+              {originStation}
+              <span className={styles.routeDetailDivider}>{String.fromCharCode(0x279E)}</span>
+              {destinationStation}
+            </h3>
+            <p className={styles.routeDetailSubhead}>
+              {originSystemName || 'Unknown system'}
+              <span className={styles.routeDetailArrow} aria-hidden='true'>{String.fromCharCode(0x2192)}</span>
+              {destinationSystemName || 'Unknown system'}
+            </p>
+          </div>
+          <div className={styles.routeDetailMeta}>
+            <span className={styles.routeDetailMetaLabel}>Last Update</span>
+            <span className={styles.routeDetailMetaValue}>{updatedDisplay || '--'}</span>
+          </div>
+        </div>
+        <div className={styles.routeDetailMetrics}>
+          {metrics.map(metric => (
+            <div key={metric.label} className={styles.routeDetailMetric}>
+              <span className={styles.routeDetailMetricLabel}>{metric.label}</span>
+              <span className={styles.routeDetailMetricValue}>{metric.value}</span>
+            </div>
+          ))}
+        </div>
+        <div className={styles.routeDetailGrid}>
+          <div className={styles.routeDetailPanel}>
+            <div className={styles.routeDetailPanelHeader}>
+              <span className={styles.routeDetailPanelLabel}>Origin</span>
+              <div className={styles.routeDetailStation}>
+                {originIconName && <StationIcon icon={originIconName} color={originStationColor} />}
+                <div className={styles.routeDetailStationInfo}>
+                  <span className={styles.routeDetailStationName}>{originStation}</span>
+                  <span className={styles.routeDetailSystem}>{originSystemName || 'Unknown system'}</span>
+                </div>
+              </div>
+            </div>
+            <div className={styles.routeDetailInfoRow}>
+              <span className={styles.routeDetailInfoLabel}>Faction</span>
+              <span className={styles.routeDetailInfoValue}>
+                <span
+                  className={originFactionName ? originStationClassName : undefined}
+                  style={originFactionName ? { fontWeight: 600, color: originStationColor } : undefined}
+                  title={originStationTitle}
+                >
+                  {originFactionName || 'Unknown faction'}
+                </span>
+              </span>
+            </div>
+            <div className={styles.routeDetailInfoRow}>
+              <span className={styles.routeDetailInfoLabel}>Standing</span>
+              <span className={styles.routeDetailInfoValue}>{originStanding}</span>
+            </div>
+            <div className={styles.routeDetailInfoRow}>
+              <span className={styles.routeDetailInfoLabel}>Outbound Supply</span>
+              <span className={styles.routeDetailInfoValue}>{outboundSupplyIndicator || indicatorPlaceholder}</span>
+            </div>
+            <div className={styles.routeDetailInfoRow}>
+              <span className={styles.routeDetailInfoLabel}>Return Demand</span>
+              <span className={styles.routeDetailInfoValue}>{returnDemandIndicator || indicatorPlaceholder}</span>
+            </div>
+            <div className={styles.routeDetailDividerLine} />
+            <div className={styles.routeDetailCommodity}>
+              <span className={styles.routeDetailCommodityLabel}>Outbound Commodity</span>
+              <span className={styles.routeDetailCommodityValue}>{outboundCommodity || '--'}</span>
+              <div className={styles.routeDetailPriceRow}>
+                <span>Buy: {outboundBuy?.priceText || '--'}</span>
+                <span>Sell: {outboundSell?.priceText || '--'}</span>
+              </div>
+            </div>
+          </div>
+          <div className={styles.routeDetailPanel}>
+            <div className={styles.routeDetailPanelHeader}>
+              <span className={styles.routeDetailPanelLabel}>Destination</span>
+              <div className={styles.routeDetailStation}>
+                {destinationIconName && <StationIcon icon={destinationIconName} color={destinationStationColor} />}
+                <div className={styles.routeDetailStationInfo}>
+                  <span className={styles.routeDetailStationName}>{destinationStation}</span>
+                  <span className={styles.routeDetailSystem}>{destinationSystemName || 'Unknown system'}</span>
+                </div>
+              </div>
+            </div>
+            <div className={styles.routeDetailInfoRow}>
+              <span className={styles.routeDetailInfoLabel}>Faction</span>
+              <span className={styles.routeDetailInfoValue}>
+                <span
+                  className={destinationFactionName ? destinationStationClassName : undefined}
+                  style={destinationFactionName ? { fontWeight: 600, color: destinationStationColor } : undefined}
+                  title={destinationStationTitle}
+                >
+                  {destinationFactionName || 'Unknown faction'}
+                </span>
+              </span>
+            </div>
+            <div className={styles.routeDetailInfoRow}>
+              <span className={styles.routeDetailInfoLabel}>Standing</span>
+              <span className={styles.routeDetailInfoValue}>{destinationStanding}</span>
+            </div>
+            <div className={styles.routeDetailInfoRow}>
+              <span className={styles.routeDetailInfoLabel}>Outbound Demand</span>
+              <span className={styles.routeDetailInfoValue}>{outboundDemandIndicator || indicatorPlaceholder}</span>
+            </div>
+            <div className={styles.routeDetailInfoRow}>
+              <span className={styles.routeDetailInfoLabel}>Return Supply</span>
+              <span className={styles.routeDetailInfoValue}>{returnSupplyIndicator || indicatorPlaceholder}</span>
+            </div>
+            <div className={styles.routeDetailDividerLine} />
+            <div className={styles.routeDetailCommodity}>
+              <span className={styles.routeDetailCommodityLabel}>Return Commodity</span>
+              <span className={styles.routeDetailCommodityValue}>{returnCommodity || '--'}</span>
+              <div className={styles.routeDetailPriceRow}>
+                <span>Buy: {returnBuy?.priceText || '--'}</span>
+                <span>Sell: {returnSell?.priceText || '--'}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const detailViewActive = Boolean(selectedRouteContext?.route)
+
   return (
     <section className={styles.tableSection}>
       <div className={styles.tableSectionHeader}>
         <h2 className={styles.tableSectionTitle}>Find Trade Routes</h2>
         <p className={styles.sectionHint}>Cross-reference GHOSTNET freight whispers to surface lucrative corridors suited to your ship profile.</p>
-        <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
-          <div>
-            <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
-            <div className='text-primary' style={CURRENT_SYSTEM_NAME_STYLE}>
-              {selectedSystemName || 'Unknown'}
+        {!detailViewActive && (
+          <>
+            <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
+              <div>
+                <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
+                <div className='text-primary' style={CURRENT_SYSTEM_NAME_STYLE}>
+                  {selectedSystemName || 'Unknown'}
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <form onSubmit={handleSubmit} style={FILTER_FORM_STYLE}>
-          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '.85rem', marginBottom: filtersCollapsed ? '.75rem' : '1.5rem' }}>
-            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '.85rem', flexGrow: 1 }}>
-              <button
-                type='button'
-                onClick={() => setFiltersCollapsed(prev => !prev)}
-                style={FILTER_TOGGLE_BUTTON_STYLE}
-                aria-expanded={!filtersCollapsed}
-                aria-controls='trade-route-filters'
-              >
-                {filtersCollapsed ? 'Show Filters' : 'Hide Filters'}
-              </button>
-              {filtersCollapsed && (
-                <div style={FILTER_SUMMARY_STYLE}>
-                  <span style={FILTER_SUMMARY_TEXT_STYLE}>{filtersSummary}</span>
+            <form onSubmit={handleSubmit} style={FILTER_FORM_STYLE}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '.85rem', marginBottom: filtersCollapsed ? '.75rem' : '1.5rem' }}>
+                <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '.85rem', flexGrow: 1 }}>
                   <button
-                    type='submit'
-                    style={FILTER_SUMMARY_REFRESH_BUTTON_STYLE}
-                    title='Refresh trade routes'
-                    aria-label='Refresh trade routes'
+                    type='button'
+                    onClick={() => setFiltersCollapsed(prev => !prev)}
+                    style={FILTER_TOGGLE_BUTTON_STYLE}
+                    aria-expanded={!filtersCollapsed}
+                    aria-controls='trade-route-filters'
                   >
-                    <svg
-                      viewBox='0 0 24 24'
-                      focusable='false'
-                      aria-hidden='true'
-                      style={FILTER_SUMMARY_REFRESH_ICON_STYLE}
-                    >
-                      <path
-                        fill='currentColor'
-                        d='M17.65 6.35A7.95 7.95 0 0 0 12 4a8 8 0 1 0 7.9 9h-2A6 6 0 1 1 12 6a5.96 5.96 0 0 1 4.24 1.76L13 11h7V4z'
-                      />
-                    </svg>
+                    {filtersCollapsed ? 'Show Filters' : 'Hide Filters'}
                   </button>
+                  {filtersCollapsed && (
+                    <div style={FILTER_SUMMARY_STYLE}>
+                      <span style={FILTER_SUMMARY_TEXT_STYLE}>{filtersSummary}</span>
+                      <button
+                        type='submit'
+                        style={FILTER_SUMMARY_REFRESH_BUTTON_STYLE}
+                        title='Refresh trade routes'
+                        aria-label='Refresh trade routes'
+                      >
+                        <svg
+                          viewBox='0 0 24 24'
+                          focusable='false'
+                          aria-hidden='true'
+                          style={FILTER_SUMMARY_REFRESH_ICON_STYLE}
+                        >
+                          <path
+                            fill='currentColor'
+                            d='M17.65 6.35A7.95 7.95 0 0 0 12 4a8 8 0 1 0 7.9 9h-2A6 6 0 1 1 12 6a5.96 5.96 0 0 1 4.24 1.76L13 11h7V4z'
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+              {!filtersCollapsed && (
+                <div id='trade-route-filters' style={FILTERS_GRID_STYLE}>
+                  <div style={{ ...FILTER_FIELD_STYLE }}>
+                    <label style={FILTER_LABEL_STYLE}>Route Distance</label>
+                    <select
+                      value={routeDistance}
+                      onChange={event => setRouteDistance(event.target.value)}
+                      style={{ ...FILTER_CONTROL_STYLE }}
+                    >
+                      {routeDistanceOptions.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div style={{ ...FILTER_FIELD_STYLE }}>
+                    <label style={FILTER_LABEL_STYLE}>Max Price Age</label>
+                    <select
+                      value={priceAge}
+                      onChange={event => setPriceAge(event.target.value)}
+                      style={{ ...FILTER_CONTROL_STYLE }}
+                    >
+                      {priceAgeOptions.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div style={{ ...FILTER_FIELD_STYLE }}>
+                    <label style={FILTER_LABEL_STYLE}>Min Supply</label>
+                    <select
+                      value={minSupply}
+                      onChange={event => setMinSupply(event.target.value)}
+                      style={{ ...FILTER_CONTROL_STYLE }}
+                    >
+                      {supplyOptions.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div style={{ ...FILTER_FIELD_STYLE }}>
+                    <label style={FILTER_LABEL_STYLE}>Min Demand</label>
+                    <select
+                      value={minDemand}
+                      onChange={event => setMinDemand(event.target.value)}
+                      style={{ ...FILTER_CONTROL_STYLE }}
+                    >
+                      {demandOptions.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div style={{ ...FILTER_FIELD_STYLE }}>
+                    <label style={FILTER_LABEL_STYLE}>Surface Stations</label>
+                    <select
+                      value={surfacePreference}
+                      onChange={event => setSurfacePreference(event.target.value)}
+                      style={{ ...FILTER_CONTROL_STYLE }}
+                    >
+                      {surfaceOptions.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div style={{ ...FILTER_FIELD_STYLE }}>
+                    <label style={FILTER_LABEL_STYLE}>Station Distance</label>
+                    <select
+                      value={stationDistance}
+                      onChange={event => setStationDistance(event.target.value)}
+                      style={{ ...FILTER_CONTROL_STYLE }}
+                    >
+                      {stationDistanceOptions.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                  </div>
                 </div>
               )}
-            </div>
+            </form>
+          </>
+        )}
+      </div>
+      {detailViewActive ? (
+        <div className='ghostnet-panel-table'>
+          <div className={`scrollable ${styles.routeDetailScrollArea}`} style={TABLE_SCROLL_AREA_STYLE}>
+            {renderRouteDetailView()}
           </div>
-          {!filtersCollapsed && (
-            <div id='trade-route-filters' style={FILTERS_GRID_STYLE}>
-              <div style={{ ...FILTER_FIELD_STYLE }}>
-                <label style={FILTER_LABEL_STYLE}>Route Distance</label>
-                <select
-                  value={routeDistance}
-                  onChange={event => setRouteDistance(event.target.value)}
-                  style={{ ...FILTER_CONTROL_STYLE }}
-                >
-                  {routeDistanceOptions.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div style={{ ...FILTER_FIELD_STYLE }}>
-                <label style={FILTER_LABEL_STYLE}>Max Price Age</label>
-                <select
-                  value={priceAge}
-                  onChange={event => setPriceAge(event.target.value)}
-                  style={{ ...FILTER_CONTROL_STYLE }}
-                >
-                  {priceAgeOptions.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div style={{ ...FILTER_FIELD_STYLE }}>
-                <label style={FILTER_LABEL_STYLE}>Min Supply</label>
-                <select
-                  value={minSupply}
-                  onChange={event => setMinSupply(event.target.value)}
-                  style={{ ...FILTER_CONTROL_STYLE }}
-                >
-                  {supplyOptions.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div style={{ ...FILTER_FIELD_STYLE }}>
-                <label style={FILTER_LABEL_STYLE}>Min Demand</label>
-                <select
-                  value={minDemand}
-                  onChange={event => setMinDemand(event.target.value)}
-                  style={{ ...FILTER_CONTROL_STYLE }}
-                >
-                  {demandOptions.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div style={{ ...FILTER_FIELD_STYLE }}>
-                <label style={FILTER_LABEL_STYLE}>Surface Stations</label>
-                <select
-                  value={surfacePreference}
-                  onChange={event => setSurfacePreference(event.target.value)}
-                  style={{ ...FILTER_CONTROL_STYLE }}
-                >
-                  {surfaceOptions.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div style={{ ...FILTER_FIELD_STYLE }}>
-                <label style={FILTER_LABEL_STYLE}>Station Distance</label>
-                <select
-                  value={stationDistance}
-                  onChange={event => setStationDistance(event.target.value)}
-                  style={{ ...FILTER_CONTROL_STYLE }}
-                >
-                  {stationDistanceOptions.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
-            </div>
-          )}
-        </form>
-      </div>
-      <div className='ghostnet-panel-table'>
-        <div className='scrollable' style={TABLE_SCROLL_AREA_STYLE}>
-          {message && status !== 'idle' && status !== 'loading' && (
-            <div className={`${styles.tableMessage} ${status === 'populated' ? styles.tableMessageBorder : ''}`}>{message}</div>
-          )}
-          {status === 'idle' && (
-            <div className={styles.tableIdleState}>Tune the filters and pulse refresh to surface profitable corridors.</div>
-          )}
-          {status === 'loading' && (
-            <LoadingSpinner label='Loading trade routes…' />
-          )}
-          {status === 'error' && (
-            <div className={styles.tableErrorState}>{error || 'Unable to fetch trade routes.'}</div>
-          )}
-          {status === 'empty' && (
-            <div className={styles.tableEmptyState}>No profitable routes detected near {selectedSystemName || 'Unknown System'}.</div>
-          )}
-          {status === 'populated' && renderRoutesTable()}
         </div>
-      </div>
+      ) : (
+        <div className='ghostnet-panel-table'>
+          <div className='scrollable' style={TABLE_SCROLL_AREA_STYLE}>
+            {message && status !== 'idle' && status !== 'loading' && (
+              <div className={`${styles.tableMessage} ${status === 'populated' ? styles.tableMessageBorder : ''}`}>{message}</div>
+            )}
+            {status === 'idle' && (
+              <div className={styles.tableIdleState}>Tune the filters and pulse refresh to surface profitable corridors.</div>
+            )}
+            {status === 'loading' && (
+              <LoadingSpinner label='Loading trade routes…' />
+            )}
+            {status === 'error' && (
+              <div className={styles.tableErrorState}>{error || 'Unable to fetch trade routes.'}</div>
+            )}
+            {status === 'empty' && (
+              <div className={styles.tableEmptyState}>No profitable routes detected near {selectedSystemName || 'Unknown System'}.</div>
+            )}
+            {status === 'populated' && renderRoutesTable()}
+          </div>
+        </div>
+      )}
     </section>
   )
 }

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -2317,7 +2317,32 @@ function TradeRoutesPanel () {
     refreshRoutes(currentName)
   }, [currentSystem?.name, refreshRoutes])
 
-  useEffect(() => animateTableEffect(), [routes])
+  const detailViewActive = Boolean(selectedRouteContext?.route)
+
+  useEffect(() => {
+    if (detailViewActive) return
+
+    if (typeof window === 'undefined') {
+      animateTableEffect()
+      return
+    }
+
+    if (typeof window.requestAnimationFrame !== 'function') {
+      animateTableEffect()
+      return
+    }
+
+    let frameId = window.requestAnimationFrame(() => {
+      frameId = null
+      animateTableEffect()
+    })
+
+    return () => {
+      if (frameId !== null && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(frameId)
+      }
+    }
+  }, [routes, detailViewActive])
 
   const renderRoutesTable = () => (
     <div className={styles.dataTableContainer}>
@@ -2694,8 +2719,6 @@ function TradeRoutesPanel () {
       </div>
     )
   }
-
-  const detailViewActive = Boolean(selectedRouteContext?.route)
 
   return (
     <section className={styles.tableSection}>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -680,6 +680,320 @@
   font-size: 0.82rem;
 }
 
+.routeDetailScrollArea {
+  padding: 2.25rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.routeDetailContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.routeDetailHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.75rem 2rem;
+  background: linear-gradient(135deg, rgba(45, 25, 98, 0.85), rgba(26, 17, 60, 0.9));
+  border: 1px solid rgba(140, 92, 255, 0.38);
+  border-radius: 1.25rem;
+  box-shadow: 0 1.5rem 3rem rgba(5, 8, 13, 0.55);
+}
+
+.routeDetailBackButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(140, 92, 255, 0.55);
+  background: linear-gradient(135deg, rgba(93, 46, 255, 0.62), rgba(140, 92, 255, 0.4));
+  color: #f5f1ff;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.66rem;
+  cursor: pointer;
+  transition: background 200ms ease, box-shadow 200ms ease, transform 200ms ease;
+  text-shadow: 0 0 14px rgba(93, 46, 255, 0.45);
+}
+
+.routeDetailBackButton:hover,
+.routeDetailBackButton:focus-visible {
+  background: linear-gradient(135deg, rgba(117, 70, 255, 0.8), rgba(140, 92, 255, 0.55));
+  transform: translateY(-1px);
+  box-shadow: 0 0 18px rgba(93, 46, 255, 0.4);
+}
+
+.routeDetailBackButton:focus-visible {
+  outline: 2px solid #29f3c3;
+  outline-offset: 3px;
+}
+
+.routeDetailBackButton:active {
+  background: linear-gradient(135deg, rgba(42, 14, 130, 0.75), rgba(93, 46, 255, 0.5));
+  transform: translateY(1px);
+  box-shadow: 0 0 12px rgba(42, 14, 130, 0.48);
+}
+
+.routeDetailHeading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: center;
+  flex: 1;
+}
+
+.routeDetailLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.68rem;
+  color: rgba(245, 241, 255, 0.7);
+}
+
+.routeDetailTitle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.85rem;
+  font-size: 1.65rem;
+  color: #f5f1ff;
+  text-shadow: 0 0 14px rgba(93, 46, 255, 0.45);
+  margin: 0;
+}
+
+.routeDetailDivider {
+  color: #29f3c3;
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.routeDetailSubhead {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin: 0;
+  font-size: 0.92rem;
+  color: rgba(245, 241, 255, 0.74);
+}
+
+.routeDetailArrow {
+  color: rgba(245, 241, 255, 0.6);
+  font-size: 1.1rem;
+}
+
+.routeDetailMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 160px;
+  padding: 0.9rem 1.25rem;
+  border-radius: 1rem;
+  background: rgba(35, 20, 68, 0.85);
+  border: 1px solid rgba(140, 92, 255, 0.35);
+  color: rgba(245, 241, 255, 0.78);
+}
+
+.routeDetailMetaLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.65rem;
+  color: rgba(245, 241, 255, 0.6);
+}
+
+.routeDetailMetaValue {
+  font-size: 0.98rem;
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+  color: #f5f1ff;
+}
+
+.routeDetailMetrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+}
+
+.routeDetailMetric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1.15rem 1.35rem;
+  border-radius: 1.1rem;
+  background: rgba(22, 15, 44, 0.92);
+  border: 1px solid rgba(140, 92, 255, 0.32);
+  box-shadow: 0 1.2rem 2.4rem rgba(4, 7, 12, 0.55);
+}
+
+.routeDetailMetricLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.68rem;
+  color: rgba(245, 241, 255, 0.62);
+}
+
+.routeDetailMetricValue {
+  font-size: 1.05rem;
+  color: #f5f1ff;
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+}
+
+.routeDetailGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.75rem;
+}
+
+.routeDetailPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.75rem 1.9rem;
+  background: rgba(12, 10, 28, 0.92);
+  border: 1px solid rgba(140, 92, 255, 0.32);
+  border-radius: 1.25rem;
+  box-shadow: 0 1.45rem 2.8rem rgba(4, 7, 12, 0.55);
+}
+
+.routeDetailPanelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.routeDetailPanelLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.68rem;
+  color: rgba(245, 241, 255, 0.62);
+}
+
+.routeDetailStation {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.routeDetailStation :global(svg) {
+  width: 1.65rem;
+  height: 1.65rem;
+}
+
+.routeDetailStationInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.routeDetailStationName {
+  font-size: 1.05rem;
+  color: #f5f1ff;
+  font-weight: 600;
+}
+
+.routeDetailSystem {
+  font-size: 0.85rem;
+  color: rgba(245, 241, 255, 0.62);
+}
+
+.routeDetailInfoRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  color: rgba(245, 241, 255, 0.78);
+  font-size: 0.92rem;
+}
+
+.routeDetailInfoLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  color: rgba(245, 241, 255, 0.58);
+}
+
+.routeDetailInfoValue {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 500;
+}
+
+.routeDetailDividerLine {
+  height: 1px;
+  width: 100%;
+  background: rgba(140, 92, 255, 0.25);
+  margin: 0.5rem 0 0.75rem;
+}
+
+.routeDetailCommodity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: rgba(245, 241, 255, 0.84);
+}
+
+.routeDetailCommodityLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.68rem;
+  color: rgba(245, 241, 255, 0.6);
+}
+
+.routeDetailCommodityValue {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #f5f1ff;
+}
+
+.routeDetailPriceRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  font-size: 0.88rem;
+  color: rgba(245, 241, 255, 0.74);
+}
+
+@media (max-width: 1100px) {
+  .routeDetailHeader {
+    padding: 1.5rem;
+  }
+
+  .routeDetailGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .routeDetailScrollArea {
+    padding: 1.75rem 1.4rem;
+  }
+
+  .routeDetailHeader {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .routeDetailHeading {
+    align-items: center;
+  }
+
+  .routeDetailMeta {
+    align-self: center;
+  }
+
+  .routeDetailMetrics {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+}
+
 .tableEntry {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- replace the expandable trade route rows with a full-page detail view that opens when a route is selected
- add a dedicated route detail layout with back navigation, route metrics, and origin/destination breakdowns
- style the new detail surface to match the GhostNet theme and hide the filters while the detail view is active

## Testing
- `npm test -- --runInBand` *(fails: jest not installed in environment)*
- `npm run build:client` *(fails: next not installed in environment)*
- `npm run start` *(fails: missing dotenv dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68de933410e88323bde818f7b5caf573