### PR TITLE
Align GhostNet table headers with purple accent

### DIFF
--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1258,6 +1258,11 @@
   color: color-mix(in srgb, var(--ghostnet-color-text-strong) 88%, transparent);
 }
 
+.ghostnet :global(.ghostnet-panel-table table thead tr th::after) {
+  border-bottom: 0.2rem solid var(--ghostnet-color-primary);
+  box-shadow: 0 0.03rem 0.5rem color-mix(in srgb, var(--ghostnet-color-primary) 60%, transparent);
+}
+
 .ghostnet :global(.ghostnet-panel-table tbody tr) {
   border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
 }


### PR DESCRIPTION
## Summary
- align the GhostNet table header ::after underline with the GhostNet purple accent so header dividers no longer use the global primary color

## Testing
- npm test -- --runInBand *(fails: jest not found in environment after npm install could not complete due to network restrictions downloading ResourceHacker)*
- npm run build:client *(fails: Next.js CLI missing because dependencies were not installed)*
- npm run start *(fails: dotenv missing because dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68deb0ecabc88323ae0d5d6494a255f4