### PR TITLE
Ensure service waits for logs before starting web server

### DIFF
--- a/src/service/main.js
+++ b/src/service/main.js
@@ -176,9 +176,18 @@ webSocketServer.on('error', function (error) {
   }
 })
 
-// Start server
-httpServer.listen(PORT)
-console.log(`Listening on port ${PORT}…`)
+async function startService () {
+  try {
+    console.log('Initializing log readers before starting web server…')
+    await init()
+  } catch (error) {
+    console.error('Failed to initialize log readers', error)
+    process.exit(1)
+  }
 
-// Initialize app - start parsing data and watching for game state changes
-setTimeout(() => init(), 500)
+  httpServer.listen(PORT, () => {
+    console.log(`Listening on port ${PORT}…`)
+  })
+}
+
+startService()


### PR DESCRIPTION
## Summary
- ensure the service waits for log initialization to complete before starting the HTTP/WebSocket server
- add explicit logging and failure handling around the log initialization step

## Testing
- npm test -- --runInBand *(fails: jest missing because dependencies could not be installed; `npm install` aborted by network errors while downloading ResourceHacker)*

------
https://chatgpt.com/codex/tasks/task_e_68deb8f0a624832394fe0ce4e897b4e3