### PR TITLE
Centralize GhostNet color palette definitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@
 - Keep the GhostNet palette constrained to the core tokens defined in `src/client/css/pages/ghostnet.css`.
 - When a design needs subtle variation, derive it with opacity or other modifiers from the shared tokens instead of introducing new hex values.
 - Avoid dumping long lists of bespoke color variables into module files; rely on the shared palette for consistency and easier maintenance.
+- Declare each palette token with a single color format (hex **or** rgb, not both) and document its primary usage with a block comment so future contributors understand the intent.
+- Keep gradients lightweight—prefer blending a small number of shared tokens with transparency rather than stacking many distinct color stops.
 
 ### GhostNet Purple Theme Specification
 - **Primary hue:** GhostNet surfaces should lean on a rich royal purple (`#5D2EFF`) for primary actions, interactive accents, and key highlights.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,11 @@
 - Keep data tables outside of `SectionFrame` containers; tables should rely on GhostNet table shells (`dataTableContainer`, `dataTable`) for structure instead of being nested inside section frames.
 - Table rows must never expand inline like a drawer. Selecting a row should always open a dedicated full-page view in the workspace, mirroring the behavior on the Find Trade Routes page. This ensures a clean experience on smaller displays.
 
+### Palette hygiene
+- Keep the GhostNet palette constrained to the core tokens defined in `src/client/css/pages/ghostnet.css`.
+- When a design needs subtle variation, derive it with opacity or other modifiers from the shared tokens instead of introducing new hex values.
+- Avoid dumping long lists of bespoke color variables into module files; rely on the shared palette for consistency and easier maintenance.
+
 ### GhostNet Purple Theme Specification
 - **Primary hue:** GhostNet surfaces should lean on a rich royal purple (`#5D2EFF`) for primary actions, interactive accents, and key highlights.
 - **Gradient treatments:** When gradients are needed, blend from the primary hue into a deeper indigo (`#2A0E82`) and finish with a soft ultraviolet (`#8C5CFF`) to preserve depth.

--- a/src/client/css/pages/ghostnet.css
+++ b/src/client/css/pages/ghostnet.css
@@ -1,28 +1,35 @@
 :root {
-  --ghostnet-spinner-text: #aaa;
-  --ghostnet-spinner-inline-text: #888;
-  --ghostnet-spinner-border: rgba(255, 255, 255, 0.15);
-  --ghostnet-inspector-border: rgba(216, 180, 254, 0.28);
-  --ghostnet-inspector-gradient-start: rgba(12, 16, 26, 0.95);
-  --ghostnet-inspector-gradient-end: rgba(7, 11, 20, 0.92);
-  --ghostnet-inspector-shadow: rgba(3, 7, 12, 0.72);
-  --ghostnet-inspector-header-bg: rgba(41, 24, 89, 0.85);
-  --ghostnet-inspector-header-border: rgba(140, 92, 255, 0.35);
-  --ghostnet-status-background: rgba(5, 8, 13, 0.88);
-  --ghostnet-status-border: rgba(140, 92, 255, 0.28);
-  --ghostnet-status-error-text: #ff5fc1;
-  --ghostnet-status-error-border: rgba(255, 95, 193, 0.45);
-  --ghostnet-status-error-background: rgba(255, 95, 193, 0.12);
-  --ghostnet-belt-ring-outer: rgba(93, 46, 255, 0.35);
-  --ghostnet-belt-ring-inner: rgba(140, 92, 255, 0.28);
-  --ghostnet-belt-dust: rgba(93, 46, 255, 0.18);
+  /* GhostNet core palette */
+  --ghostnet-color-background: #05080d;
+  --ghostnet-color-background-rgb: 5, 8, 13;
+  --ghostnet-color-surface: #1c1633;
+  --ghostnet-color-surface-rgb: 28, 22, 51;
+  --ghostnet-color-primary: #5d2eff;
+  --ghostnet-color-primary-rgb: 93, 46, 255;
+  --ghostnet-color-primary-dark: #2a0e82;
+  --ghostnet-color-primary-dark-rgb: 42, 14, 130;
+  --ghostnet-color-primary-light: #8c5cff;
+  --ghostnet-color-text-strong: #f5f1ff;
+  --ghostnet-color-text-strong-rgb: 245, 241, 255;
+  --ghostnet-color-text-muted: rgba(245, 241, 255, 0.84);
+  --ghostnet-color-success: #29f3c3;
+  --ghostnet-color-success-rgb: 41, 243, 195;
+  --ghostnet-color-warning: #ff5fc1;
+  --ghostnet-color-warning-rgb: 255, 95, 193;
+  --ghostnet-color-border-soft: rgba(140, 92, 255, 0.28);
+  --ghostnet-color-border: rgba(140, 92, 255, 0.35);
+  --ghostnet-color-border-strong: rgba(140, 92, 255, 0.55);
+  --ghostnet-color-shadow: rgba(13, 11, 26, 0.55);
+  --ghostnet-color-shadow-deep: rgba(5, 8, 13, 0.68);
+  --ghostnet-color-glow: rgba(93, 46, 255, 0.36);
+  --ghostnet-color-divider: rgba(245, 241, 255, 0.16);
 }
 
 .ghostnet-spinner {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  color: var(--ghostnet-spinner-text);
+  color: var(--ghostnet-color-text-muted);
 }
 
 .ghostnet-spinner--block {
@@ -34,15 +41,15 @@
   justify-content: flex-start;
   padding: 0;
   font-size: 0.9rem;
-  color: var(--ghostnet-spinner-inline-text);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
 }
 
 .ghostnet-spinner__icon {
   width: 1.5rem;
   height: 1.5rem;
   border-radius: 50%;
-  border: 2px solid var(--ghostnet-spinner-border);
-  border-top-color: var(--color-primary);
+  border: 2px solid rgba(var(--ghostnet-color-text-strong-rgb), 0.18);
+  border-top-color: var(--ghostnet-color-primary);
   animation: ghostnet-spinner-rotate 0.85s linear infinite;
 }
 
@@ -111,14 +118,14 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
-  border: 1px solid var(--ghostnet-inspector-border);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.28);
   border-radius: 1rem;
   background: linear-gradient(
     180deg,
-    var(--ghostnet-inspector-gradient-start) 0%,
-    var(--ghostnet-inspector-gradient-end) 100%
+    rgba(var(--ghostnet-color-surface-rgb), 0.95) 0%,
+    rgba(var(--ghostnet-color-background-rgb), 0.92) 100%
   );
-  box-shadow: 0 1.35rem 3rem var(--ghostnet-inspector-shadow);
+  box-shadow: 0 1.35rem 3rem rgba(var(--ghostnet-color-background-rgb), 0.72);
   overflow: hidden;
   padding: 0;
   box-sizing: border-box;
@@ -130,9 +137,9 @@
   width: 100%;
   height: auto;
   padding: 0.75rem 1rem 0.75rem 2.75rem;
-  background: var(--ghostnet-inspector-header-bg);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.25);
   color: var(--ghostnet-ink);
-  border-bottom: 1px solid var(--ghostnet-inspector-header-border);
+  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.35);
   border-radius: 1rem 1rem 0 0;
 }
 
@@ -157,8 +164,8 @@
 .pristine-mining__inspector-status {
   align-self: flex-start;
   width: 100%;
-  background: var(--ghostnet-status-background);
-  border: 1px solid var(--ghostnet-status-border);
+  background: rgba(var(--ghostnet-color-background-rgb), 0.88);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.28);
   border-radius: 1rem;
   padding: 1rem 1.25rem;
   color: var(--ghostnet-muted);
@@ -167,9 +174,9 @@
 }
 
 .pristine-mining__inspector-status--error {
-  color: var(--ghostnet-status-error-text);
-  border-color: var(--ghostnet-status-error-border);
-  background: var(--ghostnet-status-error-background);
+  color: var(--ghostnet-color-warning);
+  border-color: rgba(var(--ghostnet-color-warning-rgb), 0.45);
+  background: rgba(var(--ghostnet-color-warning-rgb), 0.12);
 }
 
 .pristine-mining__inspector .navigation-panel__inspector {

--- a/src/client/css/pages/ghostnet.css
+++ b/src/client/css/pages/ghostnet.css
@@ -1,35 +1,27 @@
 :root {
-  /* GhostNet core palette */
+  /* Base workspace backdrop for the GhostNet canvas */
   --ghostnet-color-background: #05080d;
-  --ghostnet-color-background-rgb: 5, 8, 13;
+  /* Elevated panels and cards that sit above the canvas */
   --ghostnet-color-surface: #1c1633;
-  --ghostnet-color-surface-rgb: 28, 22, 51;
+  /* Primary GhostNet accent for CTAs and key highlights */
   --ghostnet-color-primary: #5d2eff;
-  --ghostnet-color-primary-rgb: 93, 46, 255;
+  /* Shadowed accent used for depth, pressed, and terminal rails */
   --ghostnet-color-primary-dark: #2a0e82;
-  --ghostnet-color-primary-dark-rgb: 42, 14, 130;
+  /* Highlight accent for edges, glows, and lighter gradient stops */
   --ghostnet-color-primary-light: #8c5cff;
+  /* High-contrast text and icon color on dark grounds */
   --ghostnet-color-text-strong: #f5f1ff;
-  --ghostnet-color-text-strong-rgb: 245, 241, 255;
-  --ghostnet-color-text-muted: rgba(245, 241, 255, 0.84);
+  /* Success feedback for confirmations and positive states */
   --ghostnet-color-success: #29f3c3;
-  --ghostnet-color-success-rgb: 41, 243, 195;
+  /* Warning and error feedback across the GhostNet UI */
   --ghostnet-color-warning: #ff5fc1;
-  --ghostnet-color-warning-rgb: 255, 95, 193;
-  --ghostnet-color-border-soft: rgba(140, 92, 255, 0.28);
-  --ghostnet-color-border: rgba(140, 92, 255, 0.35);
-  --ghostnet-color-border-strong: rgba(140, 92, 255, 0.55);
-  --ghostnet-color-shadow: rgba(13, 11, 26, 0.55);
-  --ghostnet-color-shadow-deep: rgba(5, 8, 13, 0.68);
-  --ghostnet-color-glow: rgba(93, 46, 255, 0.36);
-  --ghostnet-color-divider: rgba(245, 241, 255, 0.16);
 }
 
 .ghostnet-spinner {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  color: var(--ghostnet-color-text-muted);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
 }
 
 .ghostnet-spinner--block {
@@ -41,14 +33,14 @@
   justify-content: flex-start;
   padding: 0;
   font-size: 0.9rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
 }
 
 .ghostnet-spinner__icon {
   width: 1.5rem;
   height: 1.5rem;
   border-radius: 50%;
-  border: 2px solid rgba(var(--ghostnet-color-text-strong-rgb), 0.18);
+  border: 2px solid color-mix(in srgb, var(--ghostnet-color-text-strong) 18%, transparent);
   border-top-color: var(--ghostnet-color-primary);
   animation: ghostnet-spinner-rotate 0.85s linear infinite;
 }
@@ -118,14 +110,14 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.28);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
   border-radius: 1rem;
   background: linear-gradient(
     180deg,
-    rgba(var(--ghostnet-color-surface-rgb), 0.95) 0%,
-    rgba(var(--ghostnet-color-background-rgb), 0.92) 100%
+    color-mix(in srgb, var(--ghostnet-color-surface) 95%, transparent) 0%,
+    color-mix(in srgb, var(--ghostnet-color-background) 92%, transparent) 100%
   );
-  box-shadow: 0 1.35rem 3rem rgba(var(--ghostnet-color-background-rgb), 0.72);
+  box-shadow: 0 1.35rem 3rem color-mix(in srgb, var(--ghostnet-color-background) 72%, transparent);
   overflow: hidden;
   padding: 0;
   box-sizing: border-box;
@@ -137,9 +129,9 @@
   width: 100%;
   height: auto;
   padding: 0.75rem 1rem 0.75rem 2.75rem;
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.25);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
   color: var(--ghostnet-ink);
-  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.35);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
   border-radius: 1rem 1rem 0 0;
 }
 
@@ -164,8 +156,8 @@
 .pristine-mining__inspector-status {
   align-self: flex-start;
   width: 100%;
-  background: rgba(var(--ghostnet-color-background-rgb), 0.88);
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.28);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
   border-radius: 1rem;
   padding: 1rem 1.25rem;
   color: var(--ghostnet-muted);
@@ -175,8 +167,8 @@
 
 .pristine-mining__inspector-status--error {
   color: var(--ghostnet-color-warning);
-  border-color: rgba(var(--ghostnet-color-warning-rgb), 0.45);
-  background: rgba(var(--ghostnet-color-warning-rgb), 0.12);
+  border-color: color-mix(in srgb, var(--ghostnet-color-warning) 45%, transparent);
+  background: color-mix(in srgb, var(--ghostnet-color-warning) 12%, transparent);
 }
 
 .pristine-mining__inspector .navigation-panel__inspector {

--- a/src/client/css/pages/ghostnet.css
+++ b/src/client/css/pages/ghostnet.css
@@ -1,8 +1,28 @@
+:root {
+  --ghostnet-spinner-text: #aaa;
+  --ghostnet-spinner-inline-text: #888;
+  --ghostnet-spinner-border: rgba(255, 255, 255, 0.15);
+  --ghostnet-inspector-border: rgba(216, 180, 254, 0.28);
+  --ghostnet-inspector-gradient-start: rgba(12, 16, 26, 0.95);
+  --ghostnet-inspector-gradient-end: rgba(7, 11, 20, 0.92);
+  --ghostnet-inspector-shadow: rgba(3, 7, 12, 0.72);
+  --ghostnet-inspector-header-bg: rgba(41, 24, 89, 0.85);
+  --ghostnet-inspector-header-border: rgba(140, 92, 255, 0.35);
+  --ghostnet-status-background: rgba(5, 8, 13, 0.88);
+  --ghostnet-status-border: rgba(140, 92, 255, 0.28);
+  --ghostnet-status-error-text: #ff5fc1;
+  --ghostnet-status-error-border: rgba(255, 95, 193, 0.45);
+  --ghostnet-status-error-background: rgba(255, 95, 193, 0.12);
+  --ghostnet-belt-ring-outer: rgba(93, 46, 255, 0.35);
+  --ghostnet-belt-ring-inner: rgba(140, 92, 255, 0.28);
+  --ghostnet-belt-dust: rgba(93, 46, 255, 0.18);
+}
+
 .ghostnet-spinner {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  color: #aaa;
+  color: var(--ghostnet-spinner-text);
 }
 
 .ghostnet-spinner--block {
@@ -14,14 +34,14 @@
   justify-content: flex-start;
   padding: 0;
   font-size: 0.9rem;
-  color: #888;
+  color: var(--ghostnet-spinner-inline-text);
 }
 
 .ghostnet-spinner__icon {
   width: 1.5rem;
   height: 1.5rem;
   border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.15);
+  border: 2px solid var(--ghostnet-spinner-border);
   border-top-color: var(--color-primary);
   animation: ghostnet-spinner-rotate 0.85s linear infinite;
 }
@@ -91,10 +111,14 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
-  border: 1px solid rgba(216, 180, 254, 0.28);
+  border: 1px solid var(--ghostnet-inspector-border);
   border-radius: 1rem;
-  background: linear-gradient(180deg, rgba(12, 16, 26, 0.95) 0%, rgba(7, 11, 20, 0.92) 100%);
-  box-shadow: 0 1.35rem 3rem rgba(3, 7, 12, 0.72);
+  background: linear-gradient(
+    180deg,
+    var(--ghostnet-inspector-gradient-start) 0%,
+    var(--ghostnet-inspector-gradient-end) 100%
+  );
+  box-shadow: 0 1.35rem 3rem var(--ghostnet-inspector-shadow);
   overflow: hidden;
   padding: 0;
   box-sizing: border-box;
@@ -106,9 +130,9 @@
   width: 100%;
   height: auto;
   padding: 0.75rem 1rem 0.75rem 2.75rem;
-  background: rgba(41, 24, 89, 0.85);
+  background: var(--ghostnet-inspector-header-bg);
   color: var(--ghostnet-ink);
-  border-bottom: 1px solid rgba(140, 92, 255, 0.35);
+  border-bottom: 1px solid var(--ghostnet-inspector-header-border);
   border-radius: 1rem 1rem 0 0;
 }
 
@@ -133,8 +157,8 @@
 .pristine-mining__inspector-status {
   align-self: flex-start;
   width: 100%;
-  background: rgba(5, 8, 13, 0.88);
-  border: 1px solid rgba(140, 92, 255, 0.28);
+  background: var(--ghostnet-status-background);
+  border: 1px solid var(--ghostnet-status-border);
   border-radius: 1rem;
   padding: 1rem 1.25rem;
   color: var(--ghostnet-muted);
@@ -143,9 +167,9 @@
 }
 
 .pristine-mining__inspector-status--error {
-  color: #ff5fc1;
-  border-color: rgba(255, 95, 193, 0.45);
-  background: rgba(255, 95, 193, 0.12);
+  color: var(--ghostnet-status-error-text);
+  border-color: var(--ghostnet-status-error-border);
+  background: var(--ghostnet-status-error-background);
 }
 
 .pristine-mining__inspector .navigation-panel__inspector {
@@ -200,7 +224,7 @@
 }
 
 .pristine-mining__detail-status--error {
-  color: #ff5fc1;
+  color: var(--ghostnet-status-error-text);
 }
 
 .pristine-mining__detail-artwork {
@@ -242,15 +266,15 @@
 }
 
 .pristine-mining__belt-ring {
-  fill: rgba(93, 46, 255, 0.35);
+  fill: var(--ghostnet-belt-ring-outer);
 }
 
 .pristine-mining__belt-ring--inner {
-  fill: rgba(140, 92, 255, 0.28);
+  fill: var(--ghostnet-belt-ring-inner);
 }
 
 .pristine-mining__belt-dust {
-  fill: rgba(93, 46, 255, 0.18);
+  fill: var(--ghostnet-belt-dust);
 }
 
 @media (max-width: 1200px) {

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1,211 +1,31 @@
-:global(:root) {
-  /* GhostNet color palette */
-  --ghostnet-color-hex-05080d: #05080d;
-  --ghostnet-color-hex-060611: #060611;
-  --ghostnet-color-hex-080711: #080711;
-  --ghostnet-color-hex-0a0718: #0a0718;
-  --ghostnet-color-hex-0f0720: #0f0720;
-  --ghostnet-color-hex-120804: #120804;
-  --ghostnet-color-hex-150a02: #150a02;
-  --ghostnet-color-hex-29f3c3: #29f3c3;
-  --ghostnet-color-hex-5bd1a5: #5bd1a5;
-  --ghostnet-color-hex-6c7c92: #6c7c92;
-  --ghostnet-color-hex-8da2bf: #8da2bf;
-  --ghostnet-color-hex-aaa: #aaa;
-  --ghostnet-color-hex-d8b4fe: #d8b4fe;
-  --ghostnet-color-hex-d8e9ff: #d8e9ff;
-  --ghostnet-color-hex-e0c8ff: #e0c8ff;
-  --ghostnet-color-hex-f0b8ff: #f0b8ff;
-  --ghostnet-color-hex-f5f1ff: #f5f1ff;
-  --ghostnet-color-hex-f6e9ff: #f6e9ff;
-  --ghostnet-color-hex-ff4d4f: #ff4d4f;
-  --ghostnet-color-hex-ff5fc1: #ff5fc1;
-  --ghostnet-color-hex-ffb874: #ffb874;
-  --ghostnet-color-hex-ffe8c9: #ffe8c9;
-  --ghostnet-color-rgba-10-15-22-0-88: rgba(10, 15, 22, 0.88);
-  --ghostnet-color-rgba-10-6-18-0-3: rgba(10, 6, 18, 0.3);
-  --ghostnet-color-rgba-10-6-2-0-94: rgba(10, 6, 2, 0.94);
-  --ghostnet-color-rgba-117-70-255-0-8: rgba(117, 70, 255, 0.8);
-  --ghostnet-color-rgba-117-70-255-0-85: rgba(117, 70, 255, 0.85);
-  --ghostnet-color-rgba-12-10-28-0-92: rgba(12, 10, 28, 0.92);
-  --ghostnet-color-rgba-120-140-168-0-75: rgba(120, 140, 168, 0.75);
-  --ghostnet-color-rgba-120-192-255-0-16: rgba(120, 192, 255, 0.16);
-  --ghostnet-color-rgba-120-192-255-0-18: rgba(120, 192, 255, 0.18);
-  --ghostnet-color-rgba-120-192-255-0-22: rgba(120, 192, 255, 0.22);
-  --ghostnet-color-rgba-13-11-26-0-55: rgba(13, 11, 26, 0.55);
-  --ghostnet-color-rgba-13-11-26-0-75: rgba(13, 11, 26, 0.75);
-  --ghostnet-color-rgba-13-11-26-0-85: rgba(13, 11, 26, 0.85);
-  --ghostnet-color-rgba-13-11-26-0-86: rgba(13, 11, 26, 0.86);
-  --ghostnet-color-rgba-13-11-26-0-94: rgba(13, 11, 26, 0.94);
-  --ghostnet-color-rgba-130-220-255-0-2: rgba(130, 220, 255, 0.2);
-  --ghostnet-color-rgba-14-8-26-0-75: rgba(14, 8, 26, 0.75);
-  --ghostnet-color-rgba-140-160-188-0-75: rgba(140, 160, 188, 0.75);
-  --ghostnet-color-rgba-140-160-188-0-78: rgba(140, 160, 188, 0.78);
-  --ghostnet-color-rgba-140-92-255-0-25: rgba(140, 92, 255, 0.25);
-  --ghostnet-color-rgba-140-92-255-0-28: rgba(140, 92, 255, 0.28);
-  --ghostnet-color-rgba-140-92-255-0-32: rgba(140, 92, 255, 0.32);
-  --ghostnet-color-rgba-140-92-255-0-35: rgba(140, 92, 255, 0.35);
-  --ghostnet-color-rgba-140-92-255-0-38: rgba(140, 92, 255, 0.38);
-  --ghostnet-color-rgba-140-92-255-0-4: rgba(140, 92, 255, 0.4);
-  --ghostnet-color-rgba-140-92-255-0-45: rgba(140, 92, 255, 0.45);
-  --ghostnet-color-rgba-140-92-255-0-48: rgba(140, 92, 255, 0.48);
-  --ghostnet-color-rgba-140-92-255-0-55: rgba(140, 92, 255, 0.55);
-  --ghostnet-color-rgba-140-92-255-0-6: rgba(140, 92, 255, 0.6);
-  --ghostnet-color-rgba-140-92-255-0-62: rgba(140, 92, 255, 0.62);
-  --ghostnet-color-rgba-140-92-255-0-65: rgba(140, 92, 255, 0.65);
-  --ghostnet-color-rgba-140-92-255-0-75: rgba(140, 92, 255, 0.75);
-  --ghostnet-color-rgba-140-92-255-0-85: rgba(140, 92, 255, 0.85);
-  --ghostnet-color-rgba-140-92-255-0-95: rgba(140, 92, 255, 0.95);
-  --ghostnet-color-rgba-16-9-38-0-7: rgba(16, 9, 38, 0.7);
-  --ghostnet-color-rgba-16-9-38-0-76: rgba(16, 9, 38, 0.76);
-  --ghostnet-color-rgba-167-139-250-0-22: rgba(167, 139, 250, 0.22);
-  --ghostnet-color-rgba-178-153-255-0-56: rgba(178, 153, 255, 0.56);
-  --ghostnet-color-rgba-188-148-255-0-34: rgba(188, 148, 255, 0.34);
-  --ghostnet-color-rgba-188-148-255-0-38: rgba(188, 148, 255, 0.38);
-  --ghostnet-color-rgba-195-168-255-0-92: rgba(195, 168, 255, 0.92);
-  --ghostnet-color-rgba-216-180-254-0-12: rgba(216, 180, 254, 0.12);
-  --ghostnet-color-rgba-216-180-254-0-14: rgba(216, 180, 254, 0.14);
-  --ghostnet-color-rgba-216-180-254-0-16: rgba(216, 180, 254, 0.16);
-  --ghostnet-color-rgba-216-180-254-0-18: rgba(216, 180, 254, 0.18);
-  --ghostnet-color-rgba-216-180-254-0-2: rgba(216, 180, 254, 0.2);
-  --ghostnet-color-rgba-216-180-254-0-22: rgba(216, 180, 254, 0.22);
-  --ghostnet-color-rgba-216-180-254-0-24: rgba(216, 180, 254, 0.24);
-  --ghostnet-color-rgba-216-180-254-0-28: rgba(216, 180, 254, 0.28);
-  --ghostnet-color-rgba-216-180-254-0-32: rgba(216, 180, 254, 0.32);
-  --ghostnet-color-rgba-216-180-254-0-42: rgba(216, 180, 254, 0.42);
-  --ghostnet-color-rgba-216-180-254-0-45: rgba(216, 180, 254, 0.45);
-  --ghostnet-color-rgba-22-15-44-0-92: rgba(22, 15, 44, 0.92);
-  --ghostnet-color-rgba-22-16-33-0-92: rgba(22, 16, 33, 0.92);
-  --ghostnet-color-rgba-22-16-40-0-9: rgba(22, 16, 40, 0.9);
-  --ghostnet-color-rgba-220-198-255-0-78: rgba(220, 198, 255, 0.78);
-  --ghostnet-color-rgba-220-228-255-0-84: rgba(220, 228, 255, 0.84);
-  --ghostnet-color-rgba-222-178-255-0-42: rgba(222, 178, 255, 0.42);
-  --ghostnet-color-rgba-228-175-255-0-2: rgba(228, 175, 255, 0.2);
-  --ghostnet-color-rgba-228-175-255-0-26: rgba(228, 175, 255, 0.26);
-  --ghostnet-color-rgba-228-175-255-0-28: rgba(228, 175, 255, 0.28);
-  --ghostnet-color-rgba-228-175-255-0-38: rgba(228, 175, 255, 0.38);
-  --ghostnet-color-rgba-228-175-255-0-42: rgba(228, 175, 255, 0.42);
-  --ghostnet-color-rgba-228-175-255-0-85: rgba(228, 175, 255, 0.85);
-  --ghostnet-color-rgba-24-12-6-0-4: rgba(24, 12, 6, 0.4);
-  --ghostnet-color-rgba-245-241-255-0-54: rgba(245, 241, 255, 0.54);
-  --ghostnet-color-rgba-245-241-255-0-56: rgba(245, 241, 255, 0.56);
-  --ghostnet-color-rgba-245-241-255-0-58: rgba(245, 241, 255, 0.58);
-  --ghostnet-color-rgba-245-241-255-0-6: rgba(245, 241, 255, 0.6);
-  --ghostnet-color-rgba-245-241-255-0-62: rgba(245, 241, 255, 0.62);
-  --ghostnet-color-rgba-245-241-255-0-68: rgba(245, 241, 255, 0.68);
-  --ghostnet-color-rgba-245-241-255-0-7: rgba(245, 241, 255, 0.7);
-  --ghostnet-color-rgba-245-241-255-0-72: rgba(245, 241, 255, 0.72);
-  --ghostnet-color-rgba-245-241-255-0-74: rgba(245, 241, 255, 0.74);
-  --ghostnet-color-rgba-245-241-255-0-78: rgba(245, 241, 255, 0.78);
-  --ghostnet-color-rgba-245-241-255-0-82: rgba(245, 241, 255, 0.82);
-  --ghostnet-color-rgba-245-241-255-0-84: rgba(245, 241, 255, 0.84);
-  --ghostnet-color-rgba-245-241-255-0-88: rgba(245, 241, 255, 0.88);
-  --ghostnet-color-rgba-245-241-255-0-92: rgba(245, 241, 255, 0.92);
-  --ghostnet-color-rgba-245-241-255-0-95: rgba(245, 241, 255, 0.95);
-  --ghostnet-color-rgba-255-126-59-0-55: rgba(255, 126, 59, 0.55);
-  --ghostnet-color-rgba-255-140-92-0-24: rgba(255, 140, 92, 0.24);
-  --ghostnet-color-rgba-255-150-220-0-22: rgba(255, 150, 220, 0.22);
-  --ghostnet-color-rgba-255-150-220-0-9: rgba(255, 150, 220, 0.9);
-  --ghostnet-color-rgba-255-160-86-0-45: rgba(255, 160, 86, 0.45);
-  --ghostnet-color-rgba-255-173-102-0-5: rgba(255, 173, 102, 0.5);
-  --ghostnet-color-rgba-255-173-102-0-55: rgba(255, 173, 102, 0.55);
-  --ghostnet-color-rgba-255-173-102-0-6: rgba(255, 173, 102, 0.6);
-  --ghostnet-color-rgba-255-173-108-0-38: rgba(255, 173, 108, 0.38);
-  --ghostnet-color-rgba-255-173-108-0-72: rgba(255, 173, 108, 0.72);
-  --ghostnet-color-rgba-255-183-120-0-28: rgba(255, 183, 120, 0.28);
-  --ghostnet-color-rgba-255-184-116-0-2: rgba(255, 184, 116, 0.2);
-  --ghostnet-color-rgba-255-198-140-0-92: rgba(255, 198, 140, 0.92);
-  --ghostnet-color-rgba-255-200-140-0-95: rgba(255, 200, 140, 0.95);
-  --ghostnet-color-rgba-255-207-156-0-9: rgba(255, 207, 156, 0.9);
-  --ghostnet-color-rgba-255-215-170-0-9: rgba(255, 215, 170, 0.9);
-  --ghostnet-color-rgba-255-88-172-0-6: rgba(255, 88, 172, 0.6);
-  --ghostnet-color-rgba-255-95-193-0-58: rgba(255, 95, 193, 0.58);
-  --ghostnet-color-rgba-26-17-60-0-9: rgba(26, 17, 60, 0.9);
-  --ghostnet-color-rgba-27-16-58-0-45: rgba(27, 16, 58, 0.45);
-  --ghostnet-color-rgba-28-18-42-0-9: rgba(28, 18, 42, 0.9);
-  --ghostnet-color-rgba-28-22-51-0-92: rgba(28, 22, 51, 0.92);
-  --ghostnet-color-rgba-3-7-11-0-78: rgba(3, 7, 11, 0.78);
-  --ghostnet-color-rgba-3-7-11-0-8: rgba(3, 7, 11, 0.8);
-  --ghostnet-color-rgba-3-7-12-0-78: rgba(3, 7, 12, 0.78);
-  --ghostnet-color-rgba-30-12-4-0-7: rgba(30, 12, 4, 0.7);
-  --ghostnet-color-rgba-35-20-68-0-85: rgba(35, 20, 68, 0.85);
-  --ghostnet-color-rgba-4-7-12-0-55: rgba(4, 7, 12, 0.55);
-  --ghostnet-color-rgba-4-8-13-0-85: rgba(4, 8, 13, 0.85);
-  --ghostnet-color-rgba-4-9-14-0-75: rgba(4, 9, 14, 0.75);
-  --ghostnet-color-rgba-4-9-14-0-85: rgba(4, 9, 14, 0.85);
-  --ghostnet-color-rgba-41-243-195-0-55: rgba(41, 243, 195, 0.55);
-  --ghostnet-color-rgba-41-243-195-0-92: rgba(41, 243, 195, 0.92);
-  --ghostnet-color-rgba-42-14-130-0-36: rgba(42, 14, 130, 0.36);
-  --ghostnet-color-rgba-42-14-130-0-48: rgba(42, 14, 130, 0.48);
-  --ghostnet-color-rgba-42-14-130-0-75: rgba(42, 14, 130, 0.75);
-  --ghostnet-color-rgba-42-14-130-0-78: rgba(42, 14, 130, 0.78);
-  --ghostnet-color-rgba-42-14-130-0-8: rgba(42, 14, 130, 0.8);
-  --ghostnet-color-rgba-42-14-130-0-82: rgba(42, 14, 130, 0.82);
-  --ghostnet-color-rgba-42-14-130-0-85: rgba(42, 14, 130, 0.85);
-  --ghostnet-color-rgba-42-14-130-0-9: rgba(42, 14, 130, 0.9);
-  --ghostnet-color-rgba-45-23-9-0-92: rgba(45, 23, 9, 0.92);
-  --ghostnet-color-rgba-45-25-98-0-85: rgba(45, 25, 98, 0.85);
-  --ghostnet-color-rgba-5-8-13-0: rgba(5, 8, 13, 0);
-  --ghostnet-color-rgba-5-8-13-0-55: rgba(5, 8, 13, 0.55);
-  --ghostnet-color-rgba-5-8-13-0-68: rgba(5, 8, 13, 0.68);
-  --ghostnet-color-rgba-5-8-13-0-82: rgba(5, 8, 13, 0.82);
-  --ghostnet-color-rgba-5-8-13-0-88: rgba(5, 8, 13, 0.88);
-  --ghostnet-color-rgba-5-8-13-0-9: rgba(5, 8, 13, 0.9);
-  --ghostnet-color-rgba-7-11-20-0-9: rgba(7, 11, 20, 0.9);
-  --ghostnet-color-rgba-7-11-20-0-92: rgba(7, 11, 20, 0.92);
-  --ghostnet-color-rgba-7-11-20-0-94: rgba(7, 11, 20, 0.94);
-  --ghostnet-color-rgba-8-7-16-0-92: rgba(8, 7, 16, 0.92);
-  --ghostnet-color-rgba-9-7-24-0-78: rgba(9, 7, 24, 0.78);
-  --ghostnet-color-rgba-9-8-26-0-95: rgba(9, 8, 26, 0.95);
-  --ghostnet-color-rgba-93-46-255-0: rgba(93, 46, 255, 0);
-  --ghostnet-color-rgba-93-46-255-0-12: rgba(93, 46, 255, 0.12);
-  --ghostnet-color-rgba-93-46-255-0-16: rgba(93, 46, 255, 0.16);
-  --ghostnet-color-rgba-93-46-255-0-18: rgba(93, 46, 255, 0.18);
-  --ghostnet-color-rgba-93-46-255-0-2: rgba(93, 46, 255, 0.2);
-  --ghostnet-color-rgba-93-46-255-0-22: rgba(93, 46, 255, 0.22);
-  --ghostnet-color-rgba-93-46-255-0-36: rgba(93, 46, 255, 0.36);
-  --ghostnet-color-rgba-93-46-255-0-38: rgba(93, 46, 255, 0.38);
-  --ghostnet-color-rgba-93-46-255-0-4: rgba(93, 46, 255, 0.4);
-  --ghostnet-color-rgba-93-46-255-0-45: rgba(93, 46, 255, 0.45);
-  --ghostnet-color-rgba-93-46-255-0-48: rgba(93, 46, 255, 0.48);
-  --ghostnet-color-rgba-93-46-255-0-5: rgba(93, 46, 255, 0.5);
-  --ghostnet-color-rgba-93-46-255-0-52: rgba(93, 46, 255, 0.52);
-  --ghostnet-color-rgba-93-46-255-0-55: rgba(93, 46, 255, 0.55);
-  --ghostnet-color-rgba-93-46-255-0-62: rgba(93, 46, 255, 0.62);
-  --ghostnet-color-rgba-93-46-255-0-65: rgba(93, 46, 255, 0.65);
-  --ghostnet-color-rgba-93-46-255-0-72: rgba(93, 46, 255, 0.72);
-  --ghostnet-color-rgba-93-46-255-0-75: rgba(93, 46, 255, 0.75);
-  --ghostnet-color-rgba-93-46-255-0-85: rgba(93, 46, 255, 0.85);
-  --ghostnet-color-rgba-93-46-255-0-88: rgba(93, 46, 255, 0.88);
-}
 .ghostnet {
   position: relative;
   min-height: 100%;
   --ghostnet-terminal-height: clamp(180px, 18vh, 220px);
-  padding: 2.5rem 3rem calc(3.5rem + var(--ghostnet-terminal-height));
-  background: linear-gradient(
-      180deg,
-      var(--ghostnet-color-rgba-28-22-51-0-92) 0%,
-      var(--ghostnet-color-rgba-42-14-130-0-82) 55%,
-      var(--ghostnet-color-rgba-16-9-38-0-76) 100%
-    ),
-    var(--ghostnet-color-hex-05080d);
-  color: var(--ghostnet-ink);
-  overflow: hidden;
-  --ghostnet-bg: var(--ghostnet-color-hex-05080d);
-  --ghostnet-panel: var(--ghostnet-color-rgba-10-15-22-0-88);
-  --ghostnet-panel-border: var(--ghostnet-color-rgba-216-180-254-0-28);
-  --ghostnet-ink: var(--ghostnet-color-hex-d8e9ff);
-  --ghostnet-muted: var(--ghostnet-color-hex-8da2bf);
-  --ghostnet-subdued: var(--ghostnet-color-hex-6c7c92);
-  --ghostnet-accent: var(--ghostnet-color-hex-d8b4fe);
-  --ghostnet-highlight: var(--ghostnet-color-rgba-216-180-254-0-12);
+  --ghostnet-bg: var(--ghostnet-color-background);
+  --ghostnet-panel: rgba(var(--ghostnet-color-background-rgb), 0.88);
+  --ghostnet-panel-border: var(--ghostnet-color-border-soft);
+  --ghostnet-ink: rgba(var(--ghostnet-color-text-strong-rgb), 0.92);
+  --ghostnet-muted: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
+  --ghostnet-subdued: rgba(var(--ghostnet-color-text-strong-rgb), 0.56);
+  --ghostnet-text-soft: rgba(var(--ghostnet-color-text-strong-rgb), 0.68);
+  --ghostnet-text-faint: rgba(var(--ghostnet-color-text-strong-rgb), 0.54);
+  --ghostnet-accent: var(--ghostnet-color-primary-light);
+  --ghostnet-highlight: rgba(var(--ghostnet-color-primary-rgb), 0.12);
   --ghostnet-table-header: linear-gradient(
     180deg,
-    var(--ghostnet-color-rgba-93-46-255-0-85) 0%,
-    var(--ghostnet-color-rgba-42-14-130-0-8) 75%,
-    var(--ghostnet-color-rgba-140-92-255-0-65) 100%
+    rgba(var(--ghostnet-color-primary-rgb), 0.85) 0%,
+    rgba(var(--ghostnet-color-primary-dark-rgb), 0.8) 75%,
+    rgba(var(--ghostnet-color-primary-rgb), 0.65) 100%
   );
+  --ghostnet-gradient-top: rgba(var(--ghostnet-color-surface-rgb), 0.92);
+  --ghostnet-gradient-mid: rgba(var(--ghostnet-color-primary-dark-rgb), 0.6);
+  --ghostnet-gradient-bottom: rgba(var(--ghostnet-color-background-rgb), 0.88);
+  padding: 2.5rem 3rem calc(3.5rem + var(--ghostnet-terminal-height));
+  background: linear-gradient(165deg, var(--ghostnet-gradient-top) 0%, var(--ghostnet-gradient-mid) 55%, var(--ghostnet-gradient-bottom) 100%),
+    var(--ghostnet-bg);
+  color: var(--ghostnet-ink);
+  overflow: hidden;
 }
 
 .ghostnet::before {
@@ -222,7 +42,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, var(--ghostnet-color-rgba-5-8-13-0) 0%, var(--ghostnet-color-rgba-5-8-13-0-9) 100%);
+  background: linear-gradient(180deg, rgba(var(--ghostnet-color-background-rgb), 0) 0%, rgba(var(--ghostnet-color-background-rgb), 0.9) 100%);
   pointer-events: none;
 }
 
@@ -293,13 +113,13 @@
 .terminalShell {
   width: 100%;
   max-width: none;
-  background: linear-gradient(180deg, var(--ghostnet-color-rgba-28-22-51-0-92) 0%, var(--ghostnet-color-rgba-13-11-26-0-94) 100%);
-  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-35);
+  background: linear-gradient(180deg, rgba(var(--ghostnet-color-surface-rgb), 0.92) 0%, rgba(var(--ghostnet-color-background-rgb), 0.94) 100%);
+  border: 1px solid var(--ghostnet-color-border);
   border-bottom: none;
   border-radius: 1.5rem 1.5rem 0 0;
   color: var(--ghostnet-ink);
   pointer-events: auto;
-  box-shadow: 0 -1.25rem 2.75rem var(--ghostnet-color-rgba-5-8-13-0-68), 0 0 1.75rem var(--ghostnet-color-rgba-93-46-255-0-36);
+  box-shadow: 0 -1.25rem 2.75rem var(--ghostnet-color-shadow-deep), 0 0 1.75rem var(--ghostnet-color-glow);
   backdrop-filter: blur(16px);
   display: flex;
   flex-direction: column;
@@ -311,8 +131,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.5rem 0.75rem 1.5rem;
-  background: var(--ghostnet-color-rgba-93-46-255-0-12);
-  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-28);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.12);
+  border-bottom: 1px solid var(--ghostnet-color-border-soft);
 }
 
 .terminalHeaderContent {
@@ -325,12 +145,12 @@
   font-size: 0.9rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--ghostnet-color-hex-f5f1ff);
+  color: var(--ghostnet-color-text-strong);
 }
 
 .terminalStatus {
   font-size: 0.8rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-68);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.68);
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
 }
 
@@ -341,41 +161,41 @@
   gap: 0.5rem;
   padding: 0.4rem 1.1rem;
   border-radius: 999px;
-  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-6);
-  background: linear-gradient(135deg, var(--ghostnet-color-rgba-93-46-255-0-72), var(--ghostnet-color-rgba-140-92-255-0-48));
-  color: var(--ghostnet-color-hex-f5f1ff);
+  border: 1px solid var(--ghostnet-color-border-strong);
+  background: linear-gradient(135deg, rgba(var(--ghostnet-color-primary-rgb), 0.72), rgba(var(--ghostnet-color-primary-rgb), 0.48));
+  color: var(--ghostnet-color-text-strong);
   text-transform: uppercase;
   letter-spacing: 0.24em;
   font-size: 0.72rem;
   cursor: pointer;
-  text-shadow: 0 0 12px var(--ghostnet-color-rgba-93-46-255-0-55);
-  box-shadow: 0 0 0 var(--ghostnet-color-rgba-93-46-255-0);
+  text-shadow: 0 0 12px rgba(var(--ghostnet-color-primary-rgb), 0.55);
+  box-shadow: 0 0 0 rgba(var(--ghostnet-color-primary-rgb), 0);
   transition: background 200ms ease, transform 200ms ease, box-shadow 200ms ease;
 }
 
 .terminalToggle:hover,
 .terminalToggle:focus-visible {
-  background: linear-gradient(135deg, var(--ghostnet-color-rgba-93-46-255-0-88), var(--ghostnet-color-rgba-140-92-255-0-62));
+  background: linear-gradient(135deg, rgba(var(--ghostnet-color-primary-rgb), 0.88), rgba(var(--ghostnet-color-primary-rgb), 0.62));
   transform: translateY(-1px);
-  box-shadow: 0 0 18px var(--ghostnet-color-rgba-93-46-255-0-38);
+  box-shadow: 0 0 18px rgba(var(--ghostnet-color-primary-rgb), 0.38);
 }
 
 .terminalToggle:focus-visible {
-  outline: 2px solid var(--ghostnet-color-hex-29f3c3);
+  outline: 2px solid var(--ghostnet-color-success);
   outline-offset: 3px;
 }
 
 .terminalToggle:active {
-  background: linear-gradient(135deg, var(--ghostnet-color-rgba-42-14-130-0-78), var(--ghostnet-color-rgba-93-46-255-0-52));
+  background: linear-gradient(135deg, rgba(var(--ghostnet-color-primary-dark-rgb), 0.78), rgba(var(--ghostnet-color-primary-rgb), 0.52));
   transform: translateY(1px);
-  box-shadow: 0 0 10px var(--ghostnet-color-rgba-42-14-130-0-48);
+  box-shadow: 0 0 10px rgba(var(--ghostnet-color-primary-dark-rgb), 0.48);
 }
 
 .terminalToggleIcon {
   font-size: 0.95rem;
   line-height: 1;
-  color: var(--ghostnet-color-hex-f5f1ff);
-  text-shadow: 0 0 14px var(--ghostnet-color-rgba-245-241-255-0-6);
+  color: var(--ghostnet-color-text-strong);
+  text-shadow: 0 0 14px rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
   transition: transform 200ms ease, color 200ms ease;
 }
 
@@ -387,12 +207,16 @@
 }
 
 .terminalToggleCollapsed {
-  background: linear-gradient(135deg, var(--ghostnet-color-rgba-42-14-130-0-82), var(--ghostnet-color-rgba-93-46-255-0-48));
-  box-shadow: 0 0 14px var(--ghostnet-color-rgba-42-14-130-0-36);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--ghostnet-color-primary-dark-rgb), 0.82),
+    rgba(var(--ghostnet-color-primary-rgb), 0.48)
+  );
+  box-shadow: 0 0 14px rgba(var(--ghostnet-color-primary-dark-rgb), 0.36);
 }
 
 .terminalToggleCollapsed .terminalToggleIcon {
-  color: var(--ghostnet-color-hex-29f3c3);
+  color: var(--ghostnet-color-success);
 }
 
 .terminalBody {
@@ -400,8 +224,9 @@
   padding: 1.25rem 1.5rem 1.5rem;
   background: linear-gradient(
     180deg,
-    var(--ghostnet-color-rgba-42-14-130-0-78) 0%,
-    var(--ghostnet-color-rgba-16-9-38-0-76) 100%
+    rgba(var(--ghostnet-color-primary-rgb), 0.16) 0%,
+    rgba(var(--ghostnet-color-primary-rgb), 0.04) 60%,
+    transparent 100%
   );
   overflow: hidden;
   display: flex;
@@ -423,7 +248,7 @@
   gap: 0.85rem;
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
   font-size: 0.85rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-78);
+  color: var(--ghostnet-text-soft);
   opacity: 0;
   animation: terminalLineReveal 320ms ease forwards;
 }
@@ -436,69 +261,69 @@
 }
 
 .terminalPromptCommand {
-  color: var(--ghostnet-color-hex-29f3c3);
+  color: var(--ghostnet-color-success);
 }
 
 .terminalPromptResponse {
-  color: var(--ghostnet-color-rgba-140-92-255-0-75);
+  color: rgba(var(--ghostnet-color-primary-rgb), 0.75);
 }
 
 .terminalPromptAlert {
-  color: var(--ghostnet-color-hex-ff5fc1);
+  color: var(--ghostnet-color-warning);
 }
 
 .terminalPromptCipher {
-  color: var(--ghostnet-color-rgba-245-241-255-0-56);
+  color: var(--ghostnet-text-faint);
 }
 
 .terminalPromptBinary {
-  color: var(--ghostnet-color-hex-29f3c3);
+  color: var(--ghostnet-color-success);
 }
 
 .terminalPromptDecrypt {
-  color: var(--ghostnet-color-rgba-140-92-255-0-95);
+  color: rgba(var(--ghostnet-color-primary-rgb), 0.95);
 }
 
 .terminalPromptGlitch {
-  color: var(--ghostnet-color-rgba-140-92-255-0-85);
-  text-shadow: 0 0 18px var(--ghostnet-color-rgba-93-46-255-0-48);
+  color: rgba(var(--ghostnet-color-primary-rgb), 0.85);
+  text-shadow: 0 0 18px rgba(var(--ghostnet-color-primary-rgb), 0.48);
 }
 
 .terminalPromptSystem {
-  color: var(--ghostnet-color-rgba-245-241-255-0-72);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.72);
 }
 
 .terminalText {
-  color: var(--ghostnet-color-rgba-245-241-255-0-82);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.82);
 }
 
 .terminalTextAlert {
-  color: var(--ghostnet-color-hex-ff5fc1);
-  text-shadow: 0 0 12px var(--ghostnet-color-rgba-255-95-193-0-58);
+  color: var(--ghostnet-color-warning);
+  text-shadow: 0 0 12px rgba(var(--ghostnet-color-warning-rgb), 0.58);
 }
 
 .terminalTextCipher {
-  color: var(--ghostnet-color-rgba-245-241-255-0-54);
+  color: var(--ghostnet-text-faint);
   letter-spacing: 0.18em;
 }
 
 .terminalTextBinary {
-  color: var(--ghostnet-color-rgba-41-243-195-0-92);
-  text-shadow: 0 0 10px var(--ghostnet-color-rgba-41-243-195-0-55);
+  color: rgba(var(--ghostnet-color-success-rgb), 0.92);
+  text-shadow: 0 0 10px rgba(var(--ghostnet-color-success-rgb), 0.55);
 }
 
 .terminalTextDecrypt {
-  color: var(--ghostnet-color-rgba-245-241-255-0-95);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.95);
 }
 
 .terminalTextGlitch {
-  color: var(--ghostnet-color-rgba-245-241-255-0-7);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
   letter-spacing: 0.2em;
-  text-shadow: 0 0 22px var(--ghostnet-color-rgba-93-46-255-0-45);
+  text-shadow: 0 0 22px rgba(var(--ghostnet-color-primary-rgb), 0.45);
 }
 
 .terminalTextSystem {
-  color: var(--ghostnet-color-rgba-245-241-255-0-92);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.92);
 }
 
 @keyframes terminalLineReveal {
@@ -530,7 +355,7 @@
   border-radius: 1.25rem;
   background: var(--ghostnet-panel);
   border: 1px solid var(--ghostnet-panel-border);
-  box-shadow: 0 1.75rem 3.5rem var(--ghostnet-color-rgba-3-7-11-0-8);
+  box-shadow: 0 1.75rem 3.5rem var(--ghostnet-color-shadow);
   backdrop-filter: blur(12px);
 }
 
@@ -563,8 +388,8 @@
 .sectionFrameElevated {
   border-radius: 1.5rem;
   background: var(--ghostnet-panel);
-  border: 1px solid var(--ghostnet-color-rgba-216-180-254-0-32);
-  box-shadow: 0 1.75rem 4rem var(--ghostnet-color-rgba-4-9-14-0-85);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.32);
+  box-shadow: 0 1.75rem 4rem rgba(var(--ghostnet-color-background-rgb), 0.85);
   backdrop-filter: blur(14px);
 }
 
@@ -592,8 +417,8 @@
   text-transform: uppercase;
   letter-spacing: 0.18em;
   border-radius: 999px;
-  border: 1px solid var(--ghostnet-color-rgba-216-180-254-0-42);
-  background: var(--ghostnet-color-rgba-216-180-254-0-12);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.42);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.12);
   color: var(--ghostnet-accent);
 }
 
@@ -609,16 +434,16 @@
 
 .dataTableContainer {
   position: relative;
-  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-38);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.38);
   border-radius: 1.25rem;
-  background:
-    linear-gradient(
-      180deg,
-      var(--ghostnet-color-rgba-93-46-255-0-22) 0%,
-      transparent 45%
+  background: linear-gradient(
+      175deg,
+      rgba(var(--ghostnet-color-primary-rgb), 0.18) 0%,
+      rgba(var(--ghostnet-color-primary-dark-rgb), 0.12) 45%,
+      transparent 100%
     ),
-    linear-gradient(180deg, var(--ghostnet-color-rgba-9-8-26-0-95) 0%, var(--ghostnet-color-rgba-7-11-20-0-94) 100%);
-  box-shadow: 0 1.65rem 3.75rem var(--ghostnet-color-rgba-3-7-12-0-78);
+    linear-gradient(180deg, rgba(var(--ghostnet-color-background-rgb), 0.95) 0%, rgba(var(--ghostnet-color-background-rgb), 0.94) 100%);
+  box-shadow: 0 1.65rem 3.75rem rgba(var(--ghostnet-color-background-rgb), 0.78);
   overflow: hidden;
 }
 
@@ -641,11 +466,11 @@
 
 .dataTable thead {
   background: var(--ghostnet-table-header);
-  box-shadow: inset 0 -1px 0 var(--ghostnet-color-rgba-140-92-255-0-38);
+  box-shadow: inset 0 -1px 0 rgba(var(--ghostnet-color-primary-rgb), 0.38);
 }
 
 .dataTable thead tr {
-  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-45);
+  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.45);
   background: var(--ghostnet-table-header);
 }
 
@@ -654,21 +479,25 @@
   font-size: 0.72rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--ghostnet-color-rgba-245-241-255-0-88);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.88);
   font-weight: 600;
   text-align: left;
   white-space: nowrap;
 }
 
 .dataTable tbody tr {
-  background: linear-gradient(180deg, var(--ghostnet-color-rgba-13-11-26-0-86) 0%, var(--ghostnet-color-rgba-16-9-38-0-76) 100%);
-  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-25);
+  background: linear-gradient(
+    180deg,
+    rgba(var(--ghostnet-color-background-rgb), 0.86) 0%,
+    rgba(var(--ghostnet-color-primary-dark-rgb), 0.35) 100%
+  );
+  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.25);
   transition: background 0.25s ease, transform 0.25s ease;
   font-size: 0.95rem;
 }
 
 .dataTable tbody tr:nth-child(even) {
-  background: var(--ghostnet-color-rgba-27-16-58-0-45);
+  background: rgba(var(--ghostnet-color-primary-dark-rgb), 0.45);
 }
 
 .dataTable tbody tr:last-child {
@@ -676,7 +505,7 @@
 }
 
 .dataTable tbody tr:hover {
-  background: var(--ghostnet-color-rgba-93-46-255-0-18);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.18);
 }
 
 .dataTable td {
@@ -687,7 +516,7 @@
 }
 
 .nonCommodityRow {
-  background: var(--ghostnet-color-rgba-16-9-38-0-7);
+  background: rgba(var(--ghostnet-color-primary-dark-rgb), 0.4);
   font-size: 0.85rem;
   line-height: 1.2;
 }
@@ -712,11 +541,11 @@
   font-size: 0.7rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--ghostnet-color-rgba-245-241-255-0-7);
-  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-45);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.45);
   border-radius: 999px;
   padding: 0.1rem 0.6rem;
-  background: var(--ghostnet-color-rgba-93-46-255-0-18);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.18);
 }
 
 .nonCommodityQuantity {
@@ -779,20 +608,20 @@
 }
 
 .tableRowInteractive:hover {
-  background: var(--ghostnet-color-rgba-93-46-255-0-2);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.2);
 }
 
 .tableRowExpanded {
-  background: var(--ghostnet-color-rgba-93-46-255-0-16) !important;
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.16) !important;
 }
 
 .tableRowExpanded:hover {
-  background: var(--ghostnet-color-rgba-93-46-255-0-22) !important;
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.22) !important;
 }
 
 .tableDetailRow td {
-  background: var(--ghostnet-color-rgba-5-8-13-0-88);
-  border-top: 1px solid var(--ghostnet-color-rgba-140-92-255-0-25);
+  background: rgba(var(--ghostnet-color-background-rgb), 0.88);
+  border-top: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.25);
   padding: 0 1.5rem 1.5rem;
 }
 
@@ -813,11 +642,11 @@
 }
 
 .tableTextSuccess {
-  color: var(--ghostnet-color-hex-29f3c3);
+  color: var(--ghostnet-color-success);
 }
 
 .tableTextDanger {
-  color: var(--ghostnet-color-hex-ff5fc1);
+  color: var(--ghostnet-color-warning);
 }
 
 .tableMessage {
@@ -826,7 +655,7 @@
 }
 
 .tableMessageBorder {
-  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-25);
+  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.25);
 }
 
 .tableIdleState {
@@ -835,7 +664,7 @@
 }
 
 .tableErrorState {
-  color: var(--ghostnet-color-hex-ff4d4f);
+  color: var(--ghostnet-color-warning);
   padding: 2rem;
 }
 
@@ -851,25 +680,25 @@
 }
 
 .tableMetaMuted {
-  color: var(--ghostnet-color-rgba-140-160-188-0-75);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
   font-size: 0.75rem;
   margin-top: 0.25rem;
 }
 
 .tableWarning {
-  color: var(--ghostnet-color-hex-ff5fc1);
+  color: var(--ghostnet-color-warning);
   font-size: 0.78rem;
   margin-top: 0.35rem;
 }
 
 .tableMutedNote {
-  color: var(--ghostnet-color-rgba-120-140-168-0-75);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
   font-size: 0.75rem;
   margin-top: 0.45rem;
 }
 
 .tableIndicatorPlaceholder {
-  color: var(--ghostnet-color-rgba-120-140-168-0-75);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
   font-size: 0.82rem;
 }
 
@@ -893,10 +722,14 @@
   justify-content: space-between;
   gap: 1.5rem;
   padding: 1.75rem 2rem;
-  background: linear-gradient(135deg, var(--ghostnet-color-rgba-45-25-98-0-85), var(--ghostnet-color-rgba-26-17-60-0-9));
-  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-38);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--ghostnet-color-primary-dark-rgb), 0.85),
+    rgba(var(--ghostnet-color-background-rgb), 0.9)
+  );
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.38);
   border-radius: 1.25rem;
-  box-shadow: 0 1.5rem 3rem var(--ghostnet-color-rgba-5-8-13-0-55);
+  box-shadow: 0 1.5rem 3rem var(--ghostnet-color-shadow);
 }
 
 .routeDetailBackButton {
@@ -905,33 +738,45 @@
   gap: 0.55rem;
   padding: 0.55rem 1.4rem;
   border-radius: 999px;
-  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-55);
-  background: linear-gradient(135deg, var(--ghostnet-color-rgba-93-46-255-0-62), var(--ghostnet-color-rgba-140-92-255-0-4));
-  color: var(--ghostnet-color-hex-f5f1ff);
+  border: 1px solid var(--ghostnet-color-border-strong);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--ghostnet-color-primary-rgb), 0.62),
+    rgba(var(--ghostnet-color-primary-rgb), 0.4)
+  );
+  color: var(--ghostnet-color-text-strong);
   text-transform: uppercase;
   letter-spacing: 0.24em;
   font-size: 0.66rem;
   cursor: pointer;
   transition: background 200ms ease, box-shadow 200ms ease, transform 200ms ease;
-  text-shadow: 0 0 14px var(--ghostnet-color-rgba-93-46-255-0-45);
+  text-shadow: 0 0 14px rgba(var(--ghostnet-color-primary-rgb), 0.45);
 }
 
 .routeDetailBackButton:hover,
 .routeDetailBackButton:focus-visible {
-  background: linear-gradient(135deg, var(--ghostnet-color-rgba-117-70-255-0-8), var(--ghostnet-color-rgba-140-92-255-0-55));
+  background: linear-gradient(
+    135deg,
+    rgba(var(--ghostnet-color-primary-rgb), 0.8),
+    rgba(var(--ghostnet-color-primary-rgb), 0.55)
+  );
   transform: translateY(-1px);
-  box-shadow: 0 0 18px var(--ghostnet-color-rgba-93-46-255-0-4);
+  box-shadow: 0 0 18px rgba(var(--ghostnet-color-primary-rgb), 0.4);
 }
 
 .routeDetailBackButton:focus-visible {
-  outline: 2px solid var(--ghostnet-color-hex-29f3c3);
+  outline: 2px solid var(--ghostnet-color-success);
   outline-offset: 3px;
 }
 
 .routeDetailBackButton:active {
-  background: linear-gradient(135deg, var(--ghostnet-color-rgba-42-14-130-0-75), var(--ghostnet-color-rgba-93-46-255-0-5));
+  background: linear-gradient(
+    135deg,
+    rgba(var(--ghostnet-color-primary-dark-rgb), 0.75),
+    rgba(var(--ghostnet-color-primary-rgb), 0.5)
+  );
   transform: translateY(1px);
-  box-shadow: 0 0 12px var(--ghostnet-color-rgba-42-14-130-0-48);
+  box-shadow: 0 0 12px rgba(var(--ghostnet-color-primary-dark-rgb), 0.48);
 }
 
 .routeDetailHeading {
@@ -947,7 +792,7 @@
   text-transform: uppercase;
   letter-spacing: 0.32em;
   font-size: 0.68rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-7);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
 }
 
 .routeDetailTitle {
@@ -956,13 +801,13 @@
   justify-content: center;
   gap: 0.85rem;
   font-size: 1.65rem;
-  color: var(--ghostnet-color-hex-f5f1ff);
-  text-shadow: 0 0 14px var(--ghostnet-color-rgba-93-46-255-0-45);
+  color: var(--ghostnet-color-text-strong);
+  text-shadow: 0 0 14px rgba(var(--ghostnet-color-primary-rgb), 0.45);
   margin: 0;
 }
 
 .routeDetailDivider {
-  color: var(--ghostnet-color-hex-29f3c3);
+  color: var(--ghostnet-color-success);
   font-size: 1.75rem;
   line-height: 1;
 }
@@ -973,11 +818,11 @@
   gap: 0.65rem;
   margin: 0;
   font-size: 0.92rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-74);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.74);
 }
 
 .routeDetailArrow {
-  color: var(--ghostnet-color-rgba-245-241-255-0-6);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
   font-size: 1.1rem;
 }
 
@@ -988,22 +833,22 @@
   min-width: 160px;
   padding: 0.9rem 1.25rem;
   border-radius: 1rem;
-  background: var(--ghostnet-color-rgba-35-20-68-0-85);
-  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-35);
-  color: var(--ghostnet-color-rgba-245-241-255-0-78);
+  background: rgba(var(--ghostnet-color-primary-dark-rgb), 0.6);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.35);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.78);
 }
 
 .routeDetailMetaLabel {
   text-transform: uppercase;
   letter-spacing: 0.22em;
   font-size: 0.65rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-6);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
 }
 
 .routeDetailMetaValue {
   font-size: 0.98rem;
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
-  color: var(--ghostnet-color-hex-f5f1ff);
+  color: var(--ghostnet-color-text-strong);
 }
 
 .routeDetailMetrics {
@@ -1018,21 +863,21 @@
   gap: 0.4rem;
   padding: 1.15rem 1.35rem;
   border-radius: 1.1rem;
-  background: var(--ghostnet-color-rgba-22-15-44-0-92);
-  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-32);
-  box-shadow: 0 1.2rem 2.4rem var(--ghostnet-color-rgba-4-7-12-0-55);
+  background: rgba(var(--ghostnet-color-background-rgb), 0.92);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.32);
+  box-shadow: 0 1.2rem 2.4rem rgba(var(--ghostnet-color-background-rgb), 0.55);
 }
 
 .routeDetailMetricLabel {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.68rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-62);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.62);
 }
 
 .routeDetailMetricValue {
   font-size: 1.05rem;
-  color: var(--ghostnet-color-hex-f5f1ff);
+  color: var(--ghostnet-color-text-strong);
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
 }
 
@@ -1047,10 +892,10 @@
   flex-direction: column;
   gap: 1rem;
   padding: 1.75rem 1.9rem;
-  background: var(--ghostnet-color-rgba-12-10-28-0-92);
-  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-32);
+  background: rgba(var(--ghostnet-color-background-rgb), 0.92);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.32);
   border-radius: 1.25rem;
-  box-shadow: 0 1.45rem 2.8rem var(--ghostnet-color-rgba-4-7-12-0-55);
+  box-shadow: 0 1.45rem 2.8rem rgba(var(--ghostnet-color-background-rgb), 0.55);
 }
 
 .routeDetailPanelHeader {
@@ -1064,7 +909,7 @@
   text-transform: uppercase;
   letter-spacing: 0.28em;
   font-size: 0.68rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-62);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.62);
 }
 
 .routeDetailStation {
@@ -1086,13 +931,13 @@
 
 .routeDetailStationName {
   font-size: 1.05rem;
-  color: var(--ghostnet-color-hex-f5f1ff);
+  color: var(--ghostnet-color-text-strong);
   font-weight: 600;
 }
 
 .routeDetailSystem {
   font-size: 0.85rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-62);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.62);
 }
 
 .routeDetailInfoRow {
@@ -1100,7 +945,7 @@
   justify-content: space-between;
   align-items: baseline;
   gap: 1rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-78);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.78);
   font-size: 0.92rem;
 }
 
@@ -1108,7 +953,7 @@
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.7rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-58);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.58);
 }
 
 .routeDetailInfoValue {
@@ -1121,7 +966,7 @@
 .routeDetailDividerLine {
   height: 1px;
   width: 100%;
-  background: var(--ghostnet-color-rgba-140-92-255-0-25);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.25);
   margin: 0.5rem 0 0.75rem;
 }
 
@@ -1129,20 +974,20 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-84);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.84);
 }
 
 .routeDetailCommodityLabel {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.68rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-6);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
 }
 
 .routeDetailCommodityValue {
   font-size: 1.05rem;
   font-weight: 600;
-  color: var(--ghostnet-color-hex-f5f1ff);
+  color: var(--ghostnet-color-text-strong);
 }
 
 .routeDetailPriceRow {
@@ -1150,7 +995,7 @@
   flex-wrap: wrap;
   gap: 0.85rem;
   font-size: 0.88rem;
-  color: var(--ghostnet-color-rgba-245-241-255-0-74);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.74);
 }
 
 @media (max-width: 1100px) {
@@ -1218,7 +1063,7 @@
   align-items: baseline;
   gap: 0.4rem;
   font-size: 0.95rem;
-  color: var(--ghostnet-color-rgba-220-228-255-0-84);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.84);
 }
 
 .tableEntryValueHighlight {
@@ -1229,11 +1074,11 @@
   font-size: 0.72rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--ghostnet-color-hex-5bd1a5);
+  color: var(--ghostnet-color-success);
 }
 
 .tableEntryLabel {
-  color: var(--ghostnet-color-rgba-140-160-188-0-78);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -1247,7 +1092,7 @@
 }
 
 .tableEntryFootnote {
-  color: var(--ghostnet-color-rgba-120-140-168-0-75);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
   font-size: 0.75rem;
   margin-top: 0.2rem;
 }
@@ -1260,16 +1105,16 @@
 }
 
 .tableBadgeWarning {
-  color: var(--ghostnet-color-hex-ff5fc1);
+  color: var(--ghostnet-color-warning);
 }
 
 .tableBadgeSuccess {
-  color: var(--ghostnet-color-hex-5bd1a5);
+  color: var(--ghostnet-color-success);
 }
 
 .tableFootnote {
   margin-top: 1.5rem;
-  color: var(--ghostnet-color-rgba-140-160-188-0-75);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
   font-size: 0.85rem;
   line-height: 1.6;
 }
@@ -1302,11 +1147,11 @@
 }
 
 .metricValueWarning {
-  color: var(--ghostnet-color-hex-ff5fc1);
+  color: var(--ghostnet-color-warning);
 }
 
 .metricValueSuccess {
-  color: var(--ghostnet-color-hex-5bd1a5);
+  color: var(--ghostnet-color-success);
 }
 
 .notice {
@@ -1316,17 +1161,17 @@
 }
 
 .noticeMuted {
-  color: var(--ghostnet-color-hex-aaa);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.5);
 }
 
 .inlineNotice {
   padding: 1rem 0;
-  color: var(--ghostnet-color-hex-ff4d4f);
+  color: var(--ghostnet-color-warning);
 }
 
 .inlineNoticeMuted {
   padding: 1rem 0;
-  color: var(--ghostnet-color-hex-aaa);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.5);
 }
 
 .placeholder {
@@ -1337,9 +1182,9 @@
   color: var(--ghostnet-muted);
   font-size: 1.35rem;
   border-radius: 1.5rem;
-  border: 1px solid var(--ghostnet-color-rgba-216-180-254-0-28);
-  background: linear-gradient(160deg, var(--ghostnet-color-rgba-216-180-254-0-18), var(--ghostnet-color-rgba-5-8-13-0-82));
-  box-shadow: 0 1.85rem 4rem var(--ghostnet-color-rgba-3-7-11-0-78);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.28);
+  background: linear-gradient(160deg, rgba(var(--ghostnet-color-primary-rgb), 0.18), rgba(var(--ghostnet-color-background-rgb), 0.82));
+  box-shadow: 0 1.85rem 4rem rgba(var(--ghostnet-color-background-rgb), 0.78);
 }
 
 .ghostnet :global(.ghostnet-surface) {
@@ -1359,17 +1204,17 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table) {
-  background: linear-gradient(180deg, var(--ghostnet-color-rgba-13-11-26-0-94) 0%, var(--ghostnet-color-rgba-7-11-20-0-92) 100%);
-  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-38);
+  background: linear-gradient(180deg, rgba(var(--ghostnet-color-background-rgb), 0.94) 0%, rgba(var(--ghostnet-color-background-rgb), 0.92) 100%);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.38);
   border-radius: 1.25rem;
   overflow: hidden;
-  box-shadow: 0 1.75rem 3.5rem var(--ghostnet-color-rgba-4-9-14-0-75);
+  box-shadow: 0 1.75rem 3.5rem rgba(var(--ghostnet-color-background-rgb), 0.75);
   backdrop-filter: blur(10px);
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable) {
-  background: linear-gradient(180deg, var(--ghostnet-color-rgba-9-7-24-0-78) 0%, var(--ghostnet-color-rgba-7-11-20-0-9) 100%);
-  scrollbar-color: var(--ghostnet-color-rgba-140-92-255-0-6) var(--ghostnet-color-rgba-13-11-26-0-85);
+  background: linear-gradient(180deg, rgba(var(--ghostnet-color-primary-dark-rgb), 0.78) 0%, rgba(var(--ghostnet-color-background-rgb), 0.9) 100%);
+  scrollbar-color: rgba(var(--ghostnet-color-primary-rgb), 0.6) rgba(var(--ghostnet-color-background-rgb), 0.85);
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar) {
@@ -1377,23 +1222,23 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-track) {
-  background: var(--ghostnet-color-rgba-13-11-26-0-75);
+  background: rgba(var(--ghostnet-color-background-rgb), 0.75);
   border-radius: 0.65rem;
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-thumb) {
-  background: linear-gradient(180deg, var(--ghostnet-color-rgba-93-46-255-0-75) 0%, var(--ghostnet-color-rgba-42-14-130-0-85) 100%);
+  background: linear-gradient(180deg, rgba(var(--ghostnet-color-primary-rgb), 0.75) 0%, rgba(var(--ghostnet-color-primary-dark-rgb), 0.85) 100%);
   border-radius: 0.65rem;
-  box-shadow: 0 0 0 2px var(--ghostnet-color-rgba-13-11-26-0-55) inset;
+  box-shadow: 0 0 0 2px rgba(var(--ghostnet-color-background-rgb), 0.55) inset;
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-thumb:hover) {
-  background: linear-gradient(180deg, var(--ghostnet-color-rgba-117-70-255-0-85) 0%, var(--ghostnet-color-rgba-42-14-130-0-9) 100%);
+  background: linear-gradient(180deg, rgba(var(--ghostnet-color-primary-rgb), 0.85) 0%, rgba(var(--ghostnet-color-primary-dark-rgb), 0.9) 100%);
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead) {
   background: var(--ghostnet-table-header);
-  box-shadow: inset 0 -1px 0 var(--ghostnet-color-rgba-140-92-255-0-38);
+  box-shadow: inset 0 -1px 0 rgba(var(--ghostnet-color-primary-rgb), 0.38);
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead tr) {
@@ -1401,25 +1246,25 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead tr th) {
-  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-45);
-  color: var(--ghostnet-color-rgba-245-241-255-0-88);
+  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.45);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.88);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr) {
-  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-25);
+  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.25);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr:nth-child(even)) {
-  background: var(--ghostnet-color-rgba-27-16-58-0-45);
+  background: rgba(var(--ghostnet-color-primary-dark-rgb), 0.45);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr:hover) {
-  background: var(--ghostnet-color-rgba-93-46-255-0-18) !important;
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.18) !important;
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail) {
-  background: var(--ghostnet-color-rgba-4-8-13-0-85);
-  border: 1px solid var(--ghostnet-color-rgba-216-180-254-0-22);
+  background: rgba(var(--ghostnet-color-background-rgb), 0.85);
+  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.22);
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail-status) {
@@ -1431,7 +1276,7 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail-status--error) {
-  color: var(--ghostnet-color-hex-ff5fc1);
+  color: var(--ghostnet-color-warning);
 }
 
 .ghostnet :global(.ghostnet-panel-table .text-primary) {
@@ -1439,7 +1284,7 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .text-secondary) {
-  color: var(--ghostnet-color-hex-e0c8ff);
+  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.85);
 }
 
 .ghostnet :global(.ghostnet-panel-table .text-muted) {
@@ -1456,12 +1301,12 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--active) {
-  background: var(--ghostnet-color-rgba-216-180-254-0-18);
-  border-color: var(--ghostnet-color-rgba-216-180-254-0-45);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.18);
+  border-color: rgba(var(--ghostnet-color-primary-rgb), 0.45);
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--active:hover) {
-  background: var(--ghostnet-color-rgba-216-180-254-0-24);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.24);
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--icon) {
@@ -1469,7 +1314,7 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--icon:hover) {
-  background: var(--ghostnet-color-rgba-216-180-254-0-16);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.16);
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--secondary) {
@@ -1477,11 +1322,11 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--secondary:hover) {
-  background: var(--ghostnet-color-rgba-216-180-254-0-16);
+  background: rgba(var(--ghostnet-color-primary-rgb), 0.16);
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__inspector) {
-  border-left: 1px solid var(--ghostnet-color-rgba-216-180-254-0-22);
+  border-left: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.22);
 }
 
 @media (max-width: 640px) {
@@ -1517,81 +1362,81 @@
 
 @keyframes ghostnetArrivalSurface {
   0% {
-    --ghostnet-bg: var(--ghostnet-color-hex-150a02);
-    --ghostnet-panel: var(--ghostnet-color-rgba-45-23-9-0-92);
-    --ghostnet-panel-border: var(--ghostnet-color-rgba-255-173-102-0-6);
-    --ghostnet-ink: var(--ghostnet-color-hex-ffe8c9);
-    --ghostnet-muted: var(--ghostnet-color-rgba-255-207-156-0-9);
-    --ghostnet-subdued: var(--ghostnet-color-rgba-255-173-108-0-72);
-    --ghostnet-accent: var(--ghostnet-color-hex-ffb874);
-    --ghostnet-highlight: var(--ghostnet-color-rgba-255-173-108-0-38);
+    --ghostnet-bg: var(--ghostnet-color-background);
+    --ghostnet-panel: rgba(var(--ghostnet-color-primary-dark-rgb), 0.82);
+    --ghostnet-panel-border: rgba(var(--ghostnet-color-warning-rgb), 0.45);
+    --ghostnet-ink: rgba(var(--ghostnet-color-text-strong-rgb), 0.96);
+    --ghostnet-muted: rgba(var(--ghostnet-color-warning-rgb), 0.65);
+    --ghostnet-subdued: rgba(var(--ghostnet-color-warning-rgb), 0.45);
+    --ghostnet-accent: var(--ghostnet-color-warning);
+    --ghostnet-highlight: rgba(var(--ghostnet-color-warning-rgb), 0.28);
     background: linear-gradient(
-        180deg,
-        var(--ghostnet-color-rgba-255-173-102-0-55) 0%,
-        var(--ghostnet-color-rgba-255-140-92-0-24) 45%,
-        var(--ghostnet-color-hex-120804) 100%
+        165deg,
+        rgba(var(--ghostnet-color-warning-rgb), 0.22) 0%,
+        rgba(var(--ghostnet-color-primary-rgb), 0.18) 45%,
+        rgba(var(--ghostnet-color-background-rgb), 0.9) 100%
       ),
-      var(--ghostnet-color-hex-120804);
-    filter: saturate(1.08) contrast(1.05) hue-rotate(-12deg);
+      var(--ghostnet-bg);
+    filter: saturate(1.08) contrast(1.05);
     transform: scale(1.01);
   }
   42% {
-    --ghostnet-bg: var(--ghostnet-color-hex-0f0720);
-    --ghostnet-panel: var(--ghostnet-color-rgba-22-16-40-0-9);
-    --ghostnet-panel-border: var(--ghostnet-color-rgba-228-175-255-0-42);
-    --ghostnet-ink: var(--ghostnet-color-hex-f6e9ff);
-    --ghostnet-muted: var(--ghostnet-color-rgba-220-198-255-0-78);
-    --ghostnet-subdued: var(--ghostnet-color-rgba-178-153-255-0-56);
-    --ghostnet-accent: var(--ghostnet-color-hex-f0b8ff);
-    --ghostnet-highlight: var(--ghostnet-color-rgba-216-180-254-0-2);
+    --ghostnet-bg: var(--ghostnet-color-background);
+    --ghostnet-panel: rgba(var(--ghostnet-color-surface-rgb), 0.88);
+    --ghostnet-panel-border: rgba(var(--ghostnet-color-primary-rgb), 0.38);
+    --ghostnet-ink: rgba(var(--ghostnet-color-text-strong-rgb), 0.94);
+    --ghostnet-muted: rgba(var(--ghostnet-color-text-strong-rgb), 0.78);
+    --ghostnet-subdued: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+    --ghostnet-accent: var(--ghostnet-color-primary-light);
+    --ghostnet-highlight: rgba(var(--ghostnet-color-primary-rgb), 0.2);
     background: linear-gradient(
-        180deg,
-        var(--ghostnet-color-rgba-228-175-255-0-26) 0%,
-        var(--ghostnet-color-rgba-120-192-255-0-18) 45%,
-        var(--ghostnet-color-hex-080711) 100%
+        165deg,
+        rgba(var(--ghostnet-color-primary-rgb), 0.24) 0%,
+        rgba(var(--ghostnet-color-primary-dark-rgb), 0.32) 55%,
+        rgba(var(--ghostnet-color-background-rgb), 0.88) 100%
       ),
-      var(--ghostnet-color-hex-080711);
-    filter: saturate(1.12) contrast(1.02) hue-rotate(4deg);
+      var(--ghostnet-bg);
+    filter: saturate(1.05);
     transform: scale(1.006);
   }
   62% {
     background: linear-gradient(
-        180deg,
-        var(--ghostnet-color-rgba-228-175-255-0-32) 0%,
-        var(--ghostnet-color-rgba-120-192-255-0-18) 50%,
-        var(--ghostnet-color-hex-0a0718) 100%
+        165deg,
+        rgba(var(--ghostnet-color-primary-rgb), 0.2) 0%,
+        rgba(var(--ghostnet-color-primary-dark-rgb), 0.28) 55%,
+        rgba(var(--ghostnet-color-background-rgb), 0.86) 100%
       ),
-      var(--ghostnet-color-hex-0a0718);
-    filter: saturate(1.28) hue-rotate(10deg);
+      var(--ghostnet-bg);
+    filter: saturate(1.02);
     transform: scale(1.004) translate3d(-3px, 1px, 0);
   }
   72% {
     background: linear-gradient(
-        180deg,
-        var(--ghostnet-color-rgba-120-192-255-0-22) 0%,
-        var(--ghostnet-color-rgba-228-175-255-0-28) 50%,
-        var(--ghostnet-color-hex-060611) 100%
+        165deg,
+        rgba(var(--ghostnet-color-primary-rgb), 0.16) 0%,
+        rgba(var(--ghostnet-color-primary-dark-rgb), 0.26) 55%,
+        rgba(var(--ghostnet-color-background-rgb), 0.84) 100%
       ),
-      var(--ghostnet-color-hex-060611);
-    filter: saturate(0.92) hue-rotate(-6deg);
+      var(--ghostnet-bg);
+    filter: saturate(0.96);
     transform: scale(1.002) translate3d(2px, -1px, 0);
   }
   100% {
-    --ghostnet-bg: var(--ghostnet-color-hex-05080d);
-    --ghostnet-panel: var(--ghostnet-color-rgba-10-15-22-0-88);
-    --ghostnet-panel-border: var(--ghostnet-color-rgba-216-180-254-0-28);
-    --ghostnet-ink: var(--ghostnet-color-hex-d8e9ff);
-    --ghostnet-muted: var(--ghostnet-color-hex-8da2bf);
-    --ghostnet-subdued: var(--ghostnet-color-hex-6c7c92);
-    --ghostnet-accent: var(--ghostnet-color-hex-d8b4fe);
-    --ghostnet-highlight: var(--ghostnet-color-rgba-216-180-254-0-12);
+    --ghostnet-bg: var(--ghostnet-color-background);
+    --ghostnet-panel: rgba(var(--ghostnet-color-background-rgb), 0.88);
+    --ghostnet-panel-border: var(--ghostnet-color-border-soft);
+    --ghostnet-ink: rgba(var(--ghostnet-color-text-strong-rgb), 0.92);
+    --ghostnet-muted: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
+    --ghostnet-subdued: rgba(var(--ghostnet-color-text-strong-rgb), 0.56);
+    --ghostnet-accent: var(--ghostnet-color-primary-light);
+    --ghostnet-highlight: rgba(var(--ghostnet-color-primary-rgb), 0.12);
     background: linear-gradient(
-        180deg,
-        var(--ghostnet-color-rgba-216-180-254-0-14) 0%,
-        var(--ghostnet-color-rgba-167-139-250-0-22) 55%,
-        var(--ghostnet-color-hex-05080d) 100%
+        165deg,
+        var(--ghostnet-gradient-top) 0%,
+        var(--ghostnet-gradient-mid) 55%,
+        var(--ghostnet-gradient-bottom) 100%
       ),
-      var(--ghostnet-color-hex-05080d);
+      var(--ghostnet-bg);
     filter: none;
     transform: none;
   }
@@ -1623,18 +1468,26 @@
 @keyframes ghostnetArrivalVignette {
   0% {
     opacity: 0.85;
-    background: linear-gradient(180deg, var(--ghostnet-color-rgba-24-12-6-0-4) 0%, var(--ghostnet-color-rgba-10-6-2-0-94) 100%);
+    background: linear-gradient(
+      180deg,
+      rgba(var(--ghostnet-color-background-rgb), 0.35) 0%,
+      rgba(var(--ghostnet-color-background-rgb), 0.94) 100%
+    );
   }
   40% {
     opacity: 0.7;
-    background: linear-gradient(180deg, var(--ghostnet-color-rgba-10-6-18-0-3) 0%, var(--ghostnet-color-rgba-8-7-16-0-92) 100%);
+    background: linear-gradient(
+      180deg,
+      rgba(var(--ghostnet-color-primary-dark-rgb), 0.28) 0%,
+      rgba(var(--ghostnet-color-background-rgb), 0.92) 100%
+    );
   }
   70% {
     opacity: 0.6;
   }
   100% {
     opacity: 1;
-    background: linear-gradient(180deg, var(--ghostnet-color-rgba-5-8-13-0) 0%, var(--ghostnet-color-rgba-5-8-13-0-9) 100%);
+    background: linear-gradient(180deg, rgba(var(--ghostnet-color-background-rgb), 0) 0%, rgba(var(--ghostnet-color-background-rgb), 0.9) 100%);
   }
 }
 
@@ -1668,22 +1521,22 @@
 
 @keyframes ghostnetArrivalChromatic {
   0% {
-    color: var(--ghostnet-color-rgba-255-200-140-0-95);
-    text-shadow: 0 0 1.35rem var(--ghostnet-color-rgba-255-126-59-0-55);
+    color: rgba(var(--ghostnet-color-warning-rgb), 0.95);
+    text-shadow: 0 0 1.35rem rgba(var(--ghostnet-color-warning-rgb), 0.55);
     transform: translate3d(0, 0, 0);
   }
   35% {
-    color: var(--ghostnet-color-rgba-255-215-170-0-9);
-    text-shadow: 0 0 1.15rem var(--ghostnet-color-rgba-255-160-86-0-45);
+    color: rgba(var(--ghostnet-color-warning-rgb), 0.85);
+    text-shadow: 0 0 1.15rem rgba(var(--ghostnet-color-warning-rgb), 0.45);
   }
   55% {
-    color: var(--ghostnet-color-rgba-255-150-220-0-9);
-    text-shadow: 0 0 1.35rem var(--ghostnet-color-rgba-255-88-172-0-6);
+    color: rgba(var(--ghostnet-color-success-rgb), 0.9);
+    text-shadow: 0 0 1.35rem rgba(var(--ghostnet-color-success-rgb), 0.55);
     transform: translate3d(-2px, 1px, 0);
   }
   68% {
-    color: var(--ghostnet-color-rgba-195-168-255-0-92);
-    text-shadow: 0 0 1.35rem var(--ghostnet-color-rgba-93-46-255-0-65);
+    color: rgba(var(--ghostnet-color-primary-rgb), 0.92);
+    text-shadow: 0 0 1.35rem rgba(var(--ghostnet-color-primary-rgb), 0.65);
     transform: translate3d(2px, -1px, 0);
   }
   100% {
@@ -1695,27 +1548,27 @@
 
 @keyframes ghostnetArrivalPanel {
   0% {
-    background: var(--ghostnet-color-rgba-45-23-9-0-92);
-    border-color: var(--ghostnet-color-rgba-255-173-102-0-5);
-    box-shadow: 0 1.85rem 3.9rem var(--ghostnet-color-rgba-30-12-4-0-7);
+    background: rgba(var(--ghostnet-color-primary-dark-rgb), 0.82);
+    border-color: rgba(var(--ghostnet-color-warning-rgb), 0.5);
+    box-shadow: 0 1.85rem 3.9rem rgba(var(--ghostnet-color-background-rgb), 0.7);
     filter: saturate(1.05);
     transform: translate3d(0, 8px, 0);
   }
   40% {
-    background: var(--ghostnet-color-rgba-28-18-42-0-9);
-    border-color: var(--ghostnet-color-rgba-228-175-255-0-38);
-    box-shadow: 0 1.95rem 4rem var(--ghostnet-color-rgba-14-8-26-0-75);
+    background: rgba(var(--ghostnet-color-surface-rgb), 0.9);
+    border-color: rgba(var(--ghostnet-color-primary-rgb), 0.38);
+    box-shadow: 0 1.95rem 4rem rgba(var(--ghostnet-color-background-rgb), 0.75);
     transform: translate3d(-2px, 2px, 0);
   }
   68% {
-    background: var(--ghostnet-color-rgba-22-16-33-0-92);
-    border-color: var(--ghostnet-color-rgba-188-148-255-0-34);
+    background: rgba(var(--ghostnet-color-background-rgb), 0.9);
+    border-color: rgba(var(--ghostnet-color-primary-rgb), 0.34);
     transform: translate3d(2px, -2px, 0);
   }
   100% {
     background: var(--ghostnet-panel);
     border-color: var(--ghostnet-panel-border);
-    box-shadow: 0 1.75rem 3.5rem var(--ghostnet-color-rgba-3-7-11-0-8);
+    box-shadow: 0 1.75rem 3.5rem rgba(var(--ghostnet-color-background-rgb), 0.8);
     filter: none;
     transform: none;
   }
@@ -1723,25 +1576,25 @@
 
 @keyframes ghostnetArrivalBadge {
   0% {
-    background: var(--ghostnet-color-rgba-255-183-120-0-28);
-    border-color: var(--ghostnet-color-rgba-255-173-102-0-55);
-    color: var(--ghostnet-color-rgba-255-198-140-0-92);
+    background: rgba(var(--ghostnet-color-warning-rgb), 0.28);
+    border-color: rgba(var(--ghostnet-color-warning-rgb), 0.55);
+    color: rgba(var(--ghostnet-color-warning-rgb), 0.92);
     transform: translate3d(0, 4px, 0);
   }
   55% {
-    background: var(--ghostnet-color-rgba-255-150-220-0-22);
-    border-color: var(--ghostnet-color-rgba-222-178-255-0-42);
-    color: var(--ghostnet-color-rgba-228-175-255-0-85);
+    background: rgba(var(--ghostnet-color-primary-rgb), 0.22);
+    border-color: rgba(var(--ghostnet-color-primary-rgb), 0.42);
+    color: rgba(var(--ghostnet-color-primary-rgb), 0.85);
     transform: translate3d(-2px, 0, 0);
   }
   70% {
-    background: var(--ghostnet-color-rgba-130-220-255-0-2);
-    border-color: var(--ghostnet-color-rgba-188-148-255-0-38);
+    background: rgba(var(--ghostnet-color-success-rgb), 0.2);
+    border-color: rgba(var(--ghostnet-color-primary-rgb), 0.38);
     transform: translate3d(1px, -1px, 0);
   }
   100% {
-    background: var(--ghostnet-color-rgba-216-180-254-0-12);
-    border: 1px solid var(--ghostnet-color-rgba-216-180-254-0-42);
+    background: rgba(var(--ghostnet-color-primary-rgb), 0.12);
+    border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.42);
     color: var(--ghostnet-accent);
     transform: none;
   }

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -3,24 +3,32 @@
   min-height: 100%;
   --ghostnet-terminal-height: clamp(180px, 18vh, 220px);
   --ghostnet-bg: var(--ghostnet-color-background);
-  --ghostnet-panel: rgba(var(--ghostnet-color-background-rgb), 0.88);
-  --ghostnet-panel-border: var(--ghostnet-color-border-soft);
-  --ghostnet-ink: rgba(var(--ghostnet-color-text-strong-rgb), 0.92);
-  --ghostnet-muted: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
-  --ghostnet-subdued: rgba(var(--ghostnet-color-text-strong-rgb), 0.56);
-  --ghostnet-text-soft: rgba(var(--ghostnet-color-text-strong-rgb), 0.68);
-  --ghostnet-text-faint: rgba(var(--ghostnet-color-text-strong-rgb), 0.54);
+  --ghostnet-panel: color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent);
+  --ghostnet-border-soft: color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+  --ghostnet-border-regular: color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
+  --ghostnet-border-strong: color-mix(in srgb, var(--ghostnet-color-primary) 55%, transparent);
+  --ghostnet-border-focus: color-mix(in srgb, var(--ghostnet-color-primary-light) 45%, transparent);
+  --ghostnet-panel-border: var(--ghostnet-border-soft);
+  --ghostnet-shadow: color-mix(in srgb, var(--ghostnet-color-background) 55%, transparent);
+  --ghostnet-shadow-deep: color-mix(in srgb, var(--ghostnet-color-background) 68%, transparent);
+  --ghostnet-glow: color-mix(in srgb, var(--ghostnet-color-primary-light) 36%, transparent);
+  --ghostnet-divider: color-mix(in srgb, var(--ghostnet-color-text-strong) 16%, transparent);
+  --ghostnet-ink: color-mix(in srgb, var(--ghostnet-color-text-strong) 92%, transparent);
+  --ghostnet-muted: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
+  --ghostnet-subdued: color-mix(in srgb, var(--ghostnet-color-text-strong) 56%, transparent);
+  --ghostnet-text-soft: color-mix(in srgb, var(--ghostnet-color-text-strong) 68%, transparent);
+  --ghostnet-text-faint: color-mix(in srgb, var(--ghostnet-color-text-strong) 54%, transparent);
   --ghostnet-accent: var(--ghostnet-color-primary-light);
-  --ghostnet-highlight: rgba(var(--ghostnet-color-primary-rgb), 0.12);
+  --ghostnet-highlight: color-mix(in srgb, var(--ghostnet-color-primary-light) 18%, transparent);
+  --ghostnet-highlight-strong: color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
   --ghostnet-table-header: linear-gradient(
     180deg,
-    rgba(var(--ghostnet-color-primary-rgb), 0.85) 0%,
-    rgba(var(--ghostnet-color-primary-dark-rgb), 0.8) 75%,
-    rgba(var(--ghostnet-color-primary-rgb), 0.65) 100%
+    color-mix(in srgb, var(--ghostnet-color-primary) 82%, transparent) 0%,
+    color-mix(in srgb, var(--ghostnet-color-primary-dark) 78%, transparent) 100%
   );
-  --ghostnet-gradient-top: rgba(var(--ghostnet-color-surface-rgb), 0.92);
-  --ghostnet-gradient-mid: rgba(var(--ghostnet-color-primary-dark-rgb), 0.6);
-  --ghostnet-gradient-bottom: rgba(var(--ghostnet-color-background-rgb), 0.88);
+  --ghostnet-gradient-top: color-mix(in srgb, var(--ghostnet-color-surface) 92%, transparent);
+  --ghostnet-gradient-mid: color-mix(in srgb, var(--ghostnet-color-primary-dark) 60%, transparent);
+  --ghostnet-gradient-bottom: color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent);
   padding: 2.5rem 3rem calc(3.5rem + var(--ghostnet-terminal-height));
   background: linear-gradient(165deg, var(--ghostnet-gradient-top) 0%, var(--ghostnet-gradient-mid) 55%, var(--ghostnet-gradient-bottom) 100%),
     var(--ghostnet-bg);
@@ -42,7 +50,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(var(--ghostnet-color-background-rgb), 0) 0%, rgba(var(--ghostnet-color-background-rgb), 0.9) 100%);
+  background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--ghostnet-color-background) 90%, transparent) 100%);
   pointer-events: none;
 }
 
@@ -113,13 +121,13 @@
 .terminalShell {
   width: 100%;
   max-width: none;
-  background: linear-gradient(180deg, rgba(var(--ghostnet-color-surface-rgb), 0.92) 0%, rgba(var(--ghostnet-color-background-rgb), 0.94) 100%);
-  border: 1px solid var(--ghostnet-color-border);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-surface) 92%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-background) 94%, transparent) 100%);
+  border: 1px solid var(--ghostnet-border-regular);
   border-bottom: none;
   border-radius: 1.5rem 1.5rem 0 0;
   color: var(--ghostnet-ink);
   pointer-events: auto;
-  box-shadow: 0 -1.25rem 2.75rem var(--ghostnet-color-shadow-deep), 0 0 1.75rem var(--ghostnet-color-glow);
+  box-shadow: 0 -1.25rem 2.75rem var(--ghostnet-shadow-deep), 0 0 1.75rem var(--ghostnet-glow);
   backdrop-filter: blur(16px);
   display: flex;
   flex-direction: column;
@@ -131,8 +139,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.5rem 0.75rem 1.5rem;
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.12);
-  border-bottom: 1px solid var(--ghostnet-color-border-soft);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 12%, transparent);
+  border-bottom: 1px solid var(--ghostnet-border-soft);
 }
 
 .terminalHeaderContent {
@@ -150,7 +158,7 @@
 
 .terminalStatus {
   font-size: 0.8rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.68);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 68%, transparent);
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
 }
 
@@ -161,23 +169,23 @@
   gap: 0.5rem;
   padding: 0.4rem 1.1rem;
   border-radius: 999px;
-  border: 1px solid var(--ghostnet-color-border-strong);
-  background: linear-gradient(135deg, rgba(var(--ghostnet-color-primary-rgb), 0.72), rgba(var(--ghostnet-color-primary-rgb), 0.48));
+  border: 1px solid var(--ghostnet-border-strong);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 72%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 48%, transparent));
   color: var(--ghostnet-color-text-strong);
   text-transform: uppercase;
   letter-spacing: 0.24em;
   font-size: 0.72rem;
   cursor: pointer;
-  text-shadow: 0 0 12px rgba(var(--ghostnet-color-primary-rgb), 0.55);
-  box-shadow: 0 0 0 rgba(var(--ghostnet-color-primary-rgb), 0);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--ghostnet-color-primary) 55%, transparent);
+  box-shadow: 0 0 0 transparent;
   transition: background 200ms ease, transform 200ms ease, box-shadow 200ms ease;
 }
 
 .terminalToggle:hover,
 .terminalToggle:focus-visible {
-  background: linear-gradient(135deg, rgba(var(--ghostnet-color-primary-rgb), 0.88), rgba(var(--ghostnet-color-primary-rgb), 0.62));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 88%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 62%, transparent));
   transform: translateY(-1px);
-  box-shadow: 0 0 18px rgba(var(--ghostnet-color-primary-rgb), 0.38);
+  box-shadow: 0 0 18px color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
 }
 
 .terminalToggle:focus-visible {
@@ -186,16 +194,16 @@
 }
 
 .terminalToggle:active {
-  background: linear-gradient(135deg, rgba(var(--ghostnet-color-primary-dark-rgb), 0.78), rgba(var(--ghostnet-color-primary-rgb), 0.52));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary-dark) 78%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 52%, transparent));
   transform: translateY(1px);
-  box-shadow: 0 0 10px rgba(var(--ghostnet-color-primary-dark-rgb), 0.48);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--ghostnet-color-primary-dark) 48%, transparent);
 }
 
 .terminalToggleIcon {
   font-size: 0.95rem;
   line-height: 1;
   color: var(--ghostnet-color-text-strong);
-  text-shadow: 0 0 14px rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+  text-shadow: 0 0 14px color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   transition: transform 200ms ease, color 200ms ease;
 }
 
@@ -209,10 +217,10 @@
 .terminalToggleCollapsed {
   background: linear-gradient(
     135deg,
-    rgba(var(--ghostnet-color-primary-dark-rgb), 0.82),
-    rgba(var(--ghostnet-color-primary-rgb), 0.48)
+    color-mix(in srgb, var(--ghostnet-color-primary-dark) 82%, transparent),
+    color-mix(in srgb, var(--ghostnet-color-primary) 48%, transparent)
   );
-  box-shadow: 0 0 14px rgba(var(--ghostnet-color-primary-dark-rgb), 0.36);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--ghostnet-color-primary-dark) 36%, transparent);
 }
 
 .terminalToggleCollapsed .terminalToggleIcon {
@@ -224,8 +232,8 @@
   padding: 1.25rem 1.5rem 1.5rem;
   background: linear-gradient(
     180deg,
-    rgba(var(--ghostnet-color-primary-rgb), 0.16) 0%,
-    rgba(var(--ghostnet-color-primary-rgb), 0.04) 60%,
+    color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent) 0%,
+    color-mix(in srgb, var(--ghostnet-color-primary) 4%, transparent) 60%,
     transparent 100%
   );
   overflow: hidden;
@@ -265,7 +273,7 @@
 }
 
 .terminalPromptResponse {
-  color: rgba(var(--ghostnet-color-primary-rgb), 0.75);
+  color: color-mix(in srgb, var(--ghostnet-color-primary) 75%, transparent);
 }
 
 .terminalPromptAlert {
@@ -281,25 +289,25 @@
 }
 
 .terminalPromptDecrypt {
-  color: rgba(var(--ghostnet-color-primary-rgb), 0.95);
+  color: color-mix(in srgb, var(--ghostnet-color-primary) 95%, transparent);
 }
 
 .terminalPromptGlitch {
-  color: rgba(var(--ghostnet-color-primary-rgb), 0.85);
-  text-shadow: 0 0 18px rgba(var(--ghostnet-color-primary-rgb), 0.48);
+  color: color-mix(in srgb, var(--ghostnet-color-primary) 85%, transparent);
+  text-shadow: 0 0 18px color-mix(in srgb, var(--ghostnet-color-primary) 48%, transparent);
 }
 
 .terminalPromptSystem {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.72);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 72%, transparent);
 }
 
 .terminalText {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.82);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 82%, transparent);
 }
 
 .terminalTextAlert {
   color: var(--ghostnet-color-warning);
-  text-shadow: 0 0 12px rgba(var(--ghostnet-color-warning-rgb), 0.58);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--ghostnet-color-warning) 58%, transparent);
 }
 
 .terminalTextCipher {
@@ -308,22 +316,22 @@
 }
 
 .terminalTextBinary {
-  color: rgba(var(--ghostnet-color-success-rgb), 0.92);
-  text-shadow: 0 0 10px rgba(var(--ghostnet-color-success-rgb), 0.55);
+  color: color-mix(in srgb, var(--ghostnet-color-success) 92%, transparent);
+  text-shadow: 0 0 10px color-mix(in srgb, var(--ghostnet-color-success) 55%, transparent);
 }
 
 .terminalTextDecrypt {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.95);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 95%, transparent);
 }
 
 .terminalTextGlitch {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
   letter-spacing: 0.2em;
-  text-shadow: 0 0 22px rgba(var(--ghostnet-color-primary-rgb), 0.45);
+  text-shadow: 0 0 22px color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
 }
 
 .terminalTextSystem {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.92);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 92%, transparent);
 }
 
 @keyframes terminalLineReveal {
@@ -355,7 +363,7 @@
   border-radius: 1.25rem;
   background: var(--ghostnet-panel);
   border: 1px solid var(--ghostnet-panel-border);
-  box-shadow: 0 1.75rem 3.5rem var(--ghostnet-color-shadow);
+  box-shadow: 0 1.75rem 3.5rem var(--ghostnet-shadow);
   backdrop-filter: blur(12px);
 }
 
@@ -388,8 +396,8 @@
 .sectionFrameElevated {
   border-radius: 1.5rem;
   background: var(--ghostnet-panel);
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.32);
-  box-shadow: 0 1.75rem 4rem rgba(var(--ghostnet-color-background-rgb), 0.85);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 32%, transparent);
+  box-shadow: 0 1.75rem 4rem color-mix(in srgb, var(--ghostnet-color-background) 85%, transparent);
   backdrop-filter: blur(14px);
 }
 
@@ -417,8 +425,8 @@
   text-transform: uppercase;
   letter-spacing: 0.18em;
   border-radius: 999px;
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.42);
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.12);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 42%, transparent);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 12%, transparent);
   color: var(--ghostnet-accent);
 }
 
@@ -434,16 +442,16 @@
 
 .dataTableContainer {
   position: relative;
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.38);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
   border-radius: 1.25rem;
   background: linear-gradient(
       175deg,
-      rgba(var(--ghostnet-color-primary-rgb), 0.18) 0%,
-      rgba(var(--ghostnet-color-primary-dark-rgb), 0.12) 45%,
+      color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent) 0%,
+      color-mix(in srgb, var(--ghostnet-color-primary-dark) 12%, transparent) 45%,
       transparent 100%
     ),
-    linear-gradient(180deg, rgba(var(--ghostnet-color-background-rgb), 0.95) 0%, rgba(var(--ghostnet-color-background-rgb), 0.94) 100%);
-  box-shadow: 0 1.65rem 3.75rem rgba(var(--ghostnet-color-background-rgb), 0.78);
+    linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-background) 95%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-background) 94%, transparent) 100%);
+  box-shadow: 0 1.65rem 3.75rem color-mix(in srgb, var(--ghostnet-color-background) 78%, transparent);
   overflow: hidden;
 }
 
@@ -466,11 +474,11 @@
 
 .dataTable thead {
   background: var(--ghostnet-table-header);
-  box-shadow: inset 0 -1px 0 rgba(var(--ghostnet-color-primary-rgb), 0.38);
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
 }
 
 .dataTable thead tr {
-  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.45);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
   background: var(--ghostnet-table-header);
 }
 
@@ -479,7 +487,7 @@
   font-size: 0.72rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.88);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 88%, transparent);
   font-weight: 600;
   text-align: left;
   white-space: nowrap;
@@ -488,16 +496,16 @@
 .dataTable tbody tr {
   background: linear-gradient(
     180deg,
-    rgba(var(--ghostnet-color-background-rgb), 0.86) 0%,
-    rgba(var(--ghostnet-color-primary-dark-rgb), 0.35) 100%
+    color-mix(in srgb, var(--ghostnet-color-background) 86%, transparent) 0%,
+    color-mix(in srgb, var(--ghostnet-color-primary-dark) 35%, transparent) 100%
   );
-  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.25);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
   transition: background 0.25s ease, transform 0.25s ease;
   font-size: 0.95rem;
 }
 
 .dataTable tbody tr:nth-child(even) {
-  background: rgba(var(--ghostnet-color-primary-dark-rgb), 0.45);
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 45%, transparent);
 }
 
 .dataTable tbody tr:last-child {
@@ -505,7 +513,7 @@
 }
 
 .dataTable tbody tr:hover {
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.18);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent);
 }
 
 .dataTable td {
@@ -516,7 +524,7 @@
 }
 
 .nonCommodityRow {
-  background: rgba(var(--ghostnet-color-primary-dark-rgb), 0.4);
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 40%, transparent);
   font-size: 0.85rem;
   line-height: 1.2;
 }
@@ -541,11 +549,11 @@
   font-size: 0.7rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.45);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
   border-radius: 999px;
   padding: 0.1rem 0.6rem;
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.18);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent);
 }
 
 .nonCommodityQuantity {
@@ -608,20 +616,20 @@
 }
 
 .tableRowInteractive:hover {
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.2);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 20%, transparent);
 }
 
 .tableRowExpanded {
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.16) !important;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent) !important;
 }
 
 .tableRowExpanded:hover {
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.22) !important;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 22%, transparent) !important;
 }
 
 .tableDetailRow td {
-  background: rgba(var(--ghostnet-color-background-rgb), 0.88);
-  border-top: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.25);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
   padding: 0 1.5rem 1.5rem;
 }
 
@@ -655,7 +663,7 @@
 }
 
 .tableMessageBorder {
-  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.25);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
 }
 
 .tableIdleState {
@@ -680,7 +688,7 @@
 }
 
 .tableMetaMuted {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   font-size: 0.75rem;
   margin-top: 0.25rem;
 }
@@ -692,13 +700,13 @@
 }
 
 .tableMutedNote {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   font-size: 0.75rem;
   margin-top: 0.45rem;
 }
 
 .tableIndicatorPlaceholder {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   font-size: 0.82rem;
 }
 
@@ -724,12 +732,12 @@
   padding: 1.75rem 2rem;
   background: linear-gradient(
     135deg,
-    rgba(var(--ghostnet-color-primary-dark-rgb), 0.85),
-    rgba(var(--ghostnet-color-background-rgb), 0.9)
+    color-mix(in srgb, var(--ghostnet-color-primary-dark) 85%, transparent),
+    color-mix(in srgb, var(--ghostnet-color-background) 90%, transparent)
   );
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.38);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
   border-radius: 1.25rem;
-  box-shadow: 0 1.5rem 3rem var(--ghostnet-color-shadow);
+  box-shadow: 0 1.5rem 3rem var(--ghostnet-shadow);
 }
 
 .routeDetailBackButton {
@@ -738,11 +746,11 @@
   gap: 0.55rem;
   padding: 0.55rem 1.4rem;
   border-radius: 999px;
-  border: 1px solid var(--ghostnet-color-border-strong);
+  border: 1px solid var(--ghostnet-border-strong);
   background: linear-gradient(
     135deg,
-    rgba(var(--ghostnet-color-primary-rgb), 0.62),
-    rgba(var(--ghostnet-color-primary-rgb), 0.4)
+    color-mix(in srgb, var(--ghostnet-color-primary) 62%, transparent),
+    color-mix(in srgb, var(--ghostnet-color-primary) 40%, transparent)
   );
   color: var(--ghostnet-color-text-strong);
   text-transform: uppercase;
@@ -750,18 +758,18 @@
   font-size: 0.66rem;
   cursor: pointer;
   transition: background 200ms ease, box-shadow 200ms ease, transform 200ms ease;
-  text-shadow: 0 0 14px rgba(var(--ghostnet-color-primary-rgb), 0.45);
+  text-shadow: 0 0 14px color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
 }
 
 .routeDetailBackButton:hover,
 .routeDetailBackButton:focus-visible {
   background: linear-gradient(
     135deg,
-    rgba(var(--ghostnet-color-primary-rgb), 0.8),
-    rgba(var(--ghostnet-color-primary-rgb), 0.55)
+    color-mix(in srgb, var(--ghostnet-color-primary) 80%, transparent),
+    color-mix(in srgb, var(--ghostnet-color-primary) 55%, transparent)
   );
   transform: translateY(-1px);
-  box-shadow: 0 0 18px rgba(var(--ghostnet-color-primary-rgb), 0.4);
+  box-shadow: 0 0 18px color-mix(in srgb, var(--ghostnet-color-primary) 40%, transparent);
 }
 
 .routeDetailBackButton:focus-visible {
@@ -772,11 +780,11 @@
 .routeDetailBackButton:active {
   background: linear-gradient(
     135deg,
-    rgba(var(--ghostnet-color-primary-dark-rgb), 0.75),
-    rgba(var(--ghostnet-color-primary-rgb), 0.5)
+    color-mix(in srgb, var(--ghostnet-color-primary-dark) 75%, transparent),
+    color-mix(in srgb, var(--ghostnet-color-primary) 50%, transparent)
   );
   transform: translateY(1px);
-  box-shadow: 0 0 12px rgba(var(--ghostnet-color-primary-dark-rgb), 0.48);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--ghostnet-color-primary-dark) 48%, transparent);
 }
 
 .routeDetailHeading {
@@ -792,7 +800,7 @@
   text-transform: uppercase;
   letter-spacing: 0.32em;
   font-size: 0.68rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
 }
 
 .routeDetailTitle {
@@ -802,7 +810,7 @@
   gap: 0.85rem;
   font-size: 1.65rem;
   color: var(--ghostnet-color-text-strong);
-  text-shadow: 0 0 14px rgba(var(--ghostnet-color-primary-rgb), 0.45);
+  text-shadow: 0 0 14px color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
   margin: 0;
 }
 
@@ -818,11 +826,11 @@
   gap: 0.65rem;
   margin: 0;
   font-size: 0.92rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.74);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 74%, transparent);
 }
 
 .routeDetailArrow {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   font-size: 1.1rem;
 }
 
@@ -833,16 +841,16 @@
   min-width: 160px;
   padding: 0.9rem 1.25rem;
   border-radius: 1rem;
-  background: rgba(var(--ghostnet-color-primary-dark-rgb), 0.6);
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.35);
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.78);
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 60%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 78%, transparent);
 }
 
 .routeDetailMetaLabel {
   text-transform: uppercase;
   letter-spacing: 0.22em;
   font-size: 0.65rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
 }
 
 .routeDetailMetaValue {
@@ -863,16 +871,16 @@
   gap: 0.4rem;
   padding: 1.15rem 1.35rem;
   border-radius: 1.1rem;
-  background: rgba(var(--ghostnet-color-background-rgb), 0.92);
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.32);
-  box-shadow: 0 1.2rem 2.4rem rgba(var(--ghostnet-color-background-rgb), 0.55);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 32%, transparent);
+  box-shadow: 0 1.2rem 2.4rem color-mix(in srgb, var(--ghostnet-color-background) 55%, transparent);
 }
 
 .routeDetailMetricLabel {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.68rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.62);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 62%, transparent);
 }
 
 .routeDetailMetricValue {
@@ -892,10 +900,10 @@
   flex-direction: column;
   gap: 1rem;
   padding: 1.75rem 1.9rem;
-  background: rgba(var(--ghostnet-color-background-rgb), 0.92);
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.32);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 32%, transparent);
   border-radius: 1.25rem;
-  box-shadow: 0 1.45rem 2.8rem rgba(var(--ghostnet-color-background-rgb), 0.55);
+  box-shadow: 0 1.45rem 2.8rem color-mix(in srgb, var(--ghostnet-color-background) 55%, transparent);
 }
 
 .routeDetailPanelHeader {
@@ -909,7 +917,7 @@
   text-transform: uppercase;
   letter-spacing: 0.28em;
   font-size: 0.68rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.62);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 62%, transparent);
 }
 
 .routeDetailStation {
@@ -937,7 +945,7 @@
 
 .routeDetailSystem {
   font-size: 0.85rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.62);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 62%, transparent);
 }
 
 .routeDetailInfoRow {
@@ -945,7 +953,7 @@
   justify-content: space-between;
   align-items: baseline;
   gap: 1rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.78);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 78%, transparent);
   font-size: 0.92rem;
 }
 
@@ -953,7 +961,7 @@
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.7rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.58);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 58%, transparent);
 }
 
 .routeDetailInfoValue {
@@ -966,7 +974,7 @@
 .routeDetailDividerLine {
   height: 1px;
   width: 100%;
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.25);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
   margin: 0.5rem 0 0.75rem;
 }
 
@@ -974,14 +982,14 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.84);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 84%, transparent);
 }
 
 .routeDetailCommodityLabel {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.68rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
 }
 
 .routeDetailCommodityValue {
@@ -995,7 +1003,7 @@
   flex-wrap: wrap;
   gap: 0.85rem;
   font-size: 0.88rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.74);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 74%, transparent);
 }
 
 @media (max-width: 1100px) {
@@ -1063,7 +1071,7 @@
   align-items: baseline;
   gap: 0.4rem;
   font-size: 0.95rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.84);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 84%, transparent);
 }
 
 .tableEntryValueHighlight {
@@ -1078,7 +1086,7 @@
 }
 
 .tableEntryLabel {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -1092,7 +1100,7 @@
 }
 
 .tableEntryFootnote {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   font-size: 0.75rem;
   margin-top: 0.2rem;
 }
@@ -1114,7 +1122,7 @@
 
 .tableFootnote {
   margin-top: 1.5rem;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   font-size: 0.85rem;
   line-height: 1.6;
 }
@@ -1161,7 +1169,7 @@
 }
 
 .noticeMuted {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.5);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 50%, transparent);
 }
 
 .inlineNotice {
@@ -1171,7 +1179,7 @@
 
 .inlineNoticeMuted {
   padding: 1rem 0;
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.5);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 50%, transparent);
 }
 
 .placeholder {
@@ -1182,9 +1190,9 @@
   color: var(--ghostnet-muted);
   font-size: 1.35rem;
   border-radius: 1.5rem;
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.28);
-  background: linear-gradient(160deg, rgba(var(--ghostnet-color-primary-rgb), 0.18), rgba(var(--ghostnet-color-background-rgb), 0.82));
-  box-shadow: 0 1.85rem 4rem rgba(var(--ghostnet-color-background-rgb), 0.78);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+  background: linear-gradient(160deg, color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent), color-mix(in srgb, var(--ghostnet-color-background) 82%, transparent));
+  box-shadow: 0 1.85rem 4rem color-mix(in srgb, var(--ghostnet-color-background) 78%, transparent);
 }
 
 .ghostnet :global(.ghostnet-surface) {
@@ -1204,17 +1212,17 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table) {
-  background: linear-gradient(180deg, rgba(var(--ghostnet-color-background-rgb), 0.94) 0%, rgba(var(--ghostnet-color-background-rgb), 0.92) 100%);
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.38);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-background) 94%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-background) 92%, transparent) 100%);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
   border-radius: 1.25rem;
   overflow: hidden;
-  box-shadow: 0 1.75rem 3.5rem rgba(var(--ghostnet-color-background-rgb), 0.75);
+  box-shadow: 0 1.75rem 3.5rem color-mix(in srgb, var(--ghostnet-color-background) 75%, transparent);
   backdrop-filter: blur(10px);
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable) {
-  background: linear-gradient(180deg, rgba(var(--ghostnet-color-primary-dark-rgb), 0.78) 0%, rgba(var(--ghostnet-color-background-rgb), 0.9) 100%);
-  scrollbar-color: rgba(var(--ghostnet-color-primary-rgb), 0.6) rgba(var(--ghostnet-color-background-rgb), 0.85);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-primary-dark) 78%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-background) 90%, transparent) 100%);
+  scrollbar-color: color-mix(in srgb, var(--ghostnet-color-primary) 60%, transparent) color-mix(in srgb, var(--ghostnet-color-background) 85%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar) {
@@ -1222,23 +1230,23 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-track) {
-  background: rgba(var(--ghostnet-color-background-rgb), 0.75);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 75%, transparent);
   border-radius: 0.65rem;
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-thumb) {
-  background: linear-gradient(180deg, rgba(var(--ghostnet-color-primary-rgb), 0.75) 0%, rgba(var(--ghostnet-color-primary-dark-rgb), 0.85) 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-primary) 75%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-primary-dark) 85%, transparent) 100%);
   border-radius: 0.65rem;
-  box-shadow: 0 0 0 2px rgba(var(--ghostnet-color-background-rgb), 0.55) inset;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ghostnet-color-background) 55%, transparent) inset;
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-thumb:hover) {
-  background: linear-gradient(180deg, rgba(var(--ghostnet-color-primary-rgb), 0.85) 0%, rgba(var(--ghostnet-color-primary-dark-rgb), 0.9) 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-primary) 85%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-primary-dark) 90%, transparent) 100%);
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead) {
   background: var(--ghostnet-table-header);
-  box-shadow: inset 0 -1px 0 rgba(var(--ghostnet-color-primary-rgb), 0.38);
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead tr) {
@@ -1246,25 +1254,25 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead tr th) {
-  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.45);
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.88);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 88%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr) {
-  border-bottom: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.25);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr:nth-child(even)) {
-  background: rgba(var(--ghostnet-color-primary-dark-rgb), 0.45);
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 45%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr:hover) {
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.18) !important;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent) !important;
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail) {
-  background: rgba(var(--ghostnet-color-background-rgb), 0.85);
-  border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.22);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 85%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 22%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail-status) {
@@ -1284,7 +1292,7 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .text-secondary) {
-  color: rgba(var(--ghostnet-color-text-strong-rgb), 0.85);
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 85%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table .text-muted) {
@@ -1301,12 +1309,12 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--active) {
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.18);
-  border-color: rgba(var(--ghostnet-color-primary-rgb), 0.45);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent);
+  border-color: color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--active:hover) {
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.24);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 24%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--icon) {
@@ -1314,7 +1322,7 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--icon:hover) {
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.16);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--secondary) {
@@ -1322,11 +1330,11 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--secondary:hover) {
-  background: rgba(var(--ghostnet-color-primary-rgb), 0.16);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__inspector) {
-  border-left: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.22);
+  border-left: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 22%, transparent);
 }
 
 @media (max-width: 640px) {
@@ -1363,18 +1371,18 @@
 @keyframes ghostnetArrivalSurface {
   0% {
     --ghostnet-bg: var(--ghostnet-color-background);
-    --ghostnet-panel: rgba(var(--ghostnet-color-primary-dark-rgb), 0.82);
-    --ghostnet-panel-border: rgba(var(--ghostnet-color-warning-rgb), 0.45);
-    --ghostnet-ink: rgba(var(--ghostnet-color-text-strong-rgb), 0.96);
-    --ghostnet-muted: rgba(var(--ghostnet-color-warning-rgb), 0.65);
-    --ghostnet-subdued: rgba(var(--ghostnet-color-warning-rgb), 0.45);
+    --ghostnet-panel: color-mix(in srgb, var(--ghostnet-color-primary-dark) 82%, transparent);
+    --ghostnet-panel-border: color-mix(in srgb, var(--ghostnet-color-warning) 45%, transparent);
+    --ghostnet-ink: color-mix(in srgb, var(--ghostnet-color-text-strong) 96%, transparent);
+    --ghostnet-muted: color-mix(in srgb, var(--ghostnet-color-warning) 65%, transparent);
+    --ghostnet-subdued: color-mix(in srgb, var(--ghostnet-color-warning) 45%, transparent);
     --ghostnet-accent: var(--ghostnet-color-warning);
-    --ghostnet-highlight: rgba(var(--ghostnet-color-warning-rgb), 0.28);
+    --ghostnet-highlight: color-mix(in srgb, var(--ghostnet-color-warning) 28%, transparent);
     background: linear-gradient(
         165deg,
-        rgba(var(--ghostnet-color-warning-rgb), 0.22) 0%,
-        rgba(var(--ghostnet-color-primary-rgb), 0.18) 45%,
-        rgba(var(--ghostnet-color-background-rgb), 0.9) 100%
+        color-mix(in srgb, var(--ghostnet-color-warning) 22%, transparent) 0%,
+        color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent) 45%,
+        color-mix(in srgb, var(--ghostnet-color-background) 90%, transparent) 100%
       ),
       var(--ghostnet-bg);
     filter: saturate(1.08) contrast(1.05);
@@ -1382,18 +1390,18 @@
   }
   42% {
     --ghostnet-bg: var(--ghostnet-color-background);
-    --ghostnet-panel: rgba(var(--ghostnet-color-surface-rgb), 0.88);
-    --ghostnet-panel-border: rgba(var(--ghostnet-color-primary-rgb), 0.38);
-    --ghostnet-ink: rgba(var(--ghostnet-color-text-strong-rgb), 0.94);
-    --ghostnet-muted: rgba(var(--ghostnet-color-text-strong-rgb), 0.78);
-    --ghostnet-subdued: rgba(var(--ghostnet-color-text-strong-rgb), 0.6);
+    --ghostnet-panel: color-mix(in srgb, var(--ghostnet-color-surface) 88%, transparent);
+    --ghostnet-panel-border: color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
+    --ghostnet-ink: color-mix(in srgb, var(--ghostnet-color-text-strong) 94%, transparent);
+    --ghostnet-muted: color-mix(in srgb, var(--ghostnet-color-text-strong) 78%, transparent);
+    --ghostnet-subdued: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
     --ghostnet-accent: var(--ghostnet-color-primary-light);
-    --ghostnet-highlight: rgba(var(--ghostnet-color-primary-rgb), 0.2);
+    --ghostnet-highlight: color-mix(in srgb, var(--ghostnet-color-primary) 20%, transparent);
     background: linear-gradient(
         165deg,
-        rgba(var(--ghostnet-color-primary-rgb), 0.24) 0%,
-        rgba(var(--ghostnet-color-primary-dark-rgb), 0.32) 55%,
-        rgba(var(--ghostnet-color-background-rgb), 0.88) 100%
+        color-mix(in srgb, var(--ghostnet-color-primary) 24%, transparent) 0%,
+        color-mix(in srgb, var(--ghostnet-color-primary-dark) 32%, transparent) 55%,
+        color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent) 100%
       ),
       var(--ghostnet-bg);
     filter: saturate(1.05);
@@ -1402,9 +1410,9 @@
   62% {
     background: linear-gradient(
         165deg,
-        rgba(var(--ghostnet-color-primary-rgb), 0.2) 0%,
-        rgba(var(--ghostnet-color-primary-dark-rgb), 0.28) 55%,
-        rgba(var(--ghostnet-color-background-rgb), 0.86) 100%
+        color-mix(in srgb, var(--ghostnet-color-primary) 20%, transparent) 0%,
+        color-mix(in srgb, var(--ghostnet-color-primary-dark) 28%, transparent) 55%,
+        color-mix(in srgb, var(--ghostnet-color-background) 86%, transparent) 100%
       ),
       var(--ghostnet-bg);
     filter: saturate(1.02);
@@ -1413,9 +1421,9 @@
   72% {
     background: linear-gradient(
         165deg,
-        rgba(var(--ghostnet-color-primary-rgb), 0.16) 0%,
-        rgba(var(--ghostnet-color-primary-dark-rgb), 0.26) 55%,
-        rgba(var(--ghostnet-color-background-rgb), 0.84) 100%
+        color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent) 0%,
+        color-mix(in srgb, var(--ghostnet-color-primary-dark) 26%, transparent) 55%,
+        color-mix(in srgb, var(--ghostnet-color-background) 84%, transparent) 100%
       ),
       var(--ghostnet-bg);
     filter: saturate(0.96);
@@ -1423,13 +1431,13 @@
   }
   100% {
     --ghostnet-bg: var(--ghostnet-color-background);
-    --ghostnet-panel: rgba(var(--ghostnet-color-background-rgb), 0.88);
-    --ghostnet-panel-border: var(--ghostnet-color-border-soft);
-    --ghostnet-ink: rgba(var(--ghostnet-color-text-strong-rgb), 0.92);
-    --ghostnet-muted: rgba(var(--ghostnet-color-text-strong-rgb), 0.7);
-    --ghostnet-subdued: rgba(var(--ghostnet-color-text-strong-rgb), 0.56);
+    --ghostnet-panel: color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent);
+    --ghostnet-panel-border: var(--ghostnet-border-soft);
+    --ghostnet-ink: color-mix(in srgb, var(--ghostnet-color-text-strong) 92%, transparent);
+    --ghostnet-muted: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
+    --ghostnet-subdued: color-mix(in srgb, var(--ghostnet-color-text-strong) 56%, transparent);
     --ghostnet-accent: var(--ghostnet-color-primary-light);
-    --ghostnet-highlight: rgba(var(--ghostnet-color-primary-rgb), 0.12);
+    --ghostnet-highlight: color-mix(in srgb, var(--ghostnet-color-primary) 12%, transparent);
     background: linear-gradient(
         165deg,
         var(--ghostnet-gradient-top) 0%,
@@ -1470,16 +1478,16 @@
     opacity: 0.85;
     background: linear-gradient(
       180deg,
-      rgba(var(--ghostnet-color-background-rgb), 0.35) 0%,
-      rgba(var(--ghostnet-color-background-rgb), 0.94) 100%
+      color-mix(in srgb, var(--ghostnet-color-background) 35%, transparent) 0%,
+      color-mix(in srgb, var(--ghostnet-color-background) 94%, transparent) 100%
     );
   }
   40% {
     opacity: 0.7;
     background: linear-gradient(
       180deg,
-      rgba(var(--ghostnet-color-primary-dark-rgb), 0.28) 0%,
-      rgba(var(--ghostnet-color-background-rgb), 0.92) 100%
+      color-mix(in srgb, var(--ghostnet-color-primary-dark) 28%, transparent) 0%,
+      color-mix(in srgb, var(--ghostnet-color-background) 92%, transparent) 100%
     );
   }
   70% {
@@ -1487,7 +1495,7 @@
   }
   100% {
     opacity: 1;
-    background: linear-gradient(180deg, rgba(var(--ghostnet-color-background-rgb), 0) 0%, rgba(var(--ghostnet-color-background-rgb), 0.9) 100%);
+    background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--ghostnet-color-background) 90%, transparent) 100%);
   }
 }
 
@@ -1521,22 +1529,22 @@
 
 @keyframes ghostnetArrivalChromatic {
   0% {
-    color: rgba(var(--ghostnet-color-warning-rgb), 0.95);
-    text-shadow: 0 0 1.35rem rgba(var(--ghostnet-color-warning-rgb), 0.55);
+    color: color-mix(in srgb, var(--ghostnet-color-warning) 95%, transparent);
+    text-shadow: 0 0 1.35rem color-mix(in srgb, var(--ghostnet-color-warning) 55%, transparent);
     transform: translate3d(0, 0, 0);
   }
   35% {
-    color: rgba(var(--ghostnet-color-warning-rgb), 0.85);
-    text-shadow: 0 0 1.15rem rgba(var(--ghostnet-color-warning-rgb), 0.45);
+    color: color-mix(in srgb, var(--ghostnet-color-warning) 85%, transparent);
+    text-shadow: 0 0 1.15rem color-mix(in srgb, var(--ghostnet-color-warning) 45%, transparent);
   }
   55% {
-    color: rgba(var(--ghostnet-color-success-rgb), 0.9);
-    text-shadow: 0 0 1.35rem rgba(var(--ghostnet-color-success-rgb), 0.55);
+    color: color-mix(in srgb, var(--ghostnet-color-success) 90%, transparent);
+    text-shadow: 0 0 1.35rem color-mix(in srgb, var(--ghostnet-color-success) 55%, transparent);
     transform: translate3d(-2px, 1px, 0);
   }
   68% {
-    color: rgba(var(--ghostnet-color-primary-rgb), 0.92);
-    text-shadow: 0 0 1.35rem rgba(var(--ghostnet-color-primary-rgb), 0.65);
+    color: color-mix(in srgb, var(--ghostnet-color-primary) 92%, transparent);
+    text-shadow: 0 0 1.35rem color-mix(in srgb, var(--ghostnet-color-primary) 65%, transparent);
     transform: translate3d(2px, -1px, 0);
   }
   100% {
@@ -1548,27 +1556,27 @@
 
 @keyframes ghostnetArrivalPanel {
   0% {
-    background: rgba(var(--ghostnet-color-primary-dark-rgb), 0.82);
-    border-color: rgba(var(--ghostnet-color-warning-rgb), 0.5);
-    box-shadow: 0 1.85rem 3.9rem rgba(var(--ghostnet-color-background-rgb), 0.7);
+    background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 82%, transparent);
+    border-color: color-mix(in srgb, var(--ghostnet-color-warning) 50%, transparent);
+    box-shadow: 0 1.85rem 3.9rem color-mix(in srgb, var(--ghostnet-color-background) 70%, transparent);
     filter: saturate(1.05);
     transform: translate3d(0, 8px, 0);
   }
   40% {
-    background: rgba(var(--ghostnet-color-surface-rgb), 0.9);
-    border-color: rgba(var(--ghostnet-color-primary-rgb), 0.38);
-    box-shadow: 0 1.95rem 4rem rgba(var(--ghostnet-color-background-rgb), 0.75);
+    background: color-mix(in srgb, var(--ghostnet-color-surface) 90%, transparent);
+    border-color: color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
+    box-shadow: 0 1.95rem 4rem color-mix(in srgb, var(--ghostnet-color-background) 75%, transparent);
     transform: translate3d(-2px, 2px, 0);
   }
   68% {
-    background: rgba(var(--ghostnet-color-background-rgb), 0.9);
-    border-color: rgba(var(--ghostnet-color-primary-rgb), 0.34);
+    background: color-mix(in srgb, var(--ghostnet-color-background) 90%, transparent);
+    border-color: color-mix(in srgb, var(--ghostnet-color-primary) 34%, transparent);
     transform: translate3d(2px, -2px, 0);
   }
   100% {
     background: var(--ghostnet-panel);
     border-color: var(--ghostnet-panel-border);
-    box-shadow: 0 1.75rem 3.5rem rgba(var(--ghostnet-color-background-rgb), 0.8);
+    box-shadow: 0 1.75rem 3.5rem color-mix(in srgb, var(--ghostnet-color-background) 80%, transparent);
     filter: none;
     transform: none;
   }
@@ -1576,25 +1584,25 @@
 
 @keyframes ghostnetArrivalBadge {
   0% {
-    background: rgba(var(--ghostnet-color-warning-rgb), 0.28);
-    border-color: rgba(var(--ghostnet-color-warning-rgb), 0.55);
-    color: rgba(var(--ghostnet-color-warning-rgb), 0.92);
+    background: color-mix(in srgb, var(--ghostnet-color-warning) 28%, transparent);
+    border-color: color-mix(in srgb, var(--ghostnet-color-warning) 55%, transparent);
+    color: color-mix(in srgb, var(--ghostnet-color-warning) 92%, transparent);
     transform: translate3d(0, 4px, 0);
   }
   55% {
-    background: rgba(var(--ghostnet-color-primary-rgb), 0.22);
-    border-color: rgba(var(--ghostnet-color-primary-rgb), 0.42);
-    color: rgba(var(--ghostnet-color-primary-rgb), 0.85);
+    background: color-mix(in srgb, var(--ghostnet-color-primary) 22%, transparent);
+    border-color: color-mix(in srgb, var(--ghostnet-color-primary) 42%, transparent);
+    color: color-mix(in srgb, var(--ghostnet-color-primary) 85%, transparent);
     transform: translate3d(-2px, 0, 0);
   }
   70% {
-    background: rgba(var(--ghostnet-color-success-rgb), 0.2);
-    border-color: rgba(var(--ghostnet-color-primary-rgb), 0.38);
+    background: color-mix(in srgb, var(--ghostnet-color-success) 20%, transparent);
+    border-color: color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
     transform: translate3d(1px, -1px, 0);
   }
   100% {
-    background: rgba(var(--ghostnet-color-primary-rgb), 0.12);
-    border: 1px solid rgba(var(--ghostnet-color-primary-rgb), 0.42);
+    background: color-mix(in srgb, var(--ghostnet-color-primary) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 42%, transparent);
     color: var(--ghostnet-accent);
     transform: none;
   }

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -183,8 +183,12 @@
   min-height: 100%;
   --ghostnet-terminal-height: clamp(180px, 18vh, 220px);
   padding: 2.5rem 3rem calc(3.5rem + var(--ghostnet-terminal-height));
-  background: radial-gradient(circle at 20% 15%, var(--ghostnet-color-rgba-216-180-254-0-14), transparent 55%),
-    radial-gradient(circle at 85% 10%, var(--ghostnet-color-rgba-167-139-250-0-22), transparent 60%),
+  background: linear-gradient(
+      180deg,
+      var(--ghostnet-color-rgba-28-22-51-0-92) 0%,
+      var(--ghostnet-color-rgba-42-14-130-0-82) 55%,
+      var(--ghostnet-color-rgba-16-9-38-0-76) 100%
+    ),
     var(--ghostnet-color-hex-05080d);
   color: var(--ghostnet-ink);
   overflow: hidden;
@@ -394,7 +398,11 @@
 .terminalBody {
   flex: 1;
   padding: 1.25rem 1.5rem 1.5rem;
-  background: radial-gradient(circle at 20% 0%, var(--ghostnet-color-rgba-93-46-255-0-18), transparent 55%);
+  background: linear-gradient(
+    180deg,
+    var(--ghostnet-color-rgba-42-14-130-0-78) 0%,
+    var(--ghostnet-color-rgba-16-9-38-0-76) 100%
+  );
   overflow: hidden;
   display: flex;
 }
@@ -603,7 +611,12 @@
   position: relative;
   border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-38);
   border-radius: 1.25rem;
-  background: radial-gradient(circle at 50% 0%, var(--ghostnet-color-rgba-93-46-255-0-18), transparent 65%),
+  background:
+    linear-gradient(
+      180deg,
+      var(--ghostnet-color-rgba-93-46-255-0-22) 0%,
+      transparent 45%
+    ),
     linear-gradient(180deg, var(--ghostnet-color-rgba-9-8-26-0-95) 0%, var(--ghostnet-color-rgba-7-11-20-0-94) 100%);
   box-shadow: 0 1.65rem 3.75rem var(--ghostnet-color-rgba-3-7-12-0-78);
   overflow: hidden;
@@ -1512,8 +1525,12 @@
     --ghostnet-subdued: var(--ghostnet-color-rgba-255-173-108-0-72);
     --ghostnet-accent: var(--ghostnet-color-hex-ffb874);
     --ghostnet-highlight: var(--ghostnet-color-rgba-255-173-108-0-38);
-    background: radial-gradient(circle at 20% 15%, var(--ghostnet-color-rgba-255-184-116-0-2), transparent 55%),
-      radial-gradient(circle at 85% 10%, var(--ghostnet-color-rgba-255-140-92-0-24), transparent 60%),
+    background: linear-gradient(
+        180deg,
+        var(--ghostnet-color-rgba-255-173-102-0-55) 0%,
+        var(--ghostnet-color-rgba-255-140-92-0-24) 45%,
+        var(--ghostnet-color-hex-120804) 100%
+      ),
       var(--ghostnet-color-hex-120804);
     filter: saturate(1.08) contrast(1.05) hue-rotate(-12deg);
     transform: scale(1.01);
@@ -1527,22 +1544,34 @@
     --ghostnet-subdued: var(--ghostnet-color-rgba-178-153-255-0-56);
     --ghostnet-accent: var(--ghostnet-color-hex-f0b8ff);
     --ghostnet-highlight: var(--ghostnet-color-rgba-216-180-254-0-2);
-    background: radial-gradient(circle at 22% 18%, var(--ghostnet-color-rgba-228-175-255-0-2), transparent 55%),
-      radial-gradient(circle at 80% 12%, var(--ghostnet-color-rgba-120-192-255-0-16), transparent 60%),
+    background: linear-gradient(
+        180deg,
+        var(--ghostnet-color-rgba-228-175-255-0-26) 0%,
+        var(--ghostnet-color-rgba-120-192-255-0-18) 45%,
+        var(--ghostnet-color-hex-080711) 100%
+      ),
       var(--ghostnet-color-hex-080711);
     filter: saturate(1.12) contrast(1.02) hue-rotate(4deg);
     transform: scale(1.006);
   }
   62% {
-    background: radial-gradient(circle at 24% 17%, var(--ghostnet-color-rgba-228-175-255-0-26), transparent 55%),
-      radial-gradient(circle at 78% 12%, var(--ghostnet-color-rgba-120-192-255-0-18), transparent 60%),
+    background: linear-gradient(
+        180deg,
+        var(--ghostnet-color-rgba-228-175-255-0-32) 0%,
+        var(--ghostnet-color-rgba-120-192-255-0-18) 50%,
+        var(--ghostnet-color-hex-0a0718) 100%
+      ),
       var(--ghostnet-color-hex-0a0718);
     filter: saturate(1.28) hue-rotate(10deg);
     transform: scale(1.004) translate3d(-3px, 1px, 0);
   }
   72% {
-    background: radial-gradient(circle at 26% 19%, var(--ghostnet-color-rgba-120-192-255-0-22), transparent 55%),
-      radial-gradient(circle at 82% 14%, var(--ghostnet-color-rgba-228-175-255-0-28), transparent 60%),
+    background: linear-gradient(
+        180deg,
+        var(--ghostnet-color-rgba-120-192-255-0-22) 0%,
+        var(--ghostnet-color-rgba-228-175-255-0-28) 50%,
+        var(--ghostnet-color-hex-060611) 100%
+      ),
       var(--ghostnet-color-hex-060611);
     filter: saturate(0.92) hue-rotate(-6deg);
     transform: scale(1.002) translate3d(2px, -1px, 0);
@@ -1556,8 +1585,12 @@
     --ghostnet-subdued: var(--ghostnet-color-hex-6c7c92);
     --ghostnet-accent: var(--ghostnet-color-hex-d8b4fe);
     --ghostnet-highlight: var(--ghostnet-color-rgba-216-180-254-0-12);
-    background: radial-gradient(circle at 20% 15%, var(--ghostnet-color-rgba-216-180-254-0-14), transparent 55%),
-      radial-gradient(circle at 85% 10%, var(--ghostnet-color-rgba-167-139-250-0-22), transparent 60%),
+    background: linear-gradient(
+        180deg,
+        var(--ghostnet-color-rgba-216-180-254-0-14) 0%,
+        var(--ghostnet-color-rgba-167-139-250-0-22) 55%,
+        var(--ghostnet-color-hex-05080d) 100%
+      ),
       var(--ghostnet-color-hex-05080d);
     filter: none;
     transform: none;

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1,26 +1,206 @@
+:global(:root) {
+  /* GhostNet color palette */
+  --ghostnet-color-hex-05080d: #05080d;
+  --ghostnet-color-hex-060611: #060611;
+  --ghostnet-color-hex-080711: #080711;
+  --ghostnet-color-hex-0a0718: #0a0718;
+  --ghostnet-color-hex-0f0720: #0f0720;
+  --ghostnet-color-hex-120804: #120804;
+  --ghostnet-color-hex-150a02: #150a02;
+  --ghostnet-color-hex-29f3c3: #29f3c3;
+  --ghostnet-color-hex-5bd1a5: #5bd1a5;
+  --ghostnet-color-hex-6c7c92: #6c7c92;
+  --ghostnet-color-hex-8da2bf: #8da2bf;
+  --ghostnet-color-hex-aaa: #aaa;
+  --ghostnet-color-hex-d8b4fe: #d8b4fe;
+  --ghostnet-color-hex-d8e9ff: #d8e9ff;
+  --ghostnet-color-hex-e0c8ff: #e0c8ff;
+  --ghostnet-color-hex-f0b8ff: #f0b8ff;
+  --ghostnet-color-hex-f5f1ff: #f5f1ff;
+  --ghostnet-color-hex-f6e9ff: #f6e9ff;
+  --ghostnet-color-hex-ff4d4f: #ff4d4f;
+  --ghostnet-color-hex-ff5fc1: #ff5fc1;
+  --ghostnet-color-hex-ffb874: #ffb874;
+  --ghostnet-color-hex-ffe8c9: #ffe8c9;
+  --ghostnet-color-rgba-10-15-22-0-88: rgba(10, 15, 22, 0.88);
+  --ghostnet-color-rgba-10-6-18-0-3: rgba(10, 6, 18, 0.3);
+  --ghostnet-color-rgba-10-6-2-0-94: rgba(10, 6, 2, 0.94);
+  --ghostnet-color-rgba-117-70-255-0-8: rgba(117, 70, 255, 0.8);
+  --ghostnet-color-rgba-117-70-255-0-85: rgba(117, 70, 255, 0.85);
+  --ghostnet-color-rgba-12-10-28-0-92: rgba(12, 10, 28, 0.92);
+  --ghostnet-color-rgba-120-140-168-0-75: rgba(120, 140, 168, 0.75);
+  --ghostnet-color-rgba-120-192-255-0-16: rgba(120, 192, 255, 0.16);
+  --ghostnet-color-rgba-120-192-255-0-18: rgba(120, 192, 255, 0.18);
+  --ghostnet-color-rgba-120-192-255-0-22: rgba(120, 192, 255, 0.22);
+  --ghostnet-color-rgba-13-11-26-0-55: rgba(13, 11, 26, 0.55);
+  --ghostnet-color-rgba-13-11-26-0-75: rgba(13, 11, 26, 0.75);
+  --ghostnet-color-rgba-13-11-26-0-85: rgba(13, 11, 26, 0.85);
+  --ghostnet-color-rgba-13-11-26-0-86: rgba(13, 11, 26, 0.86);
+  --ghostnet-color-rgba-13-11-26-0-94: rgba(13, 11, 26, 0.94);
+  --ghostnet-color-rgba-130-220-255-0-2: rgba(130, 220, 255, 0.2);
+  --ghostnet-color-rgba-14-8-26-0-75: rgba(14, 8, 26, 0.75);
+  --ghostnet-color-rgba-140-160-188-0-75: rgba(140, 160, 188, 0.75);
+  --ghostnet-color-rgba-140-160-188-0-78: rgba(140, 160, 188, 0.78);
+  --ghostnet-color-rgba-140-92-255-0-25: rgba(140, 92, 255, 0.25);
+  --ghostnet-color-rgba-140-92-255-0-28: rgba(140, 92, 255, 0.28);
+  --ghostnet-color-rgba-140-92-255-0-32: rgba(140, 92, 255, 0.32);
+  --ghostnet-color-rgba-140-92-255-0-35: rgba(140, 92, 255, 0.35);
+  --ghostnet-color-rgba-140-92-255-0-38: rgba(140, 92, 255, 0.38);
+  --ghostnet-color-rgba-140-92-255-0-4: rgba(140, 92, 255, 0.4);
+  --ghostnet-color-rgba-140-92-255-0-45: rgba(140, 92, 255, 0.45);
+  --ghostnet-color-rgba-140-92-255-0-48: rgba(140, 92, 255, 0.48);
+  --ghostnet-color-rgba-140-92-255-0-55: rgba(140, 92, 255, 0.55);
+  --ghostnet-color-rgba-140-92-255-0-6: rgba(140, 92, 255, 0.6);
+  --ghostnet-color-rgba-140-92-255-0-62: rgba(140, 92, 255, 0.62);
+  --ghostnet-color-rgba-140-92-255-0-65: rgba(140, 92, 255, 0.65);
+  --ghostnet-color-rgba-140-92-255-0-75: rgba(140, 92, 255, 0.75);
+  --ghostnet-color-rgba-140-92-255-0-85: rgba(140, 92, 255, 0.85);
+  --ghostnet-color-rgba-140-92-255-0-95: rgba(140, 92, 255, 0.95);
+  --ghostnet-color-rgba-16-9-38-0-7: rgba(16, 9, 38, 0.7);
+  --ghostnet-color-rgba-16-9-38-0-76: rgba(16, 9, 38, 0.76);
+  --ghostnet-color-rgba-167-139-250-0-22: rgba(167, 139, 250, 0.22);
+  --ghostnet-color-rgba-178-153-255-0-56: rgba(178, 153, 255, 0.56);
+  --ghostnet-color-rgba-188-148-255-0-34: rgba(188, 148, 255, 0.34);
+  --ghostnet-color-rgba-188-148-255-0-38: rgba(188, 148, 255, 0.38);
+  --ghostnet-color-rgba-195-168-255-0-92: rgba(195, 168, 255, 0.92);
+  --ghostnet-color-rgba-216-180-254-0-12: rgba(216, 180, 254, 0.12);
+  --ghostnet-color-rgba-216-180-254-0-14: rgba(216, 180, 254, 0.14);
+  --ghostnet-color-rgba-216-180-254-0-16: rgba(216, 180, 254, 0.16);
+  --ghostnet-color-rgba-216-180-254-0-18: rgba(216, 180, 254, 0.18);
+  --ghostnet-color-rgba-216-180-254-0-2: rgba(216, 180, 254, 0.2);
+  --ghostnet-color-rgba-216-180-254-0-22: rgba(216, 180, 254, 0.22);
+  --ghostnet-color-rgba-216-180-254-0-24: rgba(216, 180, 254, 0.24);
+  --ghostnet-color-rgba-216-180-254-0-28: rgba(216, 180, 254, 0.28);
+  --ghostnet-color-rgba-216-180-254-0-32: rgba(216, 180, 254, 0.32);
+  --ghostnet-color-rgba-216-180-254-0-42: rgba(216, 180, 254, 0.42);
+  --ghostnet-color-rgba-216-180-254-0-45: rgba(216, 180, 254, 0.45);
+  --ghostnet-color-rgba-22-15-44-0-92: rgba(22, 15, 44, 0.92);
+  --ghostnet-color-rgba-22-16-33-0-92: rgba(22, 16, 33, 0.92);
+  --ghostnet-color-rgba-22-16-40-0-9: rgba(22, 16, 40, 0.9);
+  --ghostnet-color-rgba-220-198-255-0-78: rgba(220, 198, 255, 0.78);
+  --ghostnet-color-rgba-220-228-255-0-84: rgba(220, 228, 255, 0.84);
+  --ghostnet-color-rgba-222-178-255-0-42: rgba(222, 178, 255, 0.42);
+  --ghostnet-color-rgba-228-175-255-0-2: rgba(228, 175, 255, 0.2);
+  --ghostnet-color-rgba-228-175-255-0-26: rgba(228, 175, 255, 0.26);
+  --ghostnet-color-rgba-228-175-255-0-28: rgba(228, 175, 255, 0.28);
+  --ghostnet-color-rgba-228-175-255-0-38: rgba(228, 175, 255, 0.38);
+  --ghostnet-color-rgba-228-175-255-0-42: rgba(228, 175, 255, 0.42);
+  --ghostnet-color-rgba-228-175-255-0-85: rgba(228, 175, 255, 0.85);
+  --ghostnet-color-rgba-24-12-6-0-4: rgba(24, 12, 6, 0.4);
+  --ghostnet-color-rgba-245-241-255-0-54: rgba(245, 241, 255, 0.54);
+  --ghostnet-color-rgba-245-241-255-0-56: rgba(245, 241, 255, 0.56);
+  --ghostnet-color-rgba-245-241-255-0-58: rgba(245, 241, 255, 0.58);
+  --ghostnet-color-rgba-245-241-255-0-6: rgba(245, 241, 255, 0.6);
+  --ghostnet-color-rgba-245-241-255-0-62: rgba(245, 241, 255, 0.62);
+  --ghostnet-color-rgba-245-241-255-0-68: rgba(245, 241, 255, 0.68);
+  --ghostnet-color-rgba-245-241-255-0-7: rgba(245, 241, 255, 0.7);
+  --ghostnet-color-rgba-245-241-255-0-72: rgba(245, 241, 255, 0.72);
+  --ghostnet-color-rgba-245-241-255-0-74: rgba(245, 241, 255, 0.74);
+  --ghostnet-color-rgba-245-241-255-0-78: rgba(245, 241, 255, 0.78);
+  --ghostnet-color-rgba-245-241-255-0-82: rgba(245, 241, 255, 0.82);
+  --ghostnet-color-rgba-245-241-255-0-84: rgba(245, 241, 255, 0.84);
+  --ghostnet-color-rgba-245-241-255-0-88: rgba(245, 241, 255, 0.88);
+  --ghostnet-color-rgba-245-241-255-0-92: rgba(245, 241, 255, 0.92);
+  --ghostnet-color-rgba-245-241-255-0-95: rgba(245, 241, 255, 0.95);
+  --ghostnet-color-rgba-255-126-59-0-55: rgba(255, 126, 59, 0.55);
+  --ghostnet-color-rgba-255-140-92-0-24: rgba(255, 140, 92, 0.24);
+  --ghostnet-color-rgba-255-150-220-0-22: rgba(255, 150, 220, 0.22);
+  --ghostnet-color-rgba-255-150-220-0-9: rgba(255, 150, 220, 0.9);
+  --ghostnet-color-rgba-255-160-86-0-45: rgba(255, 160, 86, 0.45);
+  --ghostnet-color-rgba-255-173-102-0-5: rgba(255, 173, 102, 0.5);
+  --ghostnet-color-rgba-255-173-102-0-55: rgba(255, 173, 102, 0.55);
+  --ghostnet-color-rgba-255-173-102-0-6: rgba(255, 173, 102, 0.6);
+  --ghostnet-color-rgba-255-173-108-0-38: rgba(255, 173, 108, 0.38);
+  --ghostnet-color-rgba-255-173-108-0-72: rgba(255, 173, 108, 0.72);
+  --ghostnet-color-rgba-255-183-120-0-28: rgba(255, 183, 120, 0.28);
+  --ghostnet-color-rgba-255-184-116-0-2: rgba(255, 184, 116, 0.2);
+  --ghostnet-color-rgba-255-198-140-0-92: rgba(255, 198, 140, 0.92);
+  --ghostnet-color-rgba-255-200-140-0-95: rgba(255, 200, 140, 0.95);
+  --ghostnet-color-rgba-255-207-156-0-9: rgba(255, 207, 156, 0.9);
+  --ghostnet-color-rgba-255-215-170-0-9: rgba(255, 215, 170, 0.9);
+  --ghostnet-color-rgba-255-88-172-0-6: rgba(255, 88, 172, 0.6);
+  --ghostnet-color-rgba-255-95-193-0-58: rgba(255, 95, 193, 0.58);
+  --ghostnet-color-rgba-26-17-60-0-9: rgba(26, 17, 60, 0.9);
+  --ghostnet-color-rgba-27-16-58-0-45: rgba(27, 16, 58, 0.45);
+  --ghostnet-color-rgba-28-18-42-0-9: rgba(28, 18, 42, 0.9);
+  --ghostnet-color-rgba-28-22-51-0-92: rgba(28, 22, 51, 0.92);
+  --ghostnet-color-rgba-3-7-11-0-78: rgba(3, 7, 11, 0.78);
+  --ghostnet-color-rgba-3-7-11-0-8: rgba(3, 7, 11, 0.8);
+  --ghostnet-color-rgba-3-7-12-0-78: rgba(3, 7, 12, 0.78);
+  --ghostnet-color-rgba-30-12-4-0-7: rgba(30, 12, 4, 0.7);
+  --ghostnet-color-rgba-35-20-68-0-85: rgba(35, 20, 68, 0.85);
+  --ghostnet-color-rgba-4-7-12-0-55: rgba(4, 7, 12, 0.55);
+  --ghostnet-color-rgba-4-8-13-0-85: rgba(4, 8, 13, 0.85);
+  --ghostnet-color-rgba-4-9-14-0-75: rgba(4, 9, 14, 0.75);
+  --ghostnet-color-rgba-4-9-14-0-85: rgba(4, 9, 14, 0.85);
+  --ghostnet-color-rgba-41-243-195-0-55: rgba(41, 243, 195, 0.55);
+  --ghostnet-color-rgba-41-243-195-0-92: rgba(41, 243, 195, 0.92);
+  --ghostnet-color-rgba-42-14-130-0-36: rgba(42, 14, 130, 0.36);
+  --ghostnet-color-rgba-42-14-130-0-48: rgba(42, 14, 130, 0.48);
+  --ghostnet-color-rgba-42-14-130-0-75: rgba(42, 14, 130, 0.75);
+  --ghostnet-color-rgba-42-14-130-0-78: rgba(42, 14, 130, 0.78);
+  --ghostnet-color-rgba-42-14-130-0-8: rgba(42, 14, 130, 0.8);
+  --ghostnet-color-rgba-42-14-130-0-82: rgba(42, 14, 130, 0.82);
+  --ghostnet-color-rgba-42-14-130-0-85: rgba(42, 14, 130, 0.85);
+  --ghostnet-color-rgba-42-14-130-0-9: rgba(42, 14, 130, 0.9);
+  --ghostnet-color-rgba-45-23-9-0-92: rgba(45, 23, 9, 0.92);
+  --ghostnet-color-rgba-45-25-98-0-85: rgba(45, 25, 98, 0.85);
+  --ghostnet-color-rgba-5-8-13-0: rgba(5, 8, 13, 0);
+  --ghostnet-color-rgba-5-8-13-0-55: rgba(5, 8, 13, 0.55);
+  --ghostnet-color-rgba-5-8-13-0-68: rgba(5, 8, 13, 0.68);
+  --ghostnet-color-rgba-5-8-13-0-82: rgba(5, 8, 13, 0.82);
+  --ghostnet-color-rgba-5-8-13-0-88: rgba(5, 8, 13, 0.88);
+  --ghostnet-color-rgba-5-8-13-0-9: rgba(5, 8, 13, 0.9);
+  --ghostnet-color-rgba-7-11-20-0-9: rgba(7, 11, 20, 0.9);
+  --ghostnet-color-rgba-7-11-20-0-92: rgba(7, 11, 20, 0.92);
+  --ghostnet-color-rgba-7-11-20-0-94: rgba(7, 11, 20, 0.94);
+  --ghostnet-color-rgba-8-7-16-0-92: rgba(8, 7, 16, 0.92);
+  --ghostnet-color-rgba-9-7-24-0-78: rgba(9, 7, 24, 0.78);
+  --ghostnet-color-rgba-9-8-26-0-95: rgba(9, 8, 26, 0.95);
+  --ghostnet-color-rgba-93-46-255-0: rgba(93, 46, 255, 0);
+  --ghostnet-color-rgba-93-46-255-0-12: rgba(93, 46, 255, 0.12);
+  --ghostnet-color-rgba-93-46-255-0-16: rgba(93, 46, 255, 0.16);
+  --ghostnet-color-rgba-93-46-255-0-18: rgba(93, 46, 255, 0.18);
+  --ghostnet-color-rgba-93-46-255-0-2: rgba(93, 46, 255, 0.2);
+  --ghostnet-color-rgba-93-46-255-0-22: rgba(93, 46, 255, 0.22);
+  --ghostnet-color-rgba-93-46-255-0-36: rgba(93, 46, 255, 0.36);
+  --ghostnet-color-rgba-93-46-255-0-38: rgba(93, 46, 255, 0.38);
+  --ghostnet-color-rgba-93-46-255-0-4: rgba(93, 46, 255, 0.4);
+  --ghostnet-color-rgba-93-46-255-0-45: rgba(93, 46, 255, 0.45);
+  --ghostnet-color-rgba-93-46-255-0-48: rgba(93, 46, 255, 0.48);
+  --ghostnet-color-rgba-93-46-255-0-5: rgba(93, 46, 255, 0.5);
+  --ghostnet-color-rgba-93-46-255-0-52: rgba(93, 46, 255, 0.52);
+  --ghostnet-color-rgba-93-46-255-0-55: rgba(93, 46, 255, 0.55);
+  --ghostnet-color-rgba-93-46-255-0-62: rgba(93, 46, 255, 0.62);
+  --ghostnet-color-rgba-93-46-255-0-65: rgba(93, 46, 255, 0.65);
+  --ghostnet-color-rgba-93-46-255-0-72: rgba(93, 46, 255, 0.72);
+  --ghostnet-color-rgba-93-46-255-0-75: rgba(93, 46, 255, 0.75);
+  --ghostnet-color-rgba-93-46-255-0-85: rgba(93, 46, 255, 0.85);
+  --ghostnet-color-rgba-93-46-255-0-88: rgba(93, 46, 255, 0.88);
+}
 .ghostnet {
   position: relative;
   min-height: 100%;
   --ghostnet-terminal-height: clamp(180px, 18vh, 220px);
   padding: 2.5rem 3rem calc(3.5rem + var(--ghostnet-terminal-height));
-  background: radial-gradient(circle at 20% 15%, rgba(216, 180, 254, 0.14), transparent 55%),
-    radial-gradient(circle at 85% 10%, rgba(167, 139, 250, 0.22), transparent 60%),
-    #05080d;
+  background: radial-gradient(circle at 20% 15%, var(--ghostnet-color-rgba-216-180-254-0-14), transparent 55%),
+    radial-gradient(circle at 85% 10%, var(--ghostnet-color-rgba-167-139-250-0-22), transparent 60%),
+    var(--ghostnet-color-hex-05080d);
   color: var(--ghostnet-ink);
   overflow: hidden;
-  --ghostnet-bg: #05080d;
-  --ghostnet-panel: rgba(10, 15, 22, 0.88);
-  --ghostnet-panel-border: rgba(216, 180, 254, 0.28);
-  --ghostnet-ink: #d8e9ff;
-  --ghostnet-muted: #8da2bf;
-  --ghostnet-subdued: #6c7c92;
-  --ghostnet-accent: #d8b4fe;
-  --ghostnet-highlight: rgba(216, 180, 254, 0.12);
+  --ghostnet-bg: var(--ghostnet-color-hex-05080d);
+  --ghostnet-panel: var(--ghostnet-color-rgba-10-15-22-0-88);
+  --ghostnet-panel-border: var(--ghostnet-color-rgba-216-180-254-0-28);
+  --ghostnet-ink: var(--ghostnet-color-hex-d8e9ff);
+  --ghostnet-muted: var(--ghostnet-color-hex-8da2bf);
+  --ghostnet-subdued: var(--ghostnet-color-hex-6c7c92);
+  --ghostnet-accent: var(--ghostnet-color-hex-d8b4fe);
+  --ghostnet-highlight: var(--ghostnet-color-rgba-216-180-254-0-12);
   --ghostnet-table-header: linear-gradient(
     180deg,
-    rgba(93, 46, 255, 0.85) 0%,
-    rgba(42, 14, 130, 0.8) 75%,
-    rgba(140, 92, 255, 0.65) 100%
+    var(--ghostnet-color-rgba-93-46-255-0-85) 0%,
+    var(--ghostnet-color-rgba-42-14-130-0-8) 75%,
+    var(--ghostnet-color-rgba-140-92-255-0-65) 100%
   );
 }
 
@@ -38,7 +218,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(5, 8, 13, 0) 0%, rgba(5, 8, 13, 0.9) 100%);
+  background: linear-gradient(180deg, var(--ghostnet-color-rgba-5-8-13-0) 0%, var(--ghostnet-color-rgba-5-8-13-0-9) 100%);
   pointer-events: none;
 }
 
@@ -109,13 +289,13 @@
 .terminalShell {
   width: 100%;
   max-width: none;
-  background: linear-gradient(180deg, rgba(28, 22, 51, 0.92) 0%, rgba(13, 11, 26, 0.94) 100%);
-  border: 1px solid rgba(140, 92, 255, 0.35);
+  background: linear-gradient(180deg, var(--ghostnet-color-rgba-28-22-51-0-92) 0%, var(--ghostnet-color-rgba-13-11-26-0-94) 100%);
+  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-35);
   border-bottom: none;
   border-radius: 1.5rem 1.5rem 0 0;
   color: var(--ghostnet-ink);
   pointer-events: auto;
-  box-shadow: 0 -1.25rem 2.75rem rgba(5, 8, 13, 0.68), 0 0 1.75rem rgba(93, 46, 255, 0.36);
+  box-shadow: 0 -1.25rem 2.75rem var(--ghostnet-color-rgba-5-8-13-0-68), 0 0 1.75rem var(--ghostnet-color-rgba-93-46-255-0-36);
   backdrop-filter: blur(16px);
   display: flex;
   flex-direction: column;
@@ -127,8 +307,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.5rem 0.75rem 1.5rem;
-  background: rgba(93, 46, 255, 0.12);
-  border-bottom: 1px solid rgba(140, 92, 255, 0.28);
+  background: var(--ghostnet-color-rgba-93-46-255-0-12);
+  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-28);
 }
 
 .terminalHeaderContent {
@@ -141,12 +321,12 @@
   font-size: 0.9rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: #f5f1ff;
+  color: var(--ghostnet-color-hex-f5f1ff);
 }
 
 .terminalStatus {
   font-size: 0.8rem;
-  color: rgba(245, 241, 255, 0.68);
+  color: var(--ghostnet-color-rgba-245-241-255-0-68);
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
 }
 
@@ -157,41 +337,41 @@
   gap: 0.5rem;
   padding: 0.4rem 1.1rem;
   border-radius: 999px;
-  border: 1px solid rgba(140, 92, 255, 0.6);
-  background: linear-gradient(135deg, rgba(93, 46, 255, 0.72), rgba(140, 92, 255, 0.48));
-  color: #f5f1ff;
+  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-6);
+  background: linear-gradient(135deg, var(--ghostnet-color-rgba-93-46-255-0-72), var(--ghostnet-color-rgba-140-92-255-0-48));
+  color: var(--ghostnet-color-hex-f5f1ff);
   text-transform: uppercase;
   letter-spacing: 0.24em;
   font-size: 0.72rem;
   cursor: pointer;
-  text-shadow: 0 0 12px rgba(93, 46, 255, 0.55);
-  box-shadow: 0 0 0 rgba(93, 46, 255, 0);
+  text-shadow: 0 0 12px var(--ghostnet-color-rgba-93-46-255-0-55);
+  box-shadow: 0 0 0 var(--ghostnet-color-rgba-93-46-255-0);
   transition: background 200ms ease, transform 200ms ease, box-shadow 200ms ease;
 }
 
 .terminalToggle:hover,
 .terminalToggle:focus-visible {
-  background: linear-gradient(135deg, rgba(93, 46, 255, 0.88), rgba(140, 92, 255, 0.62));
+  background: linear-gradient(135deg, var(--ghostnet-color-rgba-93-46-255-0-88), var(--ghostnet-color-rgba-140-92-255-0-62));
   transform: translateY(-1px);
-  box-shadow: 0 0 18px rgba(93, 46, 255, 0.38);
+  box-shadow: 0 0 18px var(--ghostnet-color-rgba-93-46-255-0-38);
 }
 
 .terminalToggle:focus-visible {
-  outline: 2px solid #29f3c3;
+  outline: 2px solid var(--ghostnet-color-hex-29f3c3);
   outline-offset: 3px;
 }
 
 .terminalToggle:active {
-  background: linear-gradient(135deg, rgba(42, 14, 130, 0.78), rgba(93, 46, 255, 0.52));
+  background: linear-gradient(135deg, var(--ghostnet-color-rgba-42-14-130-0-78), var(--ghostnet-color-rgba-93-46-255-0-52));
   transform: translateY(1px);
-  box-shadow: 0 0 10px rgba(42, 14, 130, 0.48);
+  box-shadow: 0 0 10px var(--ghostnet-color-rgba-42-14-130-0-48);
 }
 
 .terminalToggleIcon {
   font-size: 0.95rem;
   line-height: 1;
-  color: #f5f1ff;
-  text-shadow: 0 0 14px rgba(245, 241, 255, 0.6);
+  color: var(--ghostnet-color-hex-f5f1ff);
+  text-shadow: 0 0 14px var(--ghostnet-color-rgba-245-241-255-0-6);
   transition: transform 200ms ease, color 200ms ease;
 }
 
@@ -203,18 +383,18 @@
 }
 
 .terminalToggleCollapsed {
-  background: linear-gradient(135deg, rgba(42, 14, 130, 0.82), rgba(93, 46, 255, 0.48));
-  box-shadow: 0 0 14px rgba(42, 14, 130, 0.36);
+  background: linear-gradient(135deg, var(--ghostnet-color-rgba-42-14-130-0-82), var(--ghostnet-color-rgba-93-46-255-0-48));
+  box-shadow: 0 0 14px var(--ghostnet-color-rgba-42-14-130-0-36);
 }
 
 .terminalToggleCollapsed .terminalToggleIcon {
-  color: #29f3c3;
+  color: var(--ghostnet-color-hex-29f3c3);
 }
 
 .terminalBody {
   flex: 1;
   padding: 1.25rem 1.5rem 1.5rem;
-  background: radial-gradient(circle at 20% 0%, rgba(93, 46, 255, 0.18), transparent 55%);
+  background: radial-gradient(circle at 20% 0%, var(--ghostnet-color-rgba-93-46-255-0-18), transparent 55%);
   overflow: hidden;
   display: flex;
 }
@@ -235,7 +415,7 @@
   gap: 0.85rem;
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
   font-size: 0.85rem;
-  color: rgba(245, 241, 255, 0.78);
+  color: var(--ghostnet-color-rgba-245-241-255-0-78);
   opacity: 0;
   animation: terminalLineReveal 320ms ease forwards;
 }
@@ -248,69 +428,69 @@
 }
 
 .terminalPromptCommand {
-  color: #29f3c3;
+  color: var(--ghostnet-color-hex-29f3c3);
 }
 
 .terminalPromptResponse {
-  color: rgba(140, 92, 255, 0.75);
+  color: var(--ghostnet-color-rgba-140-92-255-0-75);
 }
 
 .terminalPromptAlert {
-  color: #ff5fc1;
+  color: var(--ghostnet-color-hex-ff5fc1);
 }
 
 .terminalPromptCipher {
-  color: rgba(245, 241, 255, 0.56);
+  color: var(--ghostnet-color-rgba-245-241-255-0-56);
 }
 
 .terminalPromptBinary {
-  color: #29f3c3;
+  color: var(--ghostnet-color-hex-29f3c3);
 }
 
 .terminalPromptDecrypt {
-  color: rgba(140, 92, 255, 0.95);
+  color: var(--ghostnet-color-rgba-140-92-255-0-95);
 }
 
 .terminalPromptGlitch {
-  color: rgba(140, 92, 255, 0.85);
-  text-shadow: 0 0 18px rgba(93, 46, 255, 0.48);
+  color: var(--ghostnet-color-rgba-140-92-255-0-85);
+  text-shadow: 0 0 18px var(--ghostnet-color-rgba-93-46-255-0-48);
 }
 
 .terminalPromptSystem {
-  color: rgba(245, 241, 255, 0.72);
+  color: var(--ghostnet-color-rgba-245-241-255-0-72);
 }
 
 .terminalText {
-  color: rgba(245, 241, 255, 0.82);
+  color: var(--ghostnet-color-rgba-245-241-255-0-82);
 }
 
 .terminalTextAlert {
-  color: #ff5fc1;
-  text-shadow: 0 0 12px rgba(255, 95, 193, 0.58);
+  color: var(--ghostnet-color-hex-ff5fc1);
+  text-shadow: 0 0 12px var(--ghostnet-color-rgba-255-95-193-0-58);
 }
 
 .terminalTextCipher {
-  color: rgba(245, 241, 255, 0.54);
+  color: var(--ghostnet-color-rgba-245-241-255-0-54);
   letter-spacing: 0.18em;
 }
 
 .terminalTextBinary {
-  color: rgba(41, 243, 195, 0.92);
-  text-shadow: 0 0 10px rgba(41, 243, 195, 0.55);
+  color: var(--ghostnet-color-rgba-41-243-195-0-92);
+  text-shadow: 0 0 10px var(--ghostnet-color-rgba-41-243-195-0-55);
 }
 
 .terminalTextDecrypt {
-  color: rgba(245, 241, 255, 0.95);
+  color: var(--ghostnet-color-rgba-245-241-255-0-95);
 }
 
 .terminalTextGlitch {
-  color: rgba(245, 241, 255, 0.7);
+  color: var(--ghostnet-color-rgba-245-241-255-0-7);
   letter-spacing: 0.2em;
-  text-shadow: 0 0 22px rgba(93, 46, 255, 0.45);
+  text-shadow: 0 0 22px var(--ghostnet-color-rgba-93-46-255-0-45);
 }
 
 .terminalTextSystem {
-  color: rgba(245, 241, 255, 0.92);
+  color: var(--ghostnet-color-rgba-245-241-255-0-92);
 }
 
 @keyframes terminalLineReveal {
@@ -342,7 +522,7 @@
   border-radius: 1.25rem;
   background: var(--ghostnet-panel);
   border: 1px solid var(--ghostnet-panel-border);
-  box-shadow: 0 1.75rem 3.5rem rgba(3, 7, 11, 0.8);
+  box-shadow: 0 1.75rem 3.5rem var(--ghostnet-color-rgba-3-7-11-0-8);
   backdrop-filter: blur(12px);
 }
 
@@ -375,8 +555,8 @@
 .sectionFrameElevated {
   border-radius: 1.5rem;
   background: var(--ghostnet-panel);
-  border: 1px solid rgba(216, 180, 254, 0.32);
-  box-shadow: 0 1.75rem 4rem rgba(4, 9, 14, 0.85);
+  border: 1px solid var(--ghostnet-color-rgba-216-180-254-0-32);
+  box-shadow: 0 1.75rem 4rem var(--ghostnet-color-rgba-4-9-14-0-85);
   backdrop-filter: blur(14px);
 }
 
@@ -404,8 +584,8 @@
   text-transform: uppercase;
   letter-spacing: 0.18em;
   border-radius: 999px;
-  border: 1px solid rgba(216, 180, 254, 0.42);
-  background: rgba(216, 180, 254, 0.12);
+  border: 1px solid var(--ghostnet-color-rgba-216-180-254-0-42);
+  background: var(--ghostnet-color-rgba-216-180-254-0-12);
   color: var(--ghostnet-accent);
 }
 
@@ -421,11 +601,11 @@
 
 .dataTableContainer {
   position: relative;
-  border: 1px solid rgba(140, 92, 255, 0.38);
+  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-38);
   border-radius: 1.25rem;
-  background: radial-gradient(circle at 50% 0%, rgba(93, 46, 255, 0.18), transparent 65%),
-    linear-gradient(180deg, rgba(9, 8, 26, 0.95) 0%, rgba(7, 11, 20, 0.94) 100%);
-  box-shadow: 0 1.65rem 3.75rem rgba(3, 7, 12, 0.78);
+  background: radial-gradient(circle at 50% 0%, var(--ghostnet-color-rgba-93-46-255-0-18), transparent 65%),
+    linear-gradient(180deg, var(--ghostnet-color-rgba-9-8-26-0-95) 0%, var(--ghostnet-color-rgba-7-11-20-0-94) 100%);
+  box-shadow: 0 1.65rem 3.75rem var(--ghostnet-color-rgba-3-7-12-0-78);
   overflow: hidden;
 }
 
@@ -448,11 +628,11 @@
 
 .dataTable thead {
   background: var(--ghostnet-table-header);
-  box-shadow: inset 0 -1px 0 rgba(140, 92, 255, 0.38);
+  box-shadow: inset 0 -1px 0 var(--ghostnet-color-rgba-140-92-255-0-38);
 }
 
 .dataTable thead tr {
-  border-bottom: 1px solid rgba(140, 92, 255, 0.45);
+  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-45);
   background: var(--ghostnet-table-header);
 }
 
@@ -461,21 +641,21 @@
   font-size: 0.72rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: rgba(245, 241, 255, 0.88);
+  color: var(--ghostnet-color-rgba-245-241-255-0-88);
   font-weight: 600;
   text-align: left;
   white-space: nowrap;
 }
 
 .dataTable tbody tr {
-  background: linear-gradient(180deg, rgba(13, 11, 26, 0.86) 0%, rgba(16, 9, 38, 0.76) 100%);
-  border-bottom: 1px solid rgba(140, 92, 255, 0.25);
+  background: linear-gradient(180deg, var(--ghostnet-color-rgba-13-11-26-0-86) 0%, var(--ghostnet-color-rgba-16-9-38-0-76) 100%);
+  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-25);
   transition: background 0.25s ease, transform 0.25s ease;
   font-size: 0.95rem;
 }
 
 .dataTable tbody tr:nth-child(even) {
-  background: rgba(27, 16, 58, 0.45);
+  background: var(--ghostnet-color-rgba-27-16-58-0-45);
 }
 
 .dataTable tbody tr:last-child {
@@ -483,7 +663,7 @@
 }
 
 .dataTable tbody tr:hover {
-  background: rgba(93, 46, 255, 0.18);
+  background: var(--ghostnet-color-rgba-93-46-255-0-18);
 }
 
 .dataTable td {
@@ -494,7 +674,7 @@
 }
 
 .nonCommodityRow {
-  background: rgba(16, 9, 38, 0.7);
+  background: var(--ghostnet-color-rgba-16-9-38-0-7);
   font-size: 0.85rem;
   line-height: 1.2;
 }
@@ -519,11 +699,11 @@
   font-size: 0.7rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(245, 241, 255, 0.7);
-  border: 1px solid rgba(140, 92, 255, 0.45);
+  color: var(--ghostnet-color-rgba-245-241-255-0-7);
+  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-45);
   border-radius: 999px;
   padding: 0.1rem 0.6rem;
-  background: rgba(93, 46, 255, 0.18);
+  background: var(--ghostnet-color-rgba-93-46-255-0-18);
 }
 
 .nonCommodityQuantity {
@@ -586,20 +766,20 @@
 }
 
 .tableRowInteractive:hover {
-  background: rgba(93, 46, 255, 0.2);
+  background: var(--ghostnet-color-rgba-93-46-255-0-2);
 }
 
 .tableRowExpanded {
-  background: rgba(93, 46, 255, 0.16) !important;
+  background: var(--ghostnet-color-rgba-93-46-255-0-16) !important;
 }
 
 .tableRowExpanded:hover {
-  background: rgba(93, 46, 255, 0.22) !important;
+  background: var(--ghostnet-color-rgba-93-46-255-0-22) !important;
 }
 
 .tableDetailRow td {
-  background: rgba(5, 8, 13, 0.88);
-  border-top: 1px solid rgba(140, 92, 255, 0.25);
+  background: var(--ghostnet-color-rgba-5-8-13-0-88);
+  border-top: 1px solid var(--ghostnet-color-rgba-140-92-255-0-25);
   padding: 0 1.5rem 1.5rem;
 }
 
@@ -620,11 +800,11 @@
 }
 
 .tableTextSuccess {
-  color: #29f3c3;
+  color: var(--ghostnet-color-hex-29f3c3);
 }
 
 .tableTextDanger {
-  color: #ff5fc1;
+  color: var(--ghostnet-color-hex-ff5fc1);
 }
 
 .tableMessage {
@@ -633,7 +813,7 @@
 }
 
 .tableMessageBorder {
-  border-bottom: 1px solid rgba(140, 92, 255, 0.25);
+  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-25);
 }
 
 .tableIdleState {
@@ -642,7 +822,7 @@
 }
 
 .tableErrorState {
-  color: #ff4d4f;
+  color: var(--ghostnet-color-hex-ff4d4f);
   padding: 2rem;
 }
 
@@ -658,25 +838,25 @@
 }
 
 .tableMetaMuted {
-  color: rgba(140, 160, 188, 0.75);
+  color: var(--ghostnet-color-rgba-140-160-188-0-75);
   font-size: 0.75rem;
   margin-top: 0.25rem;
 }
 
 .tableWarning {
-  color: #ff5fc1;
+  color: var(--ghostnet-color-hex-ff5fc1);
   font-size: 0.78rem;
   margin-top: 0.35rem;
 }
 
 .tableMutedNote {
-  color: rgba(120, 140, 168, 0.75);
+  color: var(--ghostnet-color-rgba-120-140-168-0-75);
   font-size: 0.75rem;
   margin-top: 0.45rem;
 }
 
 .tableIndicatorPlaceholder {
-  color: rgba(120, 140, 168, 0.75);
+  color: var(--ghostnet-color-rgba-120-140-168-0-75);
   font-size: 0.82rem;
 }
 
@@ -700,10 +880,10 @@
   justify-content: space-between;
   gap: 1.5rem;
   padding: 1.75rem 2rem;
-  background: linear-gradient(135deg, rgba(45, 25, 98, 0.85), rgba(26, 17, 60, 0.9));
-  border: 1px solid rgba(140, 92, 255, 0.38);
+  background: linear-gradient(135deg, var(--ghostnet-color-rgba-45-25-98-0-85), var(--ghostnet-color-rgba-26-17-60-0-9));
+  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-38);
   border-radius: 1.25rem;
-  box-shadow: 0 1.5rem 3rem rgba(5, 8, 13, 0.55);
+  box-shadow: 0 1.5rem 3rem var(--ghostnet-color-rgba-5-8-13-0-55);
 }
 
 .routeDetailBackButton {
@@ -712,33 +892,33 @@
   gap: 0.55rem;
   padding: 0.55rem 1.4rem;
   border-radius: 999px;
-  border: 1px solid rgba(140, 92, 255, 0.55);
-  background: linear-gradient(135deg, rgba(93, 46, 255, 0.62), rgba(140, 92, 255, 0.4));
-  color: #f5f1ff;
+  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-55);
+  background: linear-gradient(135deg, var(--ghostnet-color-rgba-93-46-255-0-62), var(--ghostnet-color-rgba-140-92-255-0-4));
+  color: var(--ghostnet-color-hex-f5f1ff);
   text-transform: uppercase;
   letter-spacing: 0.24em;
   font-size: 0.66rem;
   cursor: pointer;
   transition: background 200ms ease, box-shadow 200ms ease, transform 200ms ease;
-  text-shadow: 0 0 14px rgba(93, 46, 255, 0.45);
+  text-shadow: 0 0 14px var(--ghostnet-color-rgba-93-46-255-0-45);
 }
 
 .routeDetailBackButton:hover,
 .routeDetailBackButton:focus-visible {
-  background: linear-gradient(135deg, rgba(117, 70, 255, 0.8), rgba(140, 92, 255, 0.55));
+  background: linear-gradient(135deg, var(--ghostnet-color-rgba-117-70-255-0-8), var(--ghostnet-color-rgba-140-92-255-0-55));
   transform: translateY(-1px);
-  box-shadow: 0 0 18px rgba(93, 46, 255, 0.4);
+  box-shadow: 0 0 18px var(--ghostnet-color-rgba-93-46-255-0-4);
 }
 
 .routeDetailBackButton:focus-visible {
-  outline: 2px solid #29f3c3;
+  outline: 2px solid var(--ghostnet-color-hex-29f3c3);
   outline-offset: 3px;
 }
 
 .routeDetailBackButton:active {
-  background: linear-gradient(135deg, rgba(42, 14, 130, 0.75), rgba(93, 46, 255, 0.5));
+  background: linear-gradient(135deg, var(--ghostnet-color-rgba-42-14-130-0-75), var(--ghostnet-color-rgba-93-46-255-0-5));
   transform: translateY(1px);
-  box-shadow: 0 0 12px rgba(42, 14, 130, 0.48);
+  box-shadow: 0 0 12px var(--ghostnet-color-rgba-42-14-130-0-48);
 }
 
 .routeDetailHeading {
@@ -754,7 +934,7 @@
   text-transform: uppercase;
   letter-spacing: 0.32em;
   font-size: 0.68rem;
-  color: rgba(245, 241, 255, 0.7);
+  color: var(--ghostnet-color-rgba-245-241-255-0-7);
 }
 
 .routeDetailTitle {
@@ -763,13 +943,13 @@
   justify-content: center;
   gap: 0.85rem;
   font-size: 1.65rem;
-  color: #f5f1ff;
-  text-shadow: 0 0 14px rgba(93, 46, 255, 0.45);
+  color: var(--ghostnet-color-hex-f5f1ff);
+  text-shadow: 0 0 14px var(--ghostnet-color-rgba-93-46-255-0-45);
   margin: 0;
 }
 
 .routeDetailDivider {
-  color: #29f3c3;
+  color: var(--ghostnet-color-hex-29f3c3);
   font-size: 1.75rem;
   line-height: 1;
 }
@@ -780,11 +960,11 @@
   gap: 0.65rem;
   margin: 0;
   font-size: 0.92rem;
-  color: rgba(245, 241, 255, 0.74);
+  color: var(--ghostnet-color-rgba-245-241-255-0-74);
 }
 
 .routeDetailArrow {
-  color: rgba(245, 241, 255, 0.6);
+  color: var(--ghostnet-color-rgba-245-241-255-0-6);
   font-size: 1.1rem;
 }
 
@@ -795,22 +975,22 @@
   min-width: 160px;
   padding: 0.9rem 1.25rem;
   border-radius: 1rem;
-  background: rgba(35, 20, 68, 0.85);
-  border: 1px solid rgba(140, 92, 255, 0.35);
-  color: rgba(245, 241, 255, 0.78);
+  background: var(--ghostnet-color-rgba-35-20-68-0-85);
+  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-35);
+  color: var(--ghostnet-color-rgba-245-241-255-0-78);
 }
 
 .routeDetailMetaLabel {
   text-transform: uppercase;
   letter-spacing: 0.22em;
   font-size: 0.65rem;
-  color: rgba(245, 241, 255, 0.6);
+  color: var(--ghostnet-color-rgba-245-241-255-0-6);
 }
 
 .routeDetailMetaValue {
   font-size: 0.98rem;
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
-  color: #f5f1ff;
+  color: var(--ghostnet-color-hex-f5f1ff);
 }
 
 .routeDetailMetrics {
@@ -825,21 +1005,21 @@
   gap: 0.4rem;
   padding: 1.15rem 1.35rem;
   border-radius: 1.1rem;
-  background: rgba(22, 15, 44, 0.92);
-  border: 1px solid rgba(140, 92, 255, 0.32);
-  box-shadow: 0 1.2rem 2.4rem rgba(4, 7, 12, 0.55);
+  background: var(--ghostnet-color-rgba-22-15-44-0-92);
+  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-32);
+  box-shadow: 0 1.2rem 2.4rem var(--ghostnet-color-rgba-4-7-12-0-55);
 }
 
 .routeDetailMetricLabel {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.68rem;
-  color: rgba(245, 241, 255, 0.62);
+  color: var(--ghostnet-color-rgba-245-241-255-0-62);
 }
 
 .routeDetailMetricValue {
   font-size: 1.05rem;
-  color: #f5f1ff;
+  color: var(--ghostnet-color-hex-f5f1ff);
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
 }
 
@@ -854,10 +1034,10 @@
   flex-direction: column;
   gap: 1rem;
   padding: 1.75rem 1.9rem;
-  background: rgba(12, 10, 28, 0.92);
-  border: 1px solid rgba(140, 92, 255, 0.32);
+  background: var(--ghostnet-color-rgba-12-10-28-0-92);
+  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-32);
   border-radius: 1.25rem;
-  box-shadow: 0 1.45rem 2.8rem rgba(4, 7, 12, 0.55);
+  box-shadow: 0 1.45rem 2.8rem var(--ghostnet-color-rgba-4-7-12-0-55);
 }
 
 .routeDetailPanelHeader {
@@ -871,7 +1051,7 @@
   text-transform: uppercase;
   letter-spacing: 0.28em;
   font-size: 0.68rem;
-  color: rgba(245, 241, 255, 0.62);
+  color: var(--ghostnet-color-rgba-245-241-255-0-62);
 }
 
 .routeDetailStation {
@@ -893,13 +1073,13 @@
 
 .routeDetailStationName {
   font-size: 1.05rem;
-  color: #f5f1ff;
+  color: var(--ghostnet-color-hex-f5f1ff);
   font-weight: 600;
 }
 
 .routeDetailSystem {
   font-size: 0.85rem;
-  color: rgba(245, 241, 255, 0.62);
+  color: var(--ghostnet-color-rgba-245-241-255-0-62);
 }
 
 .routeDetailInfoRow {
@@ -907,7 +1087,7 @@
   justify-content: space-between;
   align-items: baseline;
   gap: 1rem;
-  color: rgba(245, 241, 255, 0.78);
+  color: var(--ghostnet-color-rgba-245-241-255-0-78);
   font-size: 0.92rem;
 }
 
@@ -915,7 +1095,7 @@
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.7rem;
-  color: rgba(245, 241, 255, 0.58);
+  color: var(--ghostnet-color-rgba-245-241-255-0-58);
 }
 
 .routeDetailInfoValue {
@@ -928,7 +1108,7 @@
 .routeDetailDividerLine {
   height: 1px;
   width: 100%;
-  background: rgba(140, 92, 255, 0.25);
+  background: var(--ghostnet-color-rgba-140-92-255-0-25);
   margin: 0.5rem 0 0.75rem;
 }
 
@@ -936,20 +1116,20 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  color: rgba(245, 241, 255, 0.84);
+  color: var(--ghostnet-color-rgba-245-241-255-0-84);
 }
 
 .routeDetailCommodityLabel {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.68rem;
-  color: rgba(245, 241, 255, 0.6);
+  color: var(--ghostnet-color-rgba-245-241-255-0-6);
 }
 
 .routeDetailCommodityValue {
   font-size: 1.05rem;
   font-weight: 600;
-  color: #f5f1ff;
+  color: var(--ghostnet-color-hex-f5f1ff);
 }
 
 .routeDetailPriceRow {
@@ -957,7 +1137,7 @@
   flex-wrap: wrap;
   gap: 0.85rem;
   font-size: 0.88rem;
-  color: rgba(245, 241, 255, 0.74);
+  color: var(--ghostnet-color-rgba-245-241-255-0-74);
 }
 
 @media (max-width: 1100px) {
@@ -1025,7 +1205,7 @@
   align-items: baseline;
   gap: 0.4rem;
   font-size: 0.95rem;
-  color: rgba(220, 228, 255, 0.84);
+  color: var(--ghostnet-color-rgba-220-228-255-0-84);
 }
 
 .tableEntryValueHighlight {
@@ -1036,11 +1216,11 @@
   font-size: 0.72rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #5bd1a5;
+  color: var(--ghostnet-color-hex-5bd1a5);
 }
 
 .tableEntryLabel {
-  color: rgba(140, 160, 188, 0.78);
+  color: var(--ghostnet-color-rgba-140-160-188-0-78);
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -1054,7 +1234,7 @@
 }
 
 .tableEntryFootnote {
-  color: rgba(120, 140, 168, 0.75);
+  color: var(--ghostnet-color-rgba-120-140-168-0-75);
   font-size: 0.75rem;
   margin-top: 0.2rem;
 }
@@ -1067,16 +1247,16 @@
 }
 
 .tableBadgeWarning {
-  color: #ff5fc1;
+  color: var(--ghostnet-color-hex-ff5fc1);
 }
 
 .tableBadgeSuccess {
-  color: #5bd1a5;
+  color: var(--ghostnet-color-hex-5bd1a5);
 }
 
 .tableFootnote {
   margin-top: 1.5rem;
-  color: rgba(140, 160, 188, 0.75);
+  color: var(--ghostnet-color-rgba-140-160-188-0-75);
   font-size: 0.85rem;
   line-height: 1.6;
 }
@@ -1109,11 +1289,11 @@
 }
 
 .metricValueWarning {
-  color: #ff5fc1;
+  color: var(--ghostnet-color-hex-ff5fc1);
 }
 
 .metricValueSuccess {
-  color: #5bd1a5;
+  color: var(--ghostnet-color-hex-5bd1a5);
 }
 
 .notice {
@@ -1123,17 +1303,17 @@
 }
 
 .noticeMuted {
-  color: #aaa;
+  color: var(--ghostnet-color-hex-aaa);
 }
 
 .inlineNotice {
   padding: 1rem 0;
-  color: #ff4d4f;
+  color: var(--ghostnet-color-hex-ff4d4f);
 }
 
 .inlineNoticeMuted {
   padding: 1rem 0;
-  color: #aaa;
+  color: var(--ghostnet-color-hex-aaa);
 }
 
 .placeholder {
@@ -1144,9 +1324,9 @@
   color: var(--ghostnet-muted);
   font-size: 1.35rem;
   border-radius: 1.5rem;
-  border: 1px solid rgba(216, 180, 254, 0.28);
-  background: linear-gradient(160deg, rgba(216, 180, 254, 0.18), rgba(5, 8, 13, 0.82));
-  box-shadow: 0 1.85rem 4rem rgba(3, 7, 11, 0.78);
+  border: 1px solid var(--ghostnet-color-rgba-216-180-254-0-28);
+  background: linear-gradient(160deg, var(--ghostnet-color-rgba-216-180-254-0-18), var(--ghostnet-color-rgba-5-8-13-0-82));
+  box-shadow: 0 1.85rem 4rem var(--ghostnet-color-rgba-3-7-11-0-78);
 }
 
 .ghostnet :global(.ghostnet-surface) {
@@ -1166,17 +1346,17 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table) {
-  background: linear-gradient(180deg, rgba(13, 11, 26, 0.94) 0%, rgba(7, 11, 20, 0.92) 100%);
-  border: 1px solid rgba(140, 92, 255, 0.38);
+  background: linear-gradient(180deg, var(--ghostnet-color-rgba-13-11-26-0-94) 0%, var(--ghostnet-color-rgba-7-11-20-0-92) 100%);
+  border: 1px solid var(--ghostnet-color-rgba-140-92-255-0-38);
   border-radius: 1.25rem;
   overflow: hidden;
-  box-shadow: 0 1.75rem 3.5rem rgba(4, 9, 14, 0.75);
+  box-shadow: 0 1.75rem 3.5rem var(--ghostnet-color-rgba-4-9-14-0-75);
   backdrop-filter: blur(10px);
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable) {
-  background: linear-gradient(180deg, rgba(9, 7, 24, 0.78) 0%, rgba(7, 11, 20, 0.9) 100%);
-  scrollbar-color: rgba(140, 92, 255, 0.6) rgba(13, 11, 26, 0.85);
+  background: linear-gradient(180deg, var(--ghostnet-color-rgba-9-7-24-0-78) 0%, var(--ghostnet-color-rgba-7-11-20-0-9) 100%);
+  scrollbar-color: var(--ghostnet-color-rgba-140-92-255-0-6) var(--ghostnet-color-rgba-13-11-26-0-85);
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar) {
@@ -1184,23 +1364,23 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-track) {
-  background: rgba(13, 11, 26, 0.75);
+  background: var(--ghostnet-color-rgba-13-11-26-0-75);
   border-radius: 0.65rem;
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-thumb) {
-  background: linear-gradient(180deg, rgba(93, 46, 255, 0.75) 0%, rgba(42, 14, 130, 0.85) 100%);
+  background: linear-gradient(180deg, var(--ghostnet-color-rgba-93-46-255-0-75) 0%, var(--ghostnet-color-rgba-42-14-130-0-85) 100%);
   border-radius: 0.65rem;
-  box-shadow: 0 0 0 2px rgba(13, 11, 26, 0.55) inset;
+  box-shadow: 0 0 0 2px var(--ghostnet-color-rgba-13-11-26-0-55) inset;
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-thumb:hover) {
-  background: linear-gradient(180deg, rgba(117, 70, 255, 0.85) 0%, rgba(42, 14, 130, 0.9) 100%);
+  background: linear-gradient(180deg, var(--ghostnet-color-rgba-117-70-255-0-85) 0%, var(--ghostnet-color-rgba-42-14-130-0-9) 100%);
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead) {
   background: var(--ghostnet-table-header);
-  box-shadow: inset 0 -1px 0 rgba(140, 92, 255, 0.38);
+  box-shadow: inset 0 -1px 0 var(--ghostnet-color-rgba-140-92-255-0-38);
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead tr) {
@@ -1208,25 +1388,25 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead tr th) {
-  border-bottom: 1px solid rgba(140, 92, 255, 0.45);
-  color: rgba(245, 241, 255, 0.88);
+  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-45);
+  color: var(--ghostnet-color-rgba-245-241-255-0-88);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr) {
-  border-bottom: 1px solid rgba(140, 92, 255, 0.25);
+  border-bottom: 1px solid var(--ghostnet-color-rgba-140-92-255-0-25);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr:nth-child(even)) {
-  background: rgba(27, 16, 58, 0.45);
+  background: var(--ghostnet-color-rgba-27-16-58-0-45);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr:hover) {
-  background: rgba(93, 46, 255, 0.18) !important;
+  background: var(--ghostnet-color-rgba-93-46-255-0-18) !important;
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail) {
-  background: rgba(4, 8, 13, 0.85);
-  border: 1px solid rgba(216, 180, 254, 0.22);
+  background: var(--ghostnet-color-rgba-4-8-13-0-85);
+  border: 1px solid var(--ghostnet-color-rgba-216-180-254-0-22);
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail-status) {
@@ -1238,7 +1418,7 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail-status--error) {
-  color: #ff5fc1;
+  color: var(--ghostnet-color-hex-ff5fc1);
 }
 
 .ghostnet :global(.ghostnet-panel-table .text-primary) {
@@ -1246,7 +1426,7 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .text-secondary) {
-  color: #e0c8ff;
+  color: var(--ghostnet-color-hex-e0c8ff);
 }
 
 .ghostnet :global(.ghostnet-panel-table .text-muted) {
@@ -1263,12 +1443,12 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--active) {
-  background: rgba(216, 180, 254, 0.18);
-  border-color: rgba(216, 180, 254, 0.45);
+  background: var(--ghostnet-color-rgba-216-180-254-0-18);
+  border-color: var(--ghostnet-color-rgba-216-180-254-0-45);
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--active:hover) {
-  background: rgba(216, 180, 254, 0.24);
+  background: var(--ghostnet-color-rgba-216-180-254-0-24);
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--icon) {
@@ -1276,7 +1456,7 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--icon:hover) {
-  background: rgba(216, 180, 254, 0.16);
+  background: var(--ghostnet-color-rgba-216-180-254-0-16);
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--secondary) {
@@ -1284,11 +1464,11 @@
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--secondary:hover) {
-  background: rgba(216, 180, 254, 0.16);
+  background: var(--ghostnet-color-rgba-216-180-254-0-16);
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__inspector) {
-  border-left: 1px solid rgba(216, 180, 254, 0.22);
+  border-left: 1px solid var(--ghostnet-color-rgba-216-180-254-0-22);
 }
 
 @media (max-width: 640px) {
@@ -1324,61 +1504,61 @@
 
 @keyframes ghostnetArrivalSurface {
   0% {
-    --ghostnet-bg: #150a02;
-    --ghostnet-panel: rgba(45, 23, 9, 0.92);
-    --ghostnet-panel-border: rgba(255, 173, 102, 0.6);
-    --ghostnet-ink: #ffe8c9;
-    --ghostnet-muted: rgba(255, 207, 156, 0.9);
-    --ghostnet-subdued: rgba(255, 173, 108, 0.72);
-    --ghostnet-accent: #ffb874;
-    --ghostnet-highlight: rgba(255, 173, 108, 0.38);
-    background: radial-gradient(circle at 20% 15%, rgba(255, 184, 116, 0.2), transparent 55%),
-      radial-gradient(circle at 85% 10%, rgba(255, 140, 92, 0.24), transparent 60%),
-      #120804;
+    --ghostnet-bg: var(--ghostnet-color-hex-150a02);
+    --ghostnet-panel: var(--ghostnet-color-rgba-45-23-9-0-92);
+    --ghostnet-panel-border: var(--ghostnet-color-rgba-255-173-102-0-6);
+    --ghostnet-ink: var(--ghostnet-color-hex-ffe8c9);
+    --ghostnet-muted: var(--ghostnet-color-rgba-255-207-156-0-9);
+    --ghostnet-subdued: var(--ghostnet-color-rgba-255-173-108-0-72);
+    --ghostnet-accent: var(--ghostnet-color-hex-ffb874);
+    --ghostnet-highlight: var(--ghostnet-color-rgba-255-173-108-0-38);
+    background: radial-gradient(circle at 20% 15%, var(--ghostnet-color-rgba-255-184-116-0-2), transparent 55%),
+      radial-gradient(circle at 85% 10%, var(--ghostnet-color-rgba-255-140-92-0-24), transparent 60%),
+      var(--ghostnet-color-hex-120804);
     filter: saturate(1.08) contrast(1.05) hue-rotate(-12deg);
     transform: scale(1.01);
   }
   42% {
-    --ghostnet-bg: #0f0720;
-    --ghostnet-panel: rgba(22, 16, 40, 0.9);
-    --ghostnet-panel-border: rgba(228, 175, 255, 0.42);
-    --ghostnet-ink: #f6e9ff;
-    --ghostnet-muted: rgba(220, 198, 255, 0.78);
-    --ghostnet-subdued: rgba(178, 153, 255, 0.56);
-    --ghostnet-accent: #f0b8ff;
-    --ghostnet-highlight: rgba(216, 180, 254, 0.2);
-    background: radial-gradient(circle at 22% 18%, rgba(228, 175, 255, 0.2), transparent 55%),
-      radial-gradient(circle at 80% 12%, rgba(120, 192, 255, 0.16), transparent 60%),
-      #080711;
+    --ghostnet-bg: var(--ghostnet-color-hex-0f0720);
+    --ghostnet-panel: var(--ghostnet-color-rgba-22-16-40-0-9);
+    --ghostnet-panel-border: var(--ghostnet-color-rgba-228-175-255-0-42);
+    --ghostnet-ink: var(--ghostnet-color-hex-f6e9ff);
+    --ghostnet-muted: var(--ghostnet-color-rgba-220-198-255-0-78);
+    --ghostnet-subdued: var(--ghostnet-color-rgba-178-153-255-0-56);
+    --ghostnet-accent: var(--ghostnet-color-hex-f0b8ff);
+    --ghostnet-highlight: var(--ghostnet-color-rgba-216-180-254-0-2);
+    background: radial-gradient(circle at 22% 18%, var(--ghostnet-color-rgba-228-175-255-0-2), transparent 55%),
+      radial-gradient(circle at 80% 12%, var(--ghostnet-color-rgba-120-192-255-0-16), transparent 60%),
+      var(--ghostnet-color-hex-080711);
     filter: saturate(1.12) contrast(1.02) hue-rotate(4deg);
     transform: scale(1.006);
   }
   62% {
-    background: radial-gradient(circle at 24% 17%, rgba(228, 175, 255, 0.26), transparent 55%),
-      radial-gradient(circle at 78% 12%, rgba(120, 192, 255, 0.18), transparent 60%),
-      #0a0718;
+    background: radial-gradient(circle at 24% 17%, var(--ghostnet-color-rgba-228-175-255-0-26), transparent 55%),
+      radial-gradient(circle at 78% 12%, var(--ghostnet-color-rgba-120-192-255-0-18), transparent 60%),
+      var(--ghostnet-color-hex-0a0718);
     filter: saturate(1.28) hue-rotate(10deg);
     transform: scale(1.004) translate3d(-3px, 1px, 0);
   }
   72% {
-    background: radial-gradient(circle at 26% 19%, rgba(120, 192, 255, 0.22), transparent 55%),
-      radial-gradient(circle at 82% 14%, rgba(228, 175, 255, 0.28), transparent 60%),
-      #060611;
+    background: radial-gradient(circle at 26% 19%, var(--ghostnet-color-rgba-120-192-255-0-22), transparent 55%),
+      radial-gradient(circle at 82% 14%, var(--ghostnet-color-rgba-228-175-255-0-28), transparent 60%),
+      var(--ghostnet-color-hex-060611);
     filter: saturate(0.92) hue-rotate(-6deg);
     transform: scale(1.002) translate3d(2px, -1px, 0);
   }
   100% {
-    --ghostnet-bg: #05080d;
-    --ghostnet-panel: rgba(10, 15, 22, 0.88);
-    --ghostnet-panel-border: rgba(216, 180, 254, 0.28);
-    --ghostnet-ink: #d8e9ff;
-    --ghostnet-muted: #8da2bf;
-    --ghostnet-subdued: #6c7c92;
-    --ghostnet-accent: #d8b4fe;
-    --ghostnet-highlight: rgba(216, 180, 254, 0.12);
-    background: radial-gradient(circle at 20% 15%, rgba(216, 180, 254, 0.14), transparent 55%),
-      radial-gradient(circle at 85% 10%, rgba(167, 139, 250, 0.22), transparent 60%),
-      #05080d;
+    --ghostnet-bg: var(--ghostnet-color-hex-05080d);
+    --ghostnet-panel: var(--ghostnet-color-rgba-10-15-22-0-88);
+    --ghostnet-panel-border: var(--ghostnet-color-rgba-216-180-254-0-28);
+    --ghostnet-ink: var(--ghostnet-color-hex-d8e9ff);
+    --ghostnet-muted: var(--ghostnet-color-hex-8da2bf);
+    --ghostnet-subdued: var(--ghostnet-color-hex-6c7c92);
+    --ghostnet-accent: var(--ghostnet-color-hex-d8b4fe);
+    --ghostnet-highlight: var(--ghostnet-color-rgba-216-180-254-0-12);
+    background: radial-gradient(circle at 20% 15%, var(--ghostnet-color-rgba-216-180-254-0-14), transparent 55%),
+      radial-gradient(circle at 85% 10%, var(--ghostnet-color-rgba-167-139-250-0-22), transparent 60%),
+      var(--ghostnet-color-hex-05080d);
     filter: none;
     transform: none;
   }
@@ -1410,18 +1590,18 @@
 @keyframes ghostnetArrivalVignette {
   0% {
     opacity: 0.85;
-    background: linear-gradient(180deg, rgba(24, 12, 6, 0.4) 0%, rgba(10, 6, 2, 0.94) 100%);
+    background: linear-gradient(180deg, var(--ghostnet-color-rgba-24-12-6-0-4) 0%, var(--ghostnet-color-rgba-10-6-2-0-94) 100%);
   }
   40% {
     opacity: 0.7;
-    background: linear-gradient(180deg, rgba(10, 6, 18, 0.3) 0%, rgba(8, 7, 16, 0.92) 100%);
+    background: linear-gradient(180deg, var(--ghostnet-color-rgba-10-6-18-0-3) 0%, var(--ghostnet-color-rgba-8-7-16-0-92) 100%);
   }
   70% {
     opacity: 0.6;
   }
   100% {
     opacity: 1;
-    background: linear-gradient(180deg, rgba(5, 8, 13, 0) 0%, rgba(5, 8, 13, 0.9) 100%);
+    background: linear-gradient(180deg, var(--ghostnet-color-rgba-5-8-13-0) 0%, var(--ghostnet-color-rgba-5-8-13-0-9) 100%);
   }
 }
 
@@ -1455,22 +1635,22 @@
 
 @keyframes ghostnetArrivalChromatic {
   0% {
-    color: rgba(255, 200, 140, 0.95);
-    text-shadow: 0 0 1.35rem rgba(255, 126, 59, 0.55);
+    color: var(--ghostnet-color-rgba-255-200-140-0-95);
+    text-shadow: 0 0 1.35rem var(--ghostnet-color-rgba-255-126-59-0-55);
     transform: translate3d(0, 0, 0);
   }
   35% {
-    color: rgba(255, 215, 170, 0.9);
-    text-shadow: 0 0 1.15rem rgba(255, 160, 86, 0.45);
+    color: var(--ghostnet-color-rgba-255-215-170-0-9);
+    text-shadow: 0 0 1.15rem var(--ghostnet-color-rgba-255-160-86-0-45);
   }
   55% {
-    color: rgba(255, 150, 220, 0.9);
-    text-shadow: 0 0 1.35rem rgba(255, 88, 172, 0.6);
+    color: var(--ghostnet-color-rgba-255-150-220-0-9);
+    text-shadow: 0 0 1.35rem var(--ghostnet-color-rgba-255-88-172-0-6);
     transform: translate3d(-2px, 1px, 0);
   }
   68% {
-    color: rgba(195, 168, 255, 0.92);
-    text-shadow: 0 0 1.35rem rgba(93, 46, 255, 0.65);
+    color: var(--ghostnet-color-rgba-195-168-255-0-92);
+    text-shadow: 0 0 1.35rem var(--ghostnet-color-rgba-93-46-255-0-65);
     transform: translate3d(2px, -1px, 0);
   }
   100% {
@@ -1482,27 +1662,27 @@
 
 @keyframes ghostnetArrivalPanel {
   0% {
-    background: rgba(45, 23, 9, 0.92);
-    border-color: rgba(255, 173, 102, 0.5);
-    box-shadow: 0 1.85rem 3.9rem rgba(30, 12, 4, 0.7);
+    background: var(--ghostnet-color-rgba-45-23-9-0-92);
+    border-color: var(--ghostnet-color-rgba-255-173-102-0-5);
+    box-shadow: 0 1.85rem 3.9rem var(--ghostnet-color-rgba-30-12-4-0-7);
     filter: saturate(1.05);
     transform: translate3d(0, 8px, 0);
   }
   40% {
-    background: rgba(28, 18, 42, 0.9);
-    border-color: rgba(228, 175, 255, 0.38);
-    box-shadow: 0 1.95rem 4rem rgba(14, 8, 26, 0.75);
+    background: var(--ghostnet-color-rgba-28-18-42-0-9);
+    border-color: var(--ghostnet-color-rgba-228-175-255-0-38);
+    box-shadow: 0 1.95rem 4rem var(--ghostnet-color-rgba-14-8-26-0-75);
     transform: translate3d(-2px, 2px, 0);
   }
   68% {
-    background: rgba(22, 16, 33, 0.92);
-    border-color: rgba(188, 148, 255, 0.34);
+    background: var(--ghostnet-color-rgba-22-16-33-0-92);
+    border-color: var(--ghostnet-color-rgba-188-148-255-0-34);
     transform: translate3d(2px, -2px, 0);
   }
   100% {
     background: var(--ghostnet-panel);
     border-color: var(--ghostnet-panel-border);
-    box-shadow: 0 1.75rem 3.5rem rgba(3, 7, 11, 0.8);
+    box-shadow: 0 1.75rem 3.5rem var(--ghostnet-color-rgba-3-7-11-0-8);
     filter: none;
     transform: none;
   }
@@ -1510,25 +1690,25 @@
 
 @keyframes ghostnetArrivalBadge {
   0% {
-    background: rgba(255, 183, 120, 0.28);
-    border-color: rgba(255, 173, 102, 0.55);
-    color: rgba(255, 198, 140, 0.92);
+    background: var(--ghostnet-color-rgba-255-183-120-0-28);
+    border-color: var(--ghostnet-color-rgba-255-173-102-0-55);
+    color: var(--ghostnet-color-rgba-255-198-140-0-92);
     transform: translate3d(0, 4px, 0);
   }
   55% {
-    background: rgba(255, 150, 220, 0.22);
-    border-color: rgba(222, 178, 255, 0.42);
-    color: rgba(228, 175, 255, 0.85);
+    background: var(--ghostnet-color-rgba-255-150-220-0-22);
+    border-color: var(--ghostnet-color-rgba-222-178-255-0-42);
+    color: var(--ghostnet-color-rgba-228-175-255-0-85);
     transform: translate3d(-2px, 0, 0);
   }
   70% {
-    background: rgba(130, 220, 255, 0.2);
-    border-color: rgba(188, 148, 255, 0.38);
+    background: var(--ghostnet-color-rgba-130-220-255-0-2);
+    border-color: var(--ghostnet-color-rgba-188-148-255-0-38);
     transform: translate3d(1px, -1px, 0);
   }
   100% {
-    background: rgba(216, 180, 254, 0.12);
-    border: 1px solid rgba(216, 180, 254, 0.42);
+    background: var(--ghostnet-color-rgba-216-180-254-0-12);
+    border: 1px solid var(--ghostnet-color-rgba-216-180-254-0-42);
     color: var(--ghostnet-accent);
     transform: none;
   }


### PR DESCRIPTION
## Summary
- collect every GhostNet color token into shared variables at the top of the CSS
- refactor page and component styles to reference the centralized palette

## Testing
- npm test -- --runInBand *(fails: jest not found)*
- npm run build:client *(fails: next not found)*
- npm run start *(fails: module dotenv missing)*

------
https://chatgpt.com/codex/tasks/task_e_68de9b261738832391a12cba7f91d6f6