### PR TITLE
Add commodity detail workspace view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Mirror the structural patterns and layout conventions of other Icarus pages so the product feels cohesive, while still honoring GhostNet's unique identity.
 - Keep data tables outside of `SectionFrame` containers; tables should rely on GhostNet table shells (`dataTableContainer`, `dataTable`) for structure instead of being nested inside section frames.
 - Table rows must never expand inline like a drawer. Selecting a row should always open a dedicated full-page view in the workspace, mirroring the behavior on the Find Trade Routes page. This ensures a clean experience on smaller displays.
+- Full-page workspace detail views should follow the existing `routeDetail` layout in `ghostnet.module.css`: the purple back button anchors on the left, the heading/subhead stay centered, and key stats render in the detail metrics grid ahead of any tables.
 
 ### GhostNet Purple Theme Specification
 - **Primary hue:** GhostNet surfaces should lean on a rich royal purple (`#5D2EFF`) for primary actions, interactive accents, and key highlights.

--- a/src/client/pages/api/ghostnet-commodity-values.js
+++ b/src/client/pages/api/ghostnet-commodity-values.js
@@ -815,6 +815,7 @@ export default async function handler (req, res) {
       count: commodity.count,
       market: marketEntry,
       ghostnet: bestGhostnetListing,
+      ghostnetListings: Array.isArray(resolvedEntry.listings) ? resolvedEntry.listings : [],
       localHistory: {
         best: historyBestEntry,
         entries: historyEntries

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -2143,7 +2143,6 @@ function CommodityTradePanel () {
     const commodityName = item?.name || item?.symbol || 'Unknown Commodity'
     const commoditySymbol = item?.symbol && item?.symbol !== item?.name ? item.symbol : ''
     const quantityNumber = Number(quantity) || 0
-    const quantityDisplay = quantityNumber > 0 ? `${quantityNumber.toLocaleString()} units` : '0 units'
     const bestPriceDisplay = formatCredits(bestPrice, '--')
     const bestValueDisplay = formatCredits(bestValue, '--')
     const localBestPriceDisplay = localBestEntry ? formatCredits(localBestEntry.sellPrice, '--') : '--'
@@ -2152,10 +2151,6 @@ function CommodityTradePanel () {
     const targetListing = selectedDetailListing || null
     const targetStationName = targetListing?.stationName || ''
     const targetSystemName = targetListing?.systemName || ''
-    const targetPad = targetListing?.pad || '--'
-    const targetDistanceLy = targetListing?.distanceLyText || formatSystemDistance(targetListing?.distanceLy, '--')
-    const targetDistanceLs = targetListing?.distanceLsText
-      || (Number.isFinite(targetListing?.distanceLs) ? formatStationDistance(targetListing.distanceLs) : '--')
     const targetDemandDisplay = targetListing?.demandText
       || (Number.isFinite(targetListing?.demand) ? targetListing.demand.toLocaleString() : '')
     const targetUpdatedDisplay = targetListing?.updatedText
@@ -2220,61 +2215,6 @@ function CommodityTradePanel () {
 
     return (
       <div className={styles.routeDetailContainer}>
-        <div className={styles.routeDetailHeader}>
-          <button type='button' className={styles.routeDetailBackButton} onClick={handleDetailClose}>
-            {String.fromCharCode(0x2190)} Back to Commodities
-          </button>
-          <div className={styles.routeDetailHeading}>
-            <span className={styles.routeDetailLabel}>Commodity Intel</span>
-            <h3 className={styles.routeDetailTitle}>
-              {commodityName}
-              {commoditySymbol ? <span style={{ fontSize: '0.85rem', color: 'rgba(245, 241, 255, 0.7)' }}> ({commoditySymbol})</span> : null}
-            </h3>
-            <p className={styles.routeDetailSubhead}>
-              {quantityDisplay}
-              <span className={styles.routeDetailArrow} aria-hidden='true'>{String.fromCharCode(0x2022)}</span>
-              {currentSystemName || 'Unknown system'}
-            </p>
-          </div>
-          <div className={styles.routeDetailMeta}>
-            <span className={styles.routeDetailMetaLabel}>GHOSTNET Update</span>
-            <span className={styles.routeDetailMetaValue}>{ghostnetUpdatedDisplay || '--'}</span>
-            <span className={styles.routeDetailMetaLabel}>Listings Captured</span>
-            <span className={styles.routeDetailMetaValue}>{listingsCountDisplay}</span>
-          </div>
-          <div className={styles.routeDetailContextBar}>
-            {targetListing ? (
-              <>
-                <div className={styles.routeDetailContextItem}>
-                  <span className={styles.routeDetailContextLabel}>Target Station</span>
-                  <span className={styles.routeDetailContextPrimary}>{targetStationName}</span>
-                  <span className={styles.routeDetailContextMeta}>{targetSystemName || 'Unknown system'}</span>
-                  <span className={styles.routeDetailContextMeta}>Updated {targetUpdatedDisplay || '--'}</span>
-                </div>
-                <div className={styles.routeDetailContextItem}>
-                  <span className={styles.routeDetailContextLabel}>Distance</span>
-                  <span className={styles.routeDetailContextValue}>{targetDistanceLy || '--'}</span>
-                  <span className={styles.routeDetailContextMeta}>{targetDistanceLs && targetDistanceLs !== '--' ? `${targetDistanceLs}` : 'Star distance unavailable'}</span>
-                </div>
-                <div className={styles.routeDetailContextItem}>
-                  <span className={styles.routeDetailContextLabel}>Pad & Demand</span>
-                  <span className={styles.routeDetailContextValue}>{targetPad || '--'}</span>
-                  <span className={styles.routeDetailContextMeta}>{targetDemandDisplay ? `Demand ${targetDemandDisplay}` : 'No demand data'}</span>
-                </div>
-                <div className={styles.routeDetailContextItem}>
-                  <span className={styles.routeDetailContextLabel}>Sell Price</span>
-                  <span className={styles.routeDetailContextPrimary}>{ghostnetPriceDisplay}</span>
-                  <span className={styles.routeDetailContextMeta}>Value {formatCredits(resolvedGhostnetValue, '--')}</span>
-                </div>
-              </>
-            ) : (
-              <div className={styles.routeDetailContextEmpty}>
-                No intercepted stations selected yet. Choose a listing below to focus your trade planning.
-              </div>
-            )}
-          </div>
-        </div>
-
         {ghostnetError ? (
           <div className={styles.notice} style={{ marginTop: '-0.5rem' }}>{ghostnetError}</div>
         ) : null}
@@ -2290,6 +2230,29 @@ function CommodityTradePanel () {
         </div>
 
         <div className={styles.dataTableContainer}>
+          <div className={styles.commodityDetailStickyHeader}>
+            <button type='button' className={styles.routeDetailBackButton} onClick={handleDetailClose}>
+              {String.fromCharCode(0x2190)} Back to Commodities
+            </button>
+            <div className={styles.commodityDetailHeading}>
+              <span className={styles.commodityDetailLabel}>Commodity Intel</span>
+              <div className={styles.commodityDetailTitle}>
+                {commodityName}
+                {commoditySymbol ? <span className={styles.commodityDetailSymbol}>({commoditySymbol})</span> : null}
+              </div>
+            </div>
+            <div className={styles.commodityDetailMeta}>
+              <div className={styles.commodityDetailMetaItem}>
+                <span className={styles.commodityDetailMetaLabel}>GHOSTNET Update</span>
+                <span className={styles.commodityDetailMetaValue}>{ghostnetUpdatedDisplay || '--'}</span>
+              </div>
+              <div className={styles.commodityDetailMetaItem}>
+                <span className={styles.commodityDetailMetaLabel}>Listings</span>
+                <span className={styles.commodityDetailMetaValue}>{listingsCountDisplay}</span>
+              </div>
+            </div>
+          </div>
+
           {detailListings.length > 0 ? (
             <table className={`${styles.dataTable} ${styles.dataTableFixed}`}>
               <colgroup>

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -2043,7 +2043,10 @@ function CommodityTradePanel () {
   const marketStatus = valuation?.metadata?.marketStatus || 'idle'
   const historyStatus = valuation?.metadata?.historyStatus || 'idle'
 
-  const showSummaryContext = !detailViewActive && Boolean(activeSummaryRow)
+  const showSummaryContext = Boolean(activeSummaryRow)
+  const summaryContextViewing = Boolean(
+    showSummaryContext && detailViewActive && detailContext?.rowKey === activeSummaryRow?.key
+  )
 
   const summaryCommodityName = showSummaryContext
     ? (activeSummaryRow?.item?.name || activeSummaryRow?.item?.symbol || 'Unknown Commodity')
@@ -2467,9 +2470,15 @@ function CommodityTradePanel () {
               <button
                 type='button'
                 className={styles.detailContextAction}
-                onClick={() => activeSummaryRow && handleCommoditySelect(activeSummaryRow)}
+                onClick={() => {
+                  if (!summaryContextViewing && activeSummaryRow) {
+                    handleCommoditySelect(activeSummaryRow)
+                  }
+                }}
+                disabled={summaryContextViewing}
+                aria-disabled={summaryContextViewing}
               >
-                Resume Intel
+                {summaryContextViewing ? 'Viewing Intel' : 'Resume Intel'}
               </button>
             </div>
             <div className={styles.detailContextSummaryGrid}>

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -2230,29 +2230,6 @@ function CommodityTradePanel () {
         </div>
 
         <div className={styles.dataTableContainer}>
-          <div className={styles.commodityDetailStickyHeader}>
-            <button type='button' className={styles.routeDetailBackButton} onClick={handleDetailClose}>
-              {String.fromCharCode(0x2190)} Back to Commodities
-            </button>
-            <div className={styles.commodityDetailHeading}>
-              <span className={styles.commodityDetailLabel}>Commodity Intel</span>
-              <div className={styles.commodityDetailTitle}>
-                {commodityName}
-                {commoditySymbol ? <span className={styles.commodityDetailSymbol}>({commoditySymbol})</span> : null}
-              </div>
-            </div>
-            <div className={styles.commodityDetailMeta}>
-              <div className={styles.commodityDetailMetaItem}>
-                <span className={styles.commodityDetailMetaLabel}>GHOSTNET Update</span>
-                <span className={styles.commodityDetailMetaValue}>{ghostnetUpdatedDisplay || '--'}</span>
-              </div>
-              <div className={styles.commodityDetailMetaItem}>
-                <span className={styles.commodityDetailMetaLabel}>Listings</span>
-                <span className={styles.commodityDetailMetaValue}>{listingsCountDisplay}</span>
-              </div>
-            </div>
-          </div>
-
           {detailListings.length > 0 ? (
             <table className={`${styles.dataTable} ${styles.dataTableFixed}`}>
               <colgroup>
@@ -2265,8 +2242,34 @@ function CommodityTradePanel () {
                 <col style={{ width: '10%' }} />
                 <col style={{ width: '8%' }} />
               </colgroup>
-              <thead>
-                <tr>
+              <thead className={styles.commodityDetailTableHead}>
+                <tr className={styles.commodityDetailHeaderRow}>
+                  <th colSpan='8' className={styles.commodityDetailHeaderCell}>
+                    <div className={styles.commodityDetailHeader}>
+                      <button type='button' className={styles.routeDetailBackButton} onClick={handleDetailClose}>
+                        {String.fromCharCode(0x2190)} Back to Commodities
+                      </button>
+                      <div className={styles.commodityDetailHeading}>
+                        <span className={styles.commodityDetailLabel}>Commodity Intel</span>
+                        <div className={styles.commodityDetailTitle}>
+                          {commodityName}
+                          {commoditySymbol ? <span className={styles.commodityDetailSymbol}>({commoditySymbol})</span> : null}
+                        </div>
+                      </div>
+                      <div className={styles.commodityDetailMeta}>
+                        <div className={styles.commodityDetailMetaItem}>
+                          <span className={styles.commodityDetailMetaLabel}>GHOSTNET Update</span>
+                          <span className={styles.commodityDetailMetaValue}>{ghostnetUpdatedDisplay || '--'}</span>
+                        </div>
+                        <div className={styles.commodityDetailMetaItem}>
+                          <span className={styles.commodityDetailMetaLabel}>Listings</span>
+                          <span className={styles.commodityDetailMetaValue}>{listingsCountDisplay}</span>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+                <tr className={styles.commodityDetailColumnsRow}>
                   <th>Station</th>
                   <th>System</th>
                   <th>Pad</th>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -388,6 +388,118 @@
   padding: 1.5rem;
 }
 
+.detailContextSummary {
+  margin-top: 1.5rem;
+  padding: 1.35rem 1.6rem;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(140, 92, 255, 0.32);
+  background: linear-gradient(135deg, rgba(40, 22, 82, 0.68), rgba(24, 15, 52, 0.78));
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+}
+
+.detailContextSummaryHeader {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.detailContextSummaryHeading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.detailContextSummaryLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.64rem;
+  color: rgba(245, 241, 255, 0.65);
+}
+
+.detailContextSummaryTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+}
+
+.detailContextSummarySymbol {
+  font-size: 0.85rem;
+  color: rgba(245, 241, 255, 0.6);
+}
+
+.detailContextSummaryMeta {
+  font-size: 0.82rem;
+  color: rgba(245, 241, 255, 0.72);
+}
+
+.detailContextAction {
+  border: 1px solid rgba(140, 92, 255, 0.55);
+  background: linear-gradient(135deg, rgba(93, 46, 255, 0.6), rgba(140, 92, 255, 0.45));
+  color: #f5f1ff;
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.66rem;
+  cursor: pointer;
+  transition: background 200ms ease, transform 200ms ease, box-shadow 200ms ease;
+  text-shadow: 0 0 12px rgba(93, 46, 255, 0.45);
+}
+
+.detailContextAction:hover,
+.detailContextAction:focus-visible {
+  background: linear-gradient(135deg, rgba(117, 70, 255, 0.78), rgba(140, 92, 255, 0.55));
+  transform: translateY(-1px);
+  box-shadow: 0 0 18px rgba(93, 46, 255, 0.35);
+}
+
+.detailContextAction:focus-visible {
+  outline: 2px solid #29f3c3;
+  outline-offset: 3px;
+}
+
+.detailContextAction:active {
+  background: linear-gradient(135deg, rgba(42, 14, 130, 0.75), rgba(93, 46, 255, 0.5));
+  transform: translateY(1px);
+}
+
+.detailContextSummaryGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+}
+
+.detailContextSummaryItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.detailContextSummaryItemLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.62rem;
+  color: rgba(245, 241, 255, 0.6);
+}
+
+.detailContextSummaryItemValue {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+}
+
+.detailContextSummaryItemMeta {
+  font-size: 0.78rem;
+  color: rgba(245, 241, 255, 0.68);
+}
+
 .sectionHint {
   margin: 0;
   color: var(--ghostnet-muted);
@@ -587,6 +699,29 @@
 
 .tableRowInteractive:hover {
   background: rgba(93, 46, 255, 0.2);
+}
+
+.tableRowSelectable {
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tableRowSelectable:hover {
+  background: rgba(93, 46, 255, 0.18);
+}
+
+.tableRowSelectable:focus-visible {
+  outline: 2px solid #29f3c3;
+  outline-offset: -2px;
+}
+
+.tableRowSelected {
+  background: rgba(93, 46, 255, 0.28) !important;
+  box-shadow: inset 0 0 0 1px rgba(140, 92, 255, 0.45);
+}
+
+.tableRowSelected:hover {
+  background: rgba(117, 70, 255, 0.32) !important;
 }
 
 .tableRowExpanded {
@@ -811,6 +946,60 @@
   font-size: 0.98rem;
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
   color: #f5f1ff;
+}
+
+.routeDetailContextBar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  width: 100%;
+  margin-top: 1.35rem;
+}
+
+.routeDetailContextItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem 1.2rem;
+  border-radius: 1rem;
+  background: rgba(24, 15, 54, 0.72);
+  border: 1px solid rgba(140, 92, 255, 0.32);
+  min-height: 120px;
+}
+
+.routeDetailContextLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.62rem;
+  color: rgba(245, 241, 255, 0.62);
+}
+
+.routeDetailContextPrimary {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #f5f1ff;
+}
+
+.routeDetailContextValue {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+}
+
+.routeDetailContextMeta {
+  font-size: 0.78rem;
+  color: rgba(245, 241, 255, 0.68);
+}
+
+.routeDetailContextEmpty {
+  grid-column: 1 / -1;
+  padding: 1.1rem 1.4rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(140, 92, 255, 0.4);
+  background: rgba(30, 16, 58, 0.6);
+  color: rgba(245, 241, 255, 0.74);
+  font-size: 0.9rem;
+  text-align: center;
 }
 
 .routeDetailMetrics {

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1026,58 +1026,81 @@
   color: #f5f1ff;
 }
 
-.routeDetailContextBar {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1.25rem;
-  width: 100%;
-  margin-top: 1.35rem;
+.commodityDetailStickyHeader {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.35rem;
+  padding: 1.15rem 1.6rem 1.25rem;
+  background: linear-gradient(135deg, rgba(35, 20, 68, 0.94), rgba(18, 10, 44, 0.92));
+  border-bottom: 1px solid rgba(140, 92, 255, 0.45);
+  box-shadow: 0 1rem 2.5rem rgba(5, 8, 13, 0.55);
+  border-radius: 1.25rem 1.25rem 1rem 1rem;
+  margin: -1px -1px 1.1rem;
 }
 
-.routeDetailContextItem {
+.commodityDetailHeading {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  padding: 1rem 1.2rem;
-  border-radius: 1rem;
-  background: rgba(24, 15, 54, 0.72);
-  border: 1px solid rgba(140, 92, 255, 0.32);
-  min-height: 120px;
+  min-width: 200px;
+  flex: 1 1 240px;
 }
 
-.routeDetailContextLabel {
+.commodityDetailLabel {
   text-transform: uppercase;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.28em;
   font-size: 0.62rem;
-  color: rgba(245, 241, 255, 0.62);
+  color: rgba(245, 241, 255, 0.65);
 }
 
-.routeDetailContextPrimary {
-  font-size: 1.05rem;
+.commodityDetailTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 1.42rem;
   font-weight: 600;
   color: #f5f1ff;
 }
 
-.routeDetailContextValue {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--ghostnet-ink);
+.commodityDetailSymbol {
+  font-size: 0.85rem;
+  color: rgba(245, 241, 255, 0.72);
 }
 
-.routeDetailContextMeta {
-  font-size: 0.78rem;
-  color: rgba(245, 241, 255, 0.68);
+.commodityDetailMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-left: auto;
+  padding: 0.55rem 0.85rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(140, 92, 255, 0.32);
+  background: rgba(24, 15, 54, 0.7);
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0);
 }
 
-.routeDetailContextEmpty {
-  grid-column: 1 / -1;
-  padding: 1.1rem 1.4rem;
-  border-radius: 1rem;
-  border: 1px dashed rgba(140, 92, 255, 0.4);
-  background: rgba(30, 16, 58, 0.6);
-  color: rgba(245, 241, 255, 0.74);
+.commodityDetailMetaItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 120px;
+}
+
+.commodityDetailMetaLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.58rem;
+  color: rgba(245, 241, 255, 0.62);
+}
+
+.commodityDetailMetaValue {
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
   font-size: 0.9rem;
-  text-align: center;
+  color: #f5f1ff;
 }
 
 .routeDetailMetrics {

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -407,10 +407,34 @@
   align-items: center;
 }
 
-.detailContextSummaryHeading {
+.detailContextSummaryTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.detailContextSummaryHeadingText {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+}
+
+.detailContextSummaryIcon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1rem;
+  background: radial-gradient(circle at 30% 30%, rgba(93, 46, 255, 0.4), rgba(42, 14, 130, 0.6));
+  border: 1px solid rgba(140, 92, 255, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 18px rgba(93, 46, 255, 0.35);
+}
+
+.detailContextSummaryIcon svg {
+  width: 1.75rem;
+  height: 1.75rem;
+  fill: #f5f1ff;
 }
 
 .detailContextSummaryLabel {
@@ -480,6 +504,51 @@
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
+}
+
+.detailContextSummaryStation {
+  display: flex;
+  gap: 0.85rem;
+  align-items: flex-start;
+}
+
+.detailContextSummaryStationIcon {
+  width: 2.8rem;
+  height: 2.8rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(140, 92, 255, 0.32);
+  background: radial-gradient(circle at 20% 20%, rgba(93, 46, 255, 0.35), rgba(24, 15, 52, 0.75));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 16px rgba(93, 46, 255, 0.25);
+  flex-shrink: 0;
+}
+
+.detailContextSummaryStationIcon svg {
+  width: 1.9rem;
+  height: 1.9rem;
+}
+
+.detailContextSummaryStationInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.detailContextSummaryFaction {
+  font-size: 0.78rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: rgba(245, 241, 255, 0.72);
+}
+
+.detailContextSummaryFactionStatus {
+  font-size: 0.7rem;
+  color: rgba(245, 241, 255, 0.62);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .detailContextSummaryItemLabel {

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -843,6 +843,30 @@
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
 }
 
+.routeDetailMetricFootnote {
+  font-size: 0.75rem;
+  color: rgba(245, 241, 255, 0.64);
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+  letter-spacing: 0.08em;
+}
+
+.routeDetailLink {
+  color: var(--ghostnet-accent);
+  text-decoration: none;
+  transition: color 160ms ease;
+}
+
+.routeDetailLink:hover,
+.routeDetailLink:focus-visible {
+  color: #f5f1ff;
+  text-decoration: underline;
+}
+
+.routeDetailLink:focus-visible {
+  outline: 2px solid #29f3c3;
+  outline-offset: 2px;
+}
+
 .routeDetailGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -494,6 +494,15 @@
   transform: translateY(1px);
 }
 
+.detailContextAction[disabled],
+.detailContextAction[aria-disabled='true'] {
+  cursor: default;
+  opacity: 0.6;
+  box-shadow: none;
+  transform: none;
+  pointer-events: none;
+}
+
 .detailContextSummaryGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1026,28 +1026,42 @@
   color: #f5f1ff;
 }
 
-.commodityDetailStickyHeader {
+
+.commodityDetailTableHead {
   position: sticky;
   top: 0;
-  z-index: 5;
+  z-index: 6;
+}
+
+.dataTable thead tr.commodityDetailHeaderRow {
+  background: transparent;
+  border-bottom: 0;
+  box-shadow: none;
+}
+
+.commodityDetailHeaderCell {
+  padding: 0;
+  border: 0;
+}
+
+.commodityDetailHeader {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 1.35rem;
-  padding: 1.15rem 1.6rem 1.25rem;
-  background: linear-gradient(135deg, rgba(35, 20, 68, 0.94), rgba(18, 10, 44, 0.92));
-  border-bottom: 1px solid rgba(140, 92, 255, 0.45);
-  box-shadow: 0 1rem 2.5rem rgba(5, 8, 13, 0.55);
-  border-radius: 1.25rem 1.25rem 1rem 1rem;
-  margin: -1px -1px 1.1rem;
+  gap: 1.1rem;
+  padding: 0.85rem 1.35rem 0.95rem;
+  background: linear-gradient(135deg, rgba(35, 20, 68, 0.94), rgba(18, 10, 44, 0.9));
+  border-bottom: 1px solid rgba(140, 92, 255, 0.38);
+  box-shadow: 0 0.85rem 2.35rem rgba(5, 8, 13, 0.52);
 }
+
 
 .commodityDetailHeading {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
   min-width: 200px;
-  flex: 1 1 240px;
+  flex: 1 1 220px;
 }
 
 .commodityDetailLabel {
@@ -1074,33 +1088,41 @@
 .commodityDetailMeta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65rem;
   margin-left: auto;
-  padding: 0.55rem 0.85rem;
-  border-radius: 0.9rem;
-  border: 1px solid rgba(140, 92, 255, 0.32);
-  background: rgba(24, 15, 54, 0.7);
-  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0);
+  padding: 0.45rem 0.7rem;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(140, 92, 255, 0.28);
+  background: rgba(24, 15, 54, 0.68);
 }
 
 .commodityDetailMetaItem {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  min-width: 120px;
+  gap: 0.2rem;
+  min-width: 110px;
 }
 
 .commodityDetailMetaLabel {
   text-transform: uppercase;
   letter-spacing: 0.22em;
-  font-size: 0.58rem;
-  color: rgba(245, 241, 255, 0.62);
+  font-size: 0.55rem;
+  color: rgba(245, 241, 255, 0.6);
 }
 
 .commodityDetailMetaValue {
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   color: #f5f1ff;
+}
+
+.dataTable thead tr.commodityDetailColumnsRow {
+  background: var(--ghostnet-table-header);
+  border-bottom: 1px solid rgba(140, 92, 255, 0.45);
+}
+
+.dataTable thead tr.commodityDetailColumnsRow th {
+  padding: 0.7rem 1rem;
 }
 
 .routeDetailMetrics {


### PR DESCRIPTION
## Summary
- add a full-screen commodity intel view that mirrors the existing route detail layout and exposes sortable Ghostnet listings
- return complete Ghostnet listing data from the commodity values API to power the new workspace detail experience
- extend Ghostnet styling and contributor guidance for detail view footnotes and external station links

## Testing
- `npm test -- --runInBand` *(fails: jest is not installed in this environment)*
- `npm run build:client` *(fails: next is not installed in this environment)*
- `npm run start` *(fails: service depends on dotenv which is not installed here)*
- `npm install` *(fails: unable to download Resource Hacker dependency due to ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68de9a0c58908323951a0d283afe5f6b