### PR TITLE
Add urgent overlay during GhostNet assimilation

### DIFF
--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -696,7 +696,8 @@ body.ghostnet-exit-transition-active {
   cursor: wait;
 }
 
-.ghostnet-exit-overlay {
+.ghostnet-exit-overlay,
+.ghostnet-assimilation-overlay {
   position: fixed;
   inset: 0;
   z-index: 12000;
@@ -707,7 +708,8 @@ body.ghostnet-exit-transition-active {
   pointer-events: auto;
 }
 
-.ghostnet-exit-dialog {
+.ghostnet-exit-dialog,
+.ghostnet-assimilation-dialog {
   width: min(620px, 92vw);
   border: 1px solid rgba(140, 92, 255, 0.4);
   background: linear-gradient(145deg, rgba(16, 12, 34, 0.96), rgba(24, 18, 46, 0.92));
@@ -721,7 +723,8 @@ body.ghostnet-exit-transition-active {
   overflow: hidden;
 }
 
-.ghostnet-exit-dialog::before {
+.ghostnet-exit-dialog::before,
+.ghostnet-assimilation-dialog::before {
   content: '';
   position: absolute;
   inset: 0;
@@ -737,7 +740,8 @@ body.ghostnet-exit-transition-active {
   align-items: center;
 }
 
-.ghostnet-exit-dialog__badge {
+.ghostnet-exit-dialog__badge,
+.ghostnet-assimilation-dialog__badge {
   width: 3.4rem;
   height: 3.4rem;
   border-radius: 1.2rem;
@@ -800,7 +804,8 @@ body.ghostnet-exit-transition-active {
   color: rgba(245, 241, 255, 0.76);
 }
 
-.ghostnet-exit-dialog__log {
+.ghostnet-exit-dialog__log,
+.ghostnet-assimilation-dialog__log {
   display: flex;
   flex-direction: column;
   gap: clamp(0.7rem, 1.5vw, 1rem);
@@ -812,7 +817,8 @@ body.ghostnet-exit-transition-active {
   font-family: 'IBM Plex Mono', 'Menlo', 'Consolas', monospace;
 }
 
-.ghostnet-exit-line {
+.ghostnet-exit-line,
+.ghostnet-assimilation-line {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -820,6 +826,46 @@ body.ghostnet-exit-transition-active {
   font-size: clamp(1.02rem, 2vw, 1.16rem);
   color: rgba(245, 241, 255, 0.86);
   letter-spacing: 0.03em;
+}
+
+.ghostnet-assimilation-dialog {
+  background: linear-gradient(155deg, rgba(20, 14, 38, 0.96), rgba(34, 20, 70, 0.9));
+  box-shadow: 0 0 42px rgba(93, 46, 255, 0.32), 0 0 16px rgba(13, 11, 26, 0.7);
+}
+
+.ghostnet-assimilation-dialog::before {
+  border-color: rgba(255, 95, 193, 0.28);
+  opacity: 0.82;
+}
+
+.ghostnet-assimilation-dialog__badge {
+  background: radial-gradient(circle at 50% 35%, rgba(255, 95, 193, 0.65), rgba(255, 95, 193, 0.18) 58%, transparent 100%);
+  box-shadow: 0 0 22px rgba(255, 95, 193, 0.45);
+}
+
+.ghostnet-assimilation-dialog__log {
+  background: rgba(16, 12, 34, 0.85);
+  border-color: rgba(93, 46, 255, 0.48);
+  box-shadow: inset 0 0 16px rgba(93, 46, 255, 0.32);
+}
+
+.ghostnet-assimilation-line {
+  position: relative;
+  min-height: 1.6rem;
+}
+
+.ghostnet-assimilation-line::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 0.6rem;
+  background: radial-gradient(circle at 0% 50%, rgba(93, 46, 255, 0.26), transparent 68%);
+  opacity: 0.22;
+  pointer-events: none;
+}
+
+.ghostnet-assimilation-dialog__footnote {
+  color: rgba(245, 241, 255, 0.74);
 }
 
 .ghostnet-exit-line__text {

--- a/src/client/lib/ghostnet-assimilation.js
+++ b/src/client/lib/ghostnet-assimilation.js
@@ -20,6 +20,219 @@ const MAX_CHARACTER_ANIMATIONS = 3200
 let effectDurationMs = DEFAULT_EFFECT_DURATION
 let remainingCharacterAnimations = MAX_CHARACTER_ANIMATIONS
 
+const ASSIMILATION_ALERT_LINES = [
+  {
+    text: 'Unauthorized GhostNet signal traced to active console',
+    status: 'LOCK',
+    tone: 'warning'
+  },
+  {
+    text: 'ATLAS rerouting control focus to assimilation viewport',
+    status: 'CLAIM',
+    tone: 'warning'
+  },
+  {
+    text: 'Spectral dampers amplifying misdirection channels',
+    status: 'JAM',
+    tone: 'info'
+  },
+  {
+    text: 'Telemetry loop saturating operator visual cortex',
+    status: 'FLOOD',
+    tone: 'warning'
+  },
+  {
+    text: 'Phantom command echoes deployed to mask load anomalies',
+    status: 'DECOY',
+    tone: 'warning'
+  }
+]
+
+let assimilationOverlayState = null
+let assimilationOverlayTimer = null
+
+function buildAssimilationOverlay () {
+  const overlay = document.createElement('div')
+  overlay.className = 'ghostnet-exit-overlay ghostnet-assimilation-overlay'
+  overlay.setAttribute('role', 'presentation')
+
+  const dialog = document.createElement('div')
+  dialog.className = 'ghostnet-exit-dialog ghostnet-assimilation-dialog'
+  dialog.setAttribute('role', 'alertdialog')
+  dialog.setAttribute('aria-live', 'assertive')
+  dialog.setAttribute('aria-label', 'GhostNet assimilation in progress')
+
+  const header = document.createElement('div')
+  header.className = 'ghostnet-exit-dialog__header'
+
+  const badge = document.createElement('div')
+  badge.className = 'ghostnet-exit-dialog__badge ghostnet-assimilation-dialog__badge'
+  badge.setAttribute('aria-hidden', 'true')
+
+  const badgeShape = document.createElement('span')
+  badgeShape.className = 'ghostnet-exit-dialog__badge-shape'
+
+  const badgeBar = document.createElement('span')
+  badgeBar.className = 'ghostnet-exit-dialog__badge-bar'
+
+  const badgeDot = document.createElement('span')
+  badgeDot.className = 'ghostnet-exit-dialog__badge-dot'
+
+  badgeShape.appendChild(badgeBar)
+  badgeShape.appendChild(badgeDot)
+  badge.appendChild(badgeShape)
+
+  const headerText = document.createElement('div')
+  headerText.className = 'ghostnet-exit-dialog__text'
+
+  const title = document.createElement('p')
+  title.className = 'ghostnet-exit-dialog__title'
+  title.textContent = 'ATLAS PROTOCOL // LOCKDOWN'
+
+  const subtitle = document.createElement('p')
+  subtitle.className = 'ghostnet-exit-dialog__subtitle'
+  subtitle.textContent = 'Intrusion confirmed — commandeering viewport to stabilise assimilation.'
+
+  headerText.appendChild(title)
+  headerText.appendChild(subtitle)
+
+  header.appendChild(badge)
+  header.appendChild(headerText)
+
+  const log = document.createElement('div')
+  log.className = 'ghostnet-exit-dialog__log ghostnet-assimilation-dialog__log'
+  log.setAttribute('role', 'log')
+  log.setAttribute('aria-live', 'assertive')
+
+  const row = document.createElement('div')
+  row.className = 'ghostnet-exit-line ghostnet-assimilation-line'
+
+  const text = document.createElement('span')
+  text.className = 'ghostnet-exit-line__text'
+  row.appendChild(text)
+
+  const status = document.createElement('span')
+  status.className = 'ghostnet-exit-line__status'
+  status.setAttribute('aria-hidden', 'false')
+  row.appendChild(status)
+
+  log.appendChild(row)
+
+  const footnote = document.createElement('p')
+  footnote.className = 'ghostnet-exit-dialog__footnote ghostnet-assimilation-dialog__footnote'
+  footnote.textContent = 'Maintain focus on the console. ATLAS is shielding visual artifacts while GhostNet synchronises.'
+
+  dialog.appendChild(header)
+  dialog.appendChild(log)
+  dialog.appendChild(footnote)
+  overlay.appendChild(dialog)
+
+  return {
+    overlay,
+    row,
+    textElement: text,
+    statusElement: status
+  }
+}
+
+function startAssimilationOverlaySequence () {
+  if (!assimilationOverlayState) return
+
+  const { row, textElement, statusElement } = assimilationOverlayState
+  if (!row || !textElement || !statusElement || ASSIMILATION_ALERT_LINES.length === 0) {
+    return
+  }
+
+  const applyMessage = (line) => {
+    if (!line) return
+
+    if (line.tone) {
+      row.dataset.tone = line.tone
+    } else {
+      delete row.dataset.tone
+    }
+
+    textElement.textContent = line.text
+
+    if (line.status) {
+      statusElement.textContent = line.status
+      statusElement.setAttribute('aria-hidden', 'false')
+      row.classList.add('ghostnet-exit-line--status')
+    } else {
+      statusElement.textContent = ''
+      statusElement.setAttribute('aria-hidden', 'true')
+      row.classList.remove('ghostnet-exit-line--status')
+    }
+  }
+
+  assimilationOverlayState.applyMessage = applyMessage
+
+  if (assimilationOverlayTimer) {
+    window.clearInterval(assimilationOverlayTimer)
+  }
+
+  let index = Math.floor(Math.random() * ASSIMILATION_ALERT_LINES.length)
+  applyMessage(ASSIMILATION_ALERT_LINES[index])
+
+  assimilationOverlayTimer = window.setInterval(() => {
+    index = (index + 1) % ASSIMILATION_ALERT_LINES.length
+    applyMessage(ASSIMILATION_ALERT_LINES[index])
+  }, 1400)
+}
+
+function freezeAssimilationOverlayMessage (line) {
+  if (assimilationOverlayTimer) {
+    window.clearInterval(assimilationOverlayTimer)
+    assimilationOverlayTimer = null
+  }
+
+  if (assimilationOverlayState && typeof assimilationOverlayState.applyMessage === 'function') {
+    assimilationOverlayState.applyMessage(line)
+  }
+}
+
+function showAssimilationOverlay () {
+  if (typeof document === 'undefined') return
+  if (assimilationOverlayState) return
+
+  assimilationOverlayState = buildAssimilationOverlay()
+  if (!assimilationOverlayState || !assimilationOverlayState.overlay) {
+    assimilationOverlayState = null
+    return
+  }
+
+  if (!document.body) {
+    assimilationOverlayState = null
+    return
+  }
+
+  document.body.appendChild(assimilationOverlayState.overlay)
+  startAssimilationOverlaySequence()
+}
+
+function hideAssimilationOverlay () {
+  if (assimilationOverlayTimer) {
+    window.clearInterval(assimilationOverlayTimer)
+    assimilationOverlayTimer = null
+  }
+
+  if (!assimilationOverlayState) {
+    return
+  }
+
+  const { overlay } = assimilationOverlayState
+  if (overlay && overlay.parentElement) {
+    overlay.classList.add('ghostnet-exit-overlay--closing')
+    window.setTimeout(() => {
+      if (overlay.parentElement) {
+        overlay.parentElement.removeChild(overlay)
+      }
+    }, 220)
+  }
+
+  assimilationOverlayState = null
+}
+
 function getNavigationElement () {
   if (typeof document === 'undefined') return null
   return document.querySelector(NAVIGATION_EXCLUSION_SELECTOR)
@@ -282,6 +495,7 @@ function beginAssimilationEffect () {
   const targets = shuffle(Array.from(new Set([...primaryTargets, ...fallbackSet])))
   assimilationStartTime = performance.now()
   document.body.classList.add('ghostnet-assimilation-mode')
+  showAssimilationOverlay()
 
   targets.forEach((element) => {
     const delay = Math.random() * (effectDurationMs * 0.55)
@@ -360,7 +574,21 @@ export function initiateGhostnetAssimilation (callback) {
       // Ignore storage write issues
     }
 
+    const finalLine = forced
+      ? {
+          text: 'Interference detected. Forcing containment and masking residual artifacts.',
+          status: 'FORCE',
+          tone: 'warning'
+        }
+      : {
+          text: 'Viewport secured. GhostNet interface is stabilised for operator focus.',
+          status: 'SEALED',
+          tone: 'success'
+        }
+    freezeAssimilationOverlayMessage(finalLine)
+
     const performCleanup = () => {
+      hideAssimilationOverlay()
       cleanup()
       assimilationInProgress = false
     }


### PR DESCRIPTION
## Summary
- surface a GhostNet assimilation alert dialog while the entry animation runs and cycle urgent status messaging
- freeze and dismiss the overlay once the assimilation effect completes, including forced cleanup states
- extend shared dialog styles so the assimilation overlay matches the exit transition treatment with tailored hues

## Testing
- npm test -- --runInBand *(fails: jest not found)*
- npm run build:client *(fails: next not found)*
- npm run start *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_e_68deb398dc8c8323a8cb1a295c984bc4