### PR TITLE
Strengthen GhostNet UI uniformity guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@
 - Mirror the structural patterns and layout conventions of other Icarus pages so the product feels cohesive, while still honoring GhostNet's unique identity.
 - Keep data tables outside of `SectionFrame` containers; tables should rely on GhostNet table shells (`dataTableContainer`, `dataTable`) for structure instead of being nested inside section frames.
 - Table rows must never expand inline like a drawer. Selecting a row should always open a dedicated full-page view in the workspace, mirroring the behavior on the Find Trade Routes page. This ensures a clean experience on smaller displays.
+- Before introducing a new layout or page, inspect existing GhostNet surfaces and lift their structure directly—copy the baseline layout (navigation placement, section frames, typographic hierarchy, spacing rhythm) and adjust only the dynamic content. When in doubt, start from an existing component file and refactor it into shared primitives instead of authoring novel markup.
+- Favor composing UI from the shared layout primitives in `src/client/components` (e.g., `SectionFrame`, `SectionHeader`, table shells, detail drawers). If a new view needs a combination that does not yet exist, build the combination as a reusable component and place it alongside its peers so future pages can inherit it.
+- Consistency of data presentation is critical: station summaries should always follow the pattern `Icon → Name → Key Metrics → Secondary metadata`. Expanders and drawers must surface the same canonical fields (`status`, `ownership`, `location`, `throughput`, and `alerts`) in the same order across the app.
+- Avoid ad-hoc styling or bespoke CSS for one-off views. Extend the GhostNet CSS tokens or shared utility classes, and document any new token additions with rationale and usage guidance.
 
 ### Palette hygiene
 - Keep the GhostNet palette constrained to the core tokens defined in `src/client/css/pages/ghostnet.css`.


### PR DESCRIPTION
## Summary
- reinforce the GhostNet implementation guidance with explicit instructions on reusing layout primitives
- document the canonical station summary structure and required fields for drawers and expanders
- discourage bespoke styling by directing contributors to extend shared GhostNet tokens

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ded24dc4e88323bba2914b5e3d1d6c