### PR TITLE
Redesign GhostNet commodity intelligence view

### DIFF
--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -516,6 +516,15 @@
   background: color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent);
 }
 
+.dataTable tbody tr[role='button'] {
+  cursor: pointer;
+}
+
+.dataTable tbody tr[role='button']:hover {
+  transform: translateY(-2px);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 24%, transparent);
+}
+
 .dataTable td {
   padding: 0.75rem 1rem;
   color: var(--ghostnet-ink);
@@ -1256,6 +1265,444 @@
 .ghostnet :global(.ghostnet-panel-table table thead tr th) {
   border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
   color: color-mix(in srgb, var(--ghostnet-color-text-strong) 88%, transparent);
+}
+
+.tableSortArrow {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--ghostnet-accent);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--ghostnet-color-primary) 42%, transparent);
+}
+
+.commodityRowActive {
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 36%, transparent) !important;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghostnet-color-primary-light) 45%, transparent);
+}
+
+.commodityRowActive td {
+  color: var(--ghostnet-ink);
+}
+
+.commoditySummary {
+  margin: 1.75rem 0 2rem;
+}
+
+.commoditySummaryGradient {
+  position: relative;
+  border-radius: 1.5rem;
+  padding: 1.5rem 2rem 1.75rem;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 42%, transparent);
+  background: linear-gradient(
+      140deg,
+      color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent) 0%,
+      color-mix(in srgb, var(--ghostnet-color-primary-dark) 36%, transparent) 55%,
+      color-mix(in srgb, var(--ghostnet-color-background) 94%, transparent) 100%
+    );
+  box-shadow: 0 1.95rem 3.85rem color-mix(in srgb, var(--ghostnet-color-background) 72%, transparent),
+    0 0 2.1rem color-mix(in srgb, var(--ghostnet-color-primary-light) 24%, transparent);
+  overflow: hidden;
+}
+
+.commoditySummaryGradient::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 15%, color-mix(in srgb, var(--ghostnet-color-primary-light) 26%, transparent) 0%, transparent 55%),
+    radial-gradient(circle at 85% 35%, color-mix(in srgb, var(--ghostnet-color-primary) 22%, transparent) 0%, transparent 60%);
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.commoditySummaryHeader {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.75rem;
+}
+
+.commoditySummaryIcons {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.commoditySummaryBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary-light) 42%, transparent);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 32%, transparent);
+  box-shadow: 0 0 26px color-mix(in srgb, var(--ghostnet-color-primary-light) 32%, transparent);
+}
+
+.commoditySummaryBadge :global(svg) {
+  width: 1.45rem;
+  height: 1.45rem;
+  fill: var(--ghostnet-color-text-strong);
+}
+
+.commoditySummaryChevron {
+  font-size: 1.3rem;
+  color: var(--ghostnet-accent);
+  text-shadow: 0 0 18px color-mix(in srgb, var(--ghostnet-color-primary-light) 42%, transparent);
+}
+
+.commoditySummaryHeading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.commoditySummaryLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 64%, transparent);
+}
+
+.commoditySummaryTitle {
+  margin: 0;
+  font-size: 1.6rem;
+  line-height: 1.2;
+  color: var(--ghostnet-ink);
+}
+
+.commoditySummaryAction {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1.35rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary-light) 45%, transparent);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 78%, transparent), color-mix(in srgb, var(--ghostnet-color-primary-dark) 56%, transparent));
+  color: var(--ghostnet-color-text-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-shadow: 0 0 14px color-mix(in srgb, var(--ghostnet-color-primary-light) 38%, transparent);
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.commoditySummaryAction:hover,
+.commoditySummaryAction:focus-visible {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 88%, transparent), color-mix(in srgb, var(--ghostnet-color-primary-dark) 60%, transparent));
+  box-shadow: 0 0 18px color-mix(in srgb, var(--ghostnet-color-primary-light) 32%, transparent);
+  transform: translateY(-1px);
+}
+
+.commoditySummaryAction:focus-visible {
+  outline: 2px solid var(--ghostnet-color-success);
+  outline-offset: 3px;
+}
+
+.commoditySummaryAction:active {
+  transform: translateY(1px);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary-dark) 72%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 56%, transparent));
+}
+
+.commoditySummaryAction:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.commoditySummaryAction:disabled:hover {
+  transform: none;
+}
+
+.commoditySummaryActionIcon :global(svg) {
+  width: 0.95rem;
+  height: 0.95rem;
+  fill: currentColor;
+}
+
+.commoditySummaryBody {
+  position: relative;
+  z-index: 1;
+  margin-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 78%, transparent);
+}
+
+.commoditySummaryLocation {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.commoditySummaryStation {
+  color: var(--ghostnet-color-text-strong);
+}
+
+.commoditySummarySystem {
+  color: var(--ghostnet-accent);
+}
+
+.commoditySummaryMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 1.15rem;
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 68%, transparent);
+}
+
+.commoditySummaryMeta span {
+  position: relative;
+}
+
+.commoditySummaryMeta span::before {
+  content: '';
+  position: absolute;
+  left: -0.55rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0.25rem;
+  height: 0.25rem;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--ghostnet-color-primary-light) 60%, transparent);
+}
+
+.commoditySummaryMeta span:first-child::before {
+  display: none;
+}
+
+.commoditySummaryFaction {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 78%, transparent);
+}
+
+.commoditySummaryFactionName {
+  font-weight: 600;
+  color: var(--ghostnet-color-text-strong);
+}
+
+.commoditySummaryFactionStatus {
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+}
+
+.commodityDetailScroll {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-primary-dark) 78%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-background) 92%, transparent) 100%);
+}
+
+.commodityDetailTable tbody tr {
+  font-size: 0.9rem;
+}
+
+.commodityDetailHead {
+  position: sticky;
+  top: 0;
+  z-index: 6;
+  --commodity-detail-header-height: 4.6rem;
+}
+
+.commodityDetailHead tr:first-child th {
+  position: sticky;
+  top: 0;
+  padding: 0;
+  background: transparent;
+  z-index: 6;
+}
+
+.commodityDetailHeadRow th {
+  position: sticky;
+  top: var(--commodity-detail-header-height);
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 72%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 32%, transparent);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.commodityDetailHeadRow th:focus-visible {
+  outline: 2px solid var(--ghostnet-color-success);
+  outline-offset: 2px;
+}
+
+.commodityDetailHeadRow th:hover {
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+}
+
+.commodityDetailHeaderBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.75rem;
+  padding: 1.15rem 1.6rem 1.1rem;
+  background: var(--ghostnet-table-header);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 40%, transparent);
+}
+
+.commodityDetailBackButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.5rem 1.15rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary-light) 42%, transparent);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary-dark) 62%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 52%, transparent));
+  color: var(--ghostnet-color-text-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  cursor: pointer;
+  text-shadow: 0 0 12px color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.commodityDetailBackButton:hover,
+.commodityDetailBackButton:focus-visible {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 78%, transparent), color-mix(in srgb, var(--ghostnet-color-primary-dark) 58%, transparent));
+  transform: translateY(-1px);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--ghostnet-color-primary) 36%, transparent);
+}
+
+.commodityDetailBackButton:focus-visible {
+  outline: 2px solid var(--ghostnet-color-success);
+  outline-offset: 3px;
+}
+
+.commodityDetailBackButton:active {
+  transform: translateY(1px);
+}
+
+.commodityDetailBackIcon :global(svg) {
+  width: 0.85rem;
+  height: 0.85rem;
+  fill: currentColor;
+}
+
+.commodityDetailHeaderContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.commodityDetailHeaderLabel {
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 72%, transparent);
+}
+
+.commodityDetailHeaderTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+}
+
+.commodityDetailHeaderMeta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.commodityHeaderBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 45%, transparent);
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 85%, transparent);
+}
+
+.commodityHeaderBadgeStatus[data-tone='error'],
+.commodityHeaderBadgeStatus[data-tone='partial'] {
+  color: var(--ghostnet-color-warning);
+  border-color: color-mix(in srgb, var(--ghostnet-color-warning) 55%, transparent);
+}
+
+.commodityHeaderBadgeStatus[data-tone='ok'] {
+  color: var(--ghostnet-color-success);
+  border-color: color-mix(in srgb, var(--ghostnet-color-success) 55%, transparent);
+}
+
+.commodityHeaderBadgeStatus[data-tone='empty'],
+.commodityHeaderBadgeStatus[data-tone='idle'] {
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
+}
+
+.commodityHeaderBadgeMuted[data-tone='error'] {
+  color: var(--ghostnet-color-warning);
+}
+
+.commodityHeaderBadgeMuted[data-tone='missing'] {
+  color: color-mix(in srgb, var(--ghostnet-color-warning) 70%, transparent);
+}
+
+.commodityHeaderBadgeMuted[data-tone='ok'] {
+  color: var(--ghostnet-color-success);
+}
+
+.commodityDetailCellStation {
+  width: 100%;
+}
+
+.commodityDetailStation {
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+}
+
+.commodityDetailSystem {
+  color: var(--ghostnet-accent);
+  font-size: 0.82rem;
+  margin-top: 0.15rem;
+}
+
+.commodityDetailPad {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 65%, transparent);
+}
+
+.commodityDetailSubtext {
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 62%, transparent);
+  font-size: 0.78rem;
+  margin-top: 0.2rem;
+}
+
+.commodityDetailDemandLow {
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ghostnet-color-warning);
+}
+
+.commodityDetailEmpty {
+  padding: 2.25rem 1rem;
+  text-align: center;
+  font-size: 0.95rem;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 68%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead tr th::after) {


### PR DESCRIPTION
## Summary
- Fold the intercepted commodity listings into the trade panel with a sticky workspace header and sortable columns for the detail view.
- Add a persistent commodity context summary and selection handlers so the focused item drives both the summary card and detail navigation.
- Extend the GhostNet valuations API to return raw listing arrays and station faction metadata needed by the updated UI.

## Testing
- npm test -- --runInBand *(fails: jest not found because dependencies cannot be installed in this environment)*
- npm run build:client *(fails: next not found because dependencies cannot be installed in this environment)*
- npm run start *(fails: missing module dotenv because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deb92af3ac83239c92a6800907486a