### PR TITLE
Add access control icon and dialog

### DIFF
--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -6,7 +6,7 @@ import { eliteDateTime } from 'lib/format'
 import { Settings } from 'components/settings'
 import notification from 'lib/notification'
 import { initiateGhostnetAssimilation, isGhostnetAssimilationActive, GHOSTNET_ASSIMILATION_EVENT } from 'lib/ghostnet-assimilation'
-import { isGhostnetNavUnlocked, setGhostnetNavUnlocked } from 'lib/ghostnet-settings'
+import { isGhostnetNavUnlocked } from 'lib/ghostnet-settings'
 
 const ORIGINAL_TITLE = 'ICARUS TERMINAL'
 const TARGET_TITLE = 'GHOSTNET-ATLAS'
@@ -57,42 +57,51 @@ const createNavButtonGlitchProfile = ({ outDelay, outDuration, inDelay, inDurati
   const jitterLoop = Math.round(randomBetween(emphasizeUnlock ? 180 : 220, emphasizeUnlock ? 260 : 360))
   const ghostLoop = Math.round(randomBetween(emphasizeUnlock ? 280 : 320, emphasizeUnlock ? 440 : 520))
   const ghostOpacity = randomBetween(0.28, emphasizeUnlock ? 0.6 : 0.5).toFixed(2)
-  const shiftX = formatPx(randomBetween(-6, 6))
-  const shiftY = formatPx(randomBetween(-6, 5))
-  const tilt = `${randomBetween(-2.4, 2.4).toFixed(2)}deg`
+  const shiftX = formatPx(randomBetween(-8, 8))
+  const shiftY = formatPx(randomBetween(-2.5, 2.5))
+  const tilt = `${randomBetween(-2.1, 2.1).toFixed(2)}deg`
   const glowRadius = `${randomBetween(emphasizeUnlock ? 2.1 : 1.7, emphasizeUnlock ? 3.05 : 2.5).toFixed(2)}rem`
   const glowOpacity = randomBetween(emphasizeUnlock ? 0.6 : 0.45, emphasizeUnlock ? 0.88 : 0.68).toFixed(2)
   const saturation = randomBetween(emphasizeUnlock ? 1.22 : 1.12, emphasizeUnlock ? 1.46 : 1.36).toFixed(2)
 
-  const outScaleA = randomBetween(0.88, 0.96).toFixed(3)
-  const outScaleB = randomBetween(0.78, 0.9).toFixed(3)
-  const outScaleC = randomBetween(0.68, 0.82).toFixed(3)
-  const outScaleD = randomBetween(0.62, 0.76).toFixed(3)
-  const outTranslateA = formatPx(randomBetween(-12, -4))
-  const outTranslateB = formatPx(randomBetween(-10, -2))
-  const outTranslateC = formatPx(randomBetween(-15, -5))
-  const outTranslateD = formatPx(randomBetween(-18, -8))
+  const horizontalBias = Math.random() > 0.5 ? 1 : -1
+  const outScaleA = randomBetween(0.9, 0.97).toFixed(3)
+  const outScaleB = randomBetween(0.82, 0.92).toFixed(3)
+  const outScaleC = randomBetween(0.72, 0.86).toFixed(3)
+  const outScaleD = randomBetween(0.64, 0.8).toFixed(3)
+  const outTranslateXA = formatPx(randomBetween(6, 18) * horizontalBias)
+  const outTranslateXB = formatPx(randomBetween(10, 22) * horizontalBias)
+  const outTranslateXC = formatPx(randomBetween(18, 32) * horizontalBias)
+  const outTranslateXD = formatPx(randomBetween(26, 38) * horizontalBias)
+  const outTranslateYA = formatPx(randomBetween(-2.5, 2.5))
+  const outTranslateYB = formatPx(randomBetween(-2, 2))
+  const outTranslateYC = formatPx(randomBetween(-1.5, 1.5))
+  const outTranslateYD = formatPx(randomBetween(-1, 1))
   const outOpacityA = randomBetween(0.25, 0.45).toFixed(2)
   const outOpacityB = randomBetween(0.55, 0.88).toFixed(2)
   const outOpacityC = randomBetween(0.18, 0.42).toFixed(2)
 
-  const inScaleStart = randomBetween(0.52, 0.68).toFixed(3)
-  const inScaleMidA = randomBetween(0.68, 0.86).toFixed(3)
-  const inScaleMidB = randomBetween(0.82, 0.98).toFixed(3)
-  const inScaleMidC = randomBetween(0.72, 0.94).toFixed(3)
-  const inTranslateStart = formatPx(randomBetween(9, 18))
-  const inTranslateA = formatPx(randomBetween(3, 11))
-  const inTranslateB = formatPx(randomBetween(-3, 6))
-  const inTranslateC = formatPx(randomBetween(-7, 2))
+  const inScaleStart = randomBetween(0.6, 0.74).toFixed(3)
+  const inScaleMidA = randomBetween(0.75, 0.9).toFixed(3)
+  const inScaleMidB = randomBetween(0.88, 1.01).toFixed(3)
+  const inScaleMidC = randomBetween(0.8, 0.96).toFixed(3)
+  const inTranslateStartX = formatPx(randomBetween(-26, 26))
+  const inTranslateAX = formatPx(randomBetween(-18, 18))
+  const inTranslateBX = formatPx(randomBetween(-9, 12))
+  const inTranslateCX = formatPx(randomBetween(-6, 8))
+  const inTranslateStartY = formatPx(randomBetween(-2.2, 2.2))
+  const inTranslateAY = formatPx(randomBetween(-1.8, 1.8))
+  const inTranslateBY = formatPx(randomBetween(-1.2, 1.2))
+  const inTranslateCY = formatPx(randomBetween(-0.8, 0.8))
 
-  const clipStartTop = formatPercent(randomBetween(44, 58))
-  const clipStartBottom = formatPercent(randomBetween(34, 48))
-  const clipMidTopA = formatPercent(randomBetween(0, 6))
-  const clipMidBottomA = formatPercent(randomBetween(28, 44))
+  const clipStartTop = formatPercent(randomBetween(38, 56))
+  const clipStartBottom = formatPercent(randomBetween(32, 48))
+  const clipMidTopA = formatPercent(randomBetween(0, 8))
+  const clipMidBottomA = formatPercent(randomBetween(26, 44))
   const clipMidTopB = formatPercent(randomBetween(6, 18))
-  const clipMidBottomB = formatPercent(clamp(randomBetween(-2, 14), 0, 50))
-  const clipMidTopC = formatPercent(randomBetween(0, 12))
-  const clipMidBottomC = formatPercent(randomBetween(32, 54))
+  const clipMidBottomB = formatPercent(clamp(randomBetween(-2, 16), 0, 50))
+  const clipMidTopC = formatPercent(randomBetween(0, 14))
+  const clipMidBottomC = formatPercent(randomBetween(30, 52))
 
   return {
     outDelay,
@@ -112,10 +121,14 @@ const createNavButtonGlitchProfile = ({ outDelay, outDuration, inDelay, inDurati
     outScaleB,
     outScaleC,
     outScaleD,
-    outTranslateA,
-    outTranslateB,
-    outTranslateC,
-    outTranslateD,
+    outTranslateXA,
+    outTranslateXB,
+    outTranslateXC,
+    outTranslateXD,
+    outTranslateYA,
+    outTranslateYB,
+    outTranslateYC,
+    outTranslateYD,
     outOpacityA,
     outOpacityB,
     outOpacityC,
@@ -123,10 +136,14 @@ const createNavButtonGlitchProfile = ({ outDelay, outDuration, inDelay, inDurati
     inScaleMidA,
     inScaleMidB,
     inScaleMidC,
-    inTranslateStart,
-    inTranslateA,
-    inTranslateB,
-    inTranslateC,
+    inTranslateStartX,
+    inTranslateAX,
+    inTranslateBX,
+    inTranslateCX,
+    inTranslateStartY,
+    inTranslateAY,
+    inTranslateBY,
+    inTranslateCY,
     clipStartTop,
     clipStartBottom,
     clipMidTopA,
@@ -190,10 +207,14 @@ const applyNavGlitchOut = (style, profile) => {
   style['--ghostnet-nav-glitch-out-scale-b'] = profile.outScaleB
   style['--ghostnet-nav-glitch-out-scale-c'] = profile.outScaleC
   style['--ghostnet-nav-glitch-out-scale-d'] = profile.outScaleD
-  style['--ghostnet-nav-glitch-out-translate-a'] = profile.outTranslateA
-  style['--ghostnet-nav-glitch-out-translate-b'] = profile.outTranslateB
-  style['--ghostnet-nav-glitch-out-translate-c'] = profile.outTranslateC
-  style['--ghostnet-nav-glitch-out-translate-d'] = profile.outTranslateD
+  style['--ghostnet-nav-glitch-out-translate-x-a'] = profile.outTranslateXA
+  style['--ghostnet-nav-glitch-out-translate-x-b'] = profile.outTranslateXB
+  style['--ghostnet-nav-glitch-out-translate-x-c'] = profile.outTranslateXC
+  style['--ghostnet-nav-glitch-out-translate-x-d'] = profile.outTranslateXD
+  style['--ghostnet-nav-glitch-out-translate-y-a'] = profile.outTranslateYA
+  style['--ghostnet-nav-glitch-out-translate-y-b'] = profile.outTranslateYB
+  style['--ghostnet-nav-glitch-out-translate-y-c'] = profile.outTranslateYC
+  style['--ghostnet-nav-glitch-out-translate-y-d'] = profile.outTranslateYD
   style['--ghostnet-nav-glitch-out-opacity-a'] = profile.outOpacityA
   style['--ghostnet-nav-glitch-out-opacity-b'] = profile.outOpacityB
   style['--ghostnet-nav-glitch-out-opacity-c'] = profile.outOpacityC
@@ -208,10 +229,14 @@ const applyNavGlitchIn = (style, profile) => {
   style['--ghostnet-nav-glitch-in-scale-mid-a'] = profile.inScaleMidA
   style['--ghostnet-nav-glitch-in-scale-mid-b'] = profile.inScaleMidB
   style['--ghostnet-nav-glitch-in-scale-mid-c'] = profile.inScaleMidC
-  style['--ghostnet-nav-glitch-in-translate-start'] = profile.inTranslateStart
-  style['--ghostnet-nav-glitch-in-translate-a'] = profile.inTranslateA
-  style['--ghostnet-nav-glitch-in-translate-b'] = profile.inTranslateB
-  style['--ghostnet-nav-glitch-in-translate-c'] = profile.inTranslateC
+  style['--ghostnet-nav-glitch-in-translate-start-x'] = profile.inTranslateStartX
+  style['--ghostnet-nav-glitch-in-translate-x-a'] = profile.inTranslateAX
+  style['--ghostnet-nav-glitch-in-translate-x-b'] = profile.inTranslateBX
+  style['--ghostnet-nav-glitch-in-translate-x-c'] = profile.inTranslateCX
+  style['--ghostnet-nav-glitch-in-translate-start-y'] = profile.inTranslateStartY
+  style['--ghostnet-nav-glitch-in-translate-y-a'] = profile.inTranslateAY
+  style['--ghostnet-nav-glitch-in-translate-y-b'] = profile.inTranslateBY
+  style['--ghostnet-nav-glitch-in-translate-y-c'] = profile.inTranslateCY
   style['--ghostnet-nav-glitch-in-clip-start-top'] = profile.clipStartTop
   style['--ghostnet-nav-glitch-in-clip-start-bottom'] = profile.clipStartBottom
   style['--ghostnet-nav-glitch-in-clip-mid-top-a'] = profile.clipMidTopA
@@ -385,7 +410,6 @@ export default function Header ({ connected, active }) {
       } else {
         setNavRevealState('complete')
       }
-      setGhostnetNavUnlocked(true)
       setNavUnlocked(true)
       setPirateStatus('success')
       registerPirateTimeout(() => {

--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -66,12 +66,12 @@ export default function Header ({ connected, active }) {
   const currentPath = `/${(router.pathname.split('/')[1] || '').toLowerCase()}`
   const isGhostnetRouteActive = currentPath === '/ghostnet'
   const [pirateModalVisible, setPirateModalVisible] = useState(false)
-  const [piratePassword, setPiratePassword] = useState('')
+  const [pirateCipher, setPirateCipher] = useState('')
   const [pirateAttempts, setPirateAttempts] = useState(0)
   const [pirateStatus, setPirateStatus] = useState(null)
   const [pirateGlitch, setPirateGlitch] = useState(false)
   const pirateTimeouts = useRef([])
-  const piratePasswordRef = useRef(null)
+  const pirateCipherRef = useRef(null)
   const initialNavUnlockStateRef = useRef(null)
   if (initialNavUnlockStateRef.current === null) {
     initialNavUnlockStateRef.current = isGhostnetNavUnlocked()
@@ -80,7 +80,7 @@ export default function Header ({ connected, active }) {
   const [navRevealState, setNavRevealState] = useState(initialNavUnlockStateRef.current ? 'complete' : 'locked')
   const [pendingNavReveal, setPendingNavReveal] = useState(false)
   const navRevealTimeouts = useRef([])
-  const SECRET_PASSWORD = 'ATLAS'
+  const SECRET_CODE = 'ATLAS'
 
   const clearTitleAnimationTimeouts = useCallback(() => {
     const clearTimeoutFn = typeof window !== 'undefined' ? window.clearTimeout : clearTimeout
@@ -164,7 +164,7 @@ export default function Header ({ connected, active }) {
   const closePirateModal = useCallback(() => {
     clearPirateTimeouts()
     setPirateModalVisible(false)
-    setPiratePassword('')
+    setPirateCipher('')
     setPirateAttempts(0)
     setPirateStatus(null)
     setPirateGlitch(false)
@@ -172,7 +172,7 @@ export default function Header ({ connected, active }) {
 
   const openPirateModal = useCallback(() => {
     clearPirateTimeouts()
-    setPiratePassword('')
+    setPirateCipher('')
     setPirateAttempts(0)
     setPirateStatus(null)
     setPirateGlitch(false)
@@ -183,8 +183,8 @@ export default function Header ({ connected, active }) {
     event.preventDefault()
     if (pirateStatus === 'success' || pirateStatus === 'locked' || pirateGlitch) return
 
-    const sanitizedPassword = piratePassword.trim().toUpperCase()
-    if (sanitizedPassword === SECRET_PASSWORD) {
+    const sanitizedCipher = pirateCipher.trim().toUpperCase()
+    if (sanitizedCipher === SECRET_CODE) {
       if (!navUnlocked && navRevealState === 'locked') {
         setPendingNavReveal(true)
       } else {
@@ -213,7 +213,7 @@ export default function Header ({ connected, active }) {
     }
 
     setPirateStatus('error')
-  }, [SECRET_PASSWORD, closePirateModal, navRevealState, navUnlocked, pirateAttempts, piratePassword, pirateGlitch, pirateStatus, registerPirateTimeout, setPendingNavReveal])
+  }, [SECRET_CODE, closePirateModal, navRevealState, navUnlocked, pirateAttempts, pirateCipher, pirateGlitch, pirateStatus, registerPirateTimeout, setPendingNavReveal])
 
   const runTitleGlitch = useCallback(() => {
     if (typeof window === 'undefined') return
@@ -505,7 +505,7 @@ export default function Header ({ connected, active }) {
     const setTimeoutFn = typeof window !== 'undefined' ? window.setTimeout : setTimeout
     const clearTimeoutFn = typeof window !== 'undefined' ? window.clearTimeout : clearTimeout
     const timeoutId = setTimeoutFn(() => {
-      piratePasswordRef.current?.focus()
+      pirateCipherRef.current?.focus()
     }, 120)
     pirateTimeouts.current.push(timeoutId)
     return () => {
@@ -652,11 +652,15 @@ export default function Header ({ connected, active }) {
 
           if (navRevealState === 'glitchIn') {
             buttonClasses.push('ghostnet-nav-button--glitch-phase', 'ghostnet-nav-button--glitch-in')
+            if (isGhostNet) {
+              buttonClasses.push('ghostnet-nav-button--unlock')
+            }
           }
 
           const buttonStyle = { fontSize: '1.5rem' }
           if (navRevealState === 'glitchIn') {
-            buttonStyle['--ghostnet-nav-glitch-delay'] = `${i * 90}ms`
+            const revealIndexDelay = isGhostNet ? 420 : i * 90
+            buttonStyle['--ghostnet-nav-glitch-delay'] = `${revealIndexDelay}ms`
           }
 
           return (
@@ -680,54 +684,61 @@ export default function Header ({ connected, active }) {
       <Settings visible={settingsVisible} toggleVisible={() => setSettingsVisible(!settingsVisible)} />
     </header>
     {pirateModalVisible && (
-      <div className='pirate-password-overlay' role='presentation'>
+      <div className='pirate-cipher-overlay' role='presentation'>
         <section
           className={[
-            'pirate-password-dialog',
-            pirateGlitch ? 'pirate-password-dialog--glitch ghostnet-assimilation-target ghostnet-assimilation-remove' : ''
+            'pirate-cipher-dialog',
+            pirateGlitch ? 'pirate-cipher-dialog--glitch ghostnet-assimilation-target ghostnet-assimilation-remove' : ''
           ].filter(Boolean).join(' ')}
           role='dialog'
           aria-modal='true'
-          aria-labelledby='pirate-password-title'
+          aria-labelledby='pirate-cipher-title'
         >
-          <div className='pirate-password-dialog__inner-frame' aria-hidden='true' />
-          <div className='pirate-password-dialog__surface-glow' aria-hidden='true' />
-          <div className='pirate-password-dialog__chrome' aria-hidden='true'>
-            <span className='pirate-password-dialog__chrome-light pirate-password-dialog__chrome-light--primary' />
-            <span className='pirate-password-dialog__chrome-light pirate-password-dialog__chrome-light--secondary' />
-            <span className='pirate-password-dialog__chrome-light pirate-password-dialog__chrome-light--tertiary' />
+          <div className='pirate-cipher-dialog__inner-frame' aria-hidden='true' />
+          <div className='pirate-cipher-dialog__surface-glow' aria-hidden='true' />
+          <div className='pirate-cipher-dialog__chrome' aria-hidden='true'>
+            <span className='pirate-cipher-dialog__chrome-light pirate-cipher-dialog__chrome-light--primary' />
+            <span className='pirate-cipher-dialog__chrome-light pirate-cipher-dialog__chrome-light--secondary' />
+            <span className='pirate-cipher-dialog__chrome-light pirate-cipher-dialog__chrome-light--tertiary' />
           </div>
-          <div className='pirate-password-dialog__body'>
+          <div className='pirate-cipher-dialog__body'>
             {pirateStatus === 'success' && (
-              <div className='pirate-password-success' aria-live='assertive'>
-                <span className='pirate-password-success__icon' aria-hidden='true'>✔</span>
-                <p className='pirate-password-success__text'>Signal aligned</p>
+              <div className='pirate-cipher-success' aria-live='assertive'>
+                <span className='pirate-cipher-success__icon' aria-hidden='true'>✔</span>
+                <p className='pirate-cipher-success__text'>Signal aligned</p>
               </div>
             )}
             {pirateStatus !== 'success' && (
-              <form onSubmit={handlePirateSubmit} className='pirate-password-form'>
-                <h2 id='pirate-password-title' className='pirate-password-title text-info text-uppercase'>Ghost Access Gate</h2>
-                <p className='pirate-password-subtitle text-muted'>Whisper the covenant phrase to still the static.</p>
-                <label className='pirate-password-label text-primary text-uppercase' htmlFor='pirate-password-input'>Passphrase</label>
+              <form onSubmit={handlePirateSubmit} className='pirate-cipher-form'>
+                <h2 id='pirate-cipher-title' className='pirate-cipher-title text-info text-uppercase'>Ghost Access Gate</h2>
+                <p className='pirate-cipher-subtitle text-muted'>Whisper the covenant phrase to still the static.</p>
+                <label className='pirate-cipher-label text-primary text-uppercase' htmlFor='pirate-cipher-input'>Cipher Code</label>
                 <input
-                  id='pirate-password-input'
-                  ref={piratePasswordRef}
-                  className={`pirate-password-input ${pirateStatus === 'error' ? 'pirate-password-input--error' : ''}`.trim()}
-                  type='password'
+                  id='pirate-cipher-input'
+                  ref={pirateCipherRef}
+                  className={`pirate-cipher-input ${pirateStatus === 'error' ? 'pirate-cipher-input--error' : ''}`.trim()}
+                  type='text'
                   autoComplete='off'
                   spellCheck='false'
-                  value={piratePassword}
+                  inputMode='text'
+                  maxLength={8}
+                  value={pirateCipher}
                   onChange={event => {
-                    setPiratePassword(event.target.value)
+                    const rawValue = event.target.value
+                    const nextValue = rawValue
+                      .toUpperCase()
+                      .replace(/[^A-Z0-9]/g, '')
+                      .slice(0, 8)
+                    setPirateCipher(nextValue)
                     if (pirateStatus) setPirateStatus(null)
                   }}
                   aria-invalid={pirateStatus === 'error' || pirateStatus === 'locked'}
-                  aria-describedby='pirate-password-feedback'
+                  aria-describedby='pirate-cipher-feedback'
                 />
-                <button type='submit' className='pirate-password-submit button--primary text-uppercase'>Enter</button>
-                <div id='pirate-password-feedback' className='pirate-password-feedback' aria-live='assertive'>
-                  {pirateStatus === 'error' && <span className='pirate-password-feedback--error'>Access rejected. Static persists.</span>}
-                  {pirateStatus === 'locked' && <span className='pirate-password-feedback--locked'>⟟ Cipher fracture detected. Coordinates lost in the void.</span>}
+                <button type='submit' className='pirate-cipher-submit button--primary text-uppercase'>Enter</button>
+                <div id='pirate-cipher-feedback' className='pirate-cipher-feedback' aria-live='assertive'>
+                  {pirateStatus === 'error' && <span className='pirate-cipher-feedback--error'>Access rejected. Static persists.</span>}
+                  {pirateStatus === 'locked' && <span className='pirate-cipher-feedback--locked'>⟟ Cipher fracture detected. Coordinates lost in the void.</span>}
                 </div>
               </form>
             )}

--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -647,11 +647,11 @@ export default function Header ({ connected, active }) {
           ]
 
           if (navRevealState === 'glitchOut' && !isGhostNet) {
-            buttonClasses.push('ghostnet-assimilation-target', 'ghostnet-assimilation-remove', 'ghostnet-nav-button--glitch-out')
+            buttonClasses.push('ghostnet-nav-button--glitch-phase', 'ghostnet-nav-button--glitch-out')
           }
 
           if (navRevealState === 'glitchIn') {
-            buttonClasses.push('ghostnet-assimilation-target', 'ghostnet-nav-button--glitch-in')
+            buttonClasses.push('ghostnet-nav-button--glitch-phase', 'ghostnet-nav-button--glitch-in')
           }
 
           const buttonStyle = { fontSize: '1.5rem' }

--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -442,6 +442,7 @@ export default function Header ({ connected, active }) {
   const accessibleTitle = (titleChars.join('').trimEnd()) || ORIGINAL_TITLE
   const assimilationComplete = titleAnimationState.current.completed
   const smallVisibleLimit = assimilationComplete ? TITLE_PREFIX_LENGTH + 1 : TITLE_PREFIX_LENGTH
+  const dateTimeLabel = `${dateTime.day} ${dateTime.month} ${dateTime.year} ${dateTime.time}`
 
   function handleNavigate (path) {
     if (path === '/ghostnet') {
@@ -489,54 +490,55 @@ export default function Header ({ connected, active }) {
           </span>
         </span>
       </h1>
-      <div style={{ position: 'absolute', top: '1rem', right: '.5rem' }}>
-        <p
-          className='text-primary text-center text-uppercase'
-          style={{ display: 'inline-block', padding: 0, margin: 0, lineHeight: '1rem', minWidth: '7.5rem' }}
-        >
-           <span style={{position: 'relative', top: '.3rem', fontSize: '2.4rem', paddingTop: '.25rem'}}>
-           {dateTime.time}
-          </span>
-          <br/>
-          <span style={{fontSize: '1.1rem', position: 'relative', top: '.4rem'}}>
+      <div className='header-utility-tray'>
+        <time className='header-utility-clock text-uppercase' aria-label={dateTimeLabel}>
+          <span className='header-utility-clock__time text-primary'>{dateTime.time}</span>
+          <span className='header-utility-clock__date text-muted'>
             {dateTime.day} {dateTime.month} {dateTime.year}
           </span>
-        </p>
+        </time>
 
-        <button
-          tabIndex='1'
-          onClick={() => { openPirateModal(); document.activeElement?.blur?.() }}
-          className='button--icon button--transparent pirate-access-button'
-          style={{ marginRight: '.5rem' }}
-          aria-haspopup='dialog'
-          aria-expanded={pirateModalVisible}
-        >
-          <i className='icon icarus-terminal-shield pirate-access-icon' aria-hidden='true' />
-          <span className='sr-only'>Open encrypted access challenge</span>
-        </button>
+        <div className='header-utility-controls'>
+          <button
+            tabIndex='1'
+            onClick={() => { openPirateModal(); document.activeElement?.blur?.() }}
+            className='button--icon button--transparent pirate-access-button header-utility-button'
+            aria-haspopup='dialog'
+            aria-expanded={pirateModalVisible}
+          >
+            <i className='icon icarus-terminal-shield pirate-access-icon' aria-hidden='true' />
+            <span className='sr-only'>Open encrypted access challenge</span>
+          </button>
 
-        <button disabled className='button--icon button--transparent' style={{ marginRight: '.5rem', opacity: active ? 1 : .25, transition: 'all .25s ease-out' }}>
-          <i className={signalClassName} style={{ position: 'relative', transition: 'all .25s ease', fontSize: '3rem', lineHeight: '1.8rem', top: '.5rem', right: '.25rem' }} />
-        </button>
+          <button disabled className='button--icon button--transparent header-utility-button header-utility-button--signal' style={{ opacity: active ? 1 : 0.25 }}>
+            <i className={signalClassName} />
+          </button>
 
-        {IS_WINDOWS_APP &&
-          <button tabIndex='1' onClick={pinWindow} className={`button--icon ${isPinned ? 'button--transparent' : ''}`} style={{ marginRight: '.5rem' }} disabled={isFullScreen}>
-            <i className='icon icarus-terminal-pin-window' style={{ fontSize: '2rem' }} />
-          </button>}
+          {IS_WINDOWS_APP &&
+            <button
+              tabIndex='1'
+              onClick={pinWindow}
+              className={`button--icon header-utility-button ${isPinned ? 'button--transparent' : ''}`.trim()}
+              disabled={isFullScreen}
+            >
+              <i className='icon icarus-terminal-pin-window' />
+            </button>}
 
-        <button tabIndex='1' onClick={toggleNotifications} className='button--icon' style={{ marginRight: '.5rem' }}>
-          <i className={`icon ${notificationsVisible ? 'icarus-terminal-notifications' : 'icarus-terminal-notifications-disabled text-muted'}`} style={{ fontSize: '2rem' }} />
-        </button>
+          <button tabIndex='1' onClick={toggleNotifications} className='button--icon header-utility-button'>
+            <i className={`icon ${notificationsVisible ? 'icarus-terminal-notifications' : 'icarus-terminal-notifications-disabled text-muted'}`} />
+          </button>
 
-        <button
-          tabIndex='1' className='button--icon' style={{ marginRight: '.5rem' }}
-          onClick={() => { setSettingsVisible(!settingsVisible); document.activeElement.blur() }}
-        >
-          <i className='icon icarus-terminal-settings' style={{ fontSize: '2rem' }} />
-        </button>
-        <button tabIndex='1' onClick={fullScreen} className='button--icon'>
-          <i className='icon icarus-terminal-fullscreen' style={{ fontSize: '2rem' }} />
-        </button>
+          <button
+            tabIndex='1'
+            className='button--icon header-utility-button'
+            onClick={() => { setSettingsVisible(!settingsVisible); document.activeElement.blur() }}
+          >
+            <i className='icon icarus-terminal-settings' />
+          </button>
+          <button tabIndex='1' onClick={fullScreen} className='button--icon header-utility-button'>
+            <i className='icon icarus-terminal-fullscreen' />
+          </button>
+        </div>
       </div>
       <hr />
       <div id='primaryNavigation' className='button-group'>
@@ -575,39 +577,46 @@ export default function Header ({ connected, active }) {
           aria-modal='true'
           aria-labelledby='pirate-password-title'
         >
-          {pirateStatus === 'success' && (
-            <div className='pirate-password-success' aria-live='assertive'>
-              <span className='pirate-password-success__icon' aria-hidden='true'>✔</span>
-              <p className='pirate-password-success__text'>Signal aligned</p>
-            </div>
-          )}
-          {pirateStatus !== 'success' && (
-            <form onSubmit={handlePirateSubmit}>
-              <h2 id='pirate-password-title' className='pirate-password-title text-info text-uppercase'>Ghost Access Gate</h2>
-              <p className='pirate-password-subtitle text-muted'>Whisper the covenant phrase to still the static.</p>
-              <label className='pirate-password-label text-primary text-uppercase' htmlFor='pirate-password-input'>Passphrase</label>
-              <input
-                id='pirate-password-input'
-                ref={piratePasswordRef}
-                className={`pirate-password-input ${pirateStatus === 'error' ? 'pirate-password-input--error' : ''}`.trim()}
-                type='password'
-                autoComplete='off'
-                spellCheck='false'
-                value={piratePassword}
-                onChange={event => {
-                  setPiratePassword(event.target.value)
-                  if (pirateStatus) setPirateStatus(null)
-                }}
-                aria-invalid={pirateStatus === 'error' || pirateStatus === 'locked'}
-                aria-describedby='pirate-password-feedback'
-              />
-              <button type='submit' className='pirate-password-submit button--primary text-uppercase'>Enter</button>
-              <div id='pirate-password-feedback' className='pirate-password-feedback' aria-live='assertive'>
-                {pirateStatus === 'error' && <span className='pirate-password-feedback--error'>Access rejected. Static persists.</span>}
-                {pirateStatus === 'locked' && <span className='pirate-password-feedback--locked'>⟟ Cipher fracture detected. Coordinates lost in the void.</span>}
+          <div className='pirate-password-dialog__chrome' aria-hidden='true'>
+            <span className='pirate-password-dialog__chrome-light pirate-password-dialog__chrome-light--primary' />
+            <span className='pirate-password-dialog__chrome-light pirate-password-dialog__chrome-light--secondary' />
+            <span className='pirate-password-dialog__chrome-light pirate-password-dialog__chrome-light--tertiary' />
+          </div>
+          <div className='pirate-password-dialog__body'>
+            {pirateStatus === 'success' && (
+              <div className='pirate-password-success' aria-live='assertive'>
+                <span className='pirate-password-success__icon' aria-hidden='true'>✔</span>
+                <p className='pirate-password-success__text'>Signal aligned</p>
               </div>
-            </form>
-          )}
+            )}
+            {pirateStatus !== 'success' && (
+              <form onSubmit={handlePirateSubmit}>
+                <h2 id='pirate-password-title' className='pirate-password-title text-info text-uppercase'>Ghost Access Gate</h2>
+                <p className='pirate-password-subtitle text-muted'>Whisper the covenant phrase to still the static.</p>
+                <label className='pirate-password-label text-primary text-uppercase' htmlFor='pirate-password-input'>Passphrase</label>
+                <input
+                  id='pirate-password-input'
+                  ref={piratePasswordRef}
+                  className={`pirate-password-input ${pirateStatus === 'error' ? 'pirate-password-input--error' : ''}`.trim()}
+                  type='password'
+                  autoComplete='off'
+                  spellCheck='false'
+                  value={piratePassword}
+                  onChange={event => {
+                    setPiratePassword(event.target.value)
+                    if (pirateStatus) setPirateStatus(null)
+                  }}
+                  aria-invalid={pirateStatus === 'error' || pirateStatus === 'locked'}
+                  aria-describedby='pirate-password-feedback'
+                />
+                <button type='submit' className='pirate-password-submit button--primary text-uppercase'>Enter</button>
+                <div id='pirate-password-feedback' className='pirate-password-feedback' aria-live='assertive'>
+                  {pirateStatus === 'error' && <span className='pirate-password-feedback--error'>Access rejected. Static persists.</span>}
+                  {pirateStatus === 'locked' && <span className='pirate-password-feedback--locked'>⟟ Cipher fracture detected. Coordinates lost in the void.</span>}
+                </div>
+              </form>
+            )}
+          </div>
         </section>
       </div>
     )}

--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -572,11 +572,16 @@ export default function Header ({ connected, active }) {
     {pirateModalVisible && (
       <div className='pirate-password-overlay' role='presentation'>
         <section
-          className={`pirate-password-dialog ${pirateGlitch ? 'pirate-password-dialog--glitch' : ''}`.trim()}
+          className={[
+            'pirate-password-dialog',
+            pirateGlitch ? 'pirate-password-dialog--glitch ghostnet-assimilation-target ghostnet-assimilation-remove' : ''
+          ].filter(Boolean).join(' ')}
           role='dialog'
           aria-modal='true'
           aria-labelledby='pirate-password-title'
         >
+          <div className='pirate-password-dialog__inner-frame' aria-hidden='true' />
+          <div className='pirate-password-dialog__surface-glow' aria-hidden='true' />
           <div className='pirate-password-dialog__chrome' aria-hidden='true'>
             <span className='pirate-password-dialog__chrome-light pirate-password-dialog__chrome-light--primary' />
             <span className='pirate-password-dialog__chrome-light pirate-password-dialog__chrome-light--secondary' />
@@ -590,7 +595,7 @@ export default function Header ({ connected, active }) {
               </div>
             )}
             {pirateStatus !== 'success' && (
-              <form onSubmit={handlePirateSubmit}>
+              <form onSubmit={handlePirateSubmit} className='pirate-password-form'>
                 <h2 id='pirate-password-title' className='pirate-password-title text-info text-uppercase'>Ghost Access Gate</h2>
                 <p className='pirate-password-subtitle text-muted'>Whisper the covenant phrase to still the static.</p>
                 <label className='pirate-password-label text-primary text-uppercase' htmlFor='pirate-password-input'>Passphrase</label>

--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -18,6 +18,8 @@ const TITLE_GLYPHS = ['Λ', 'Ξ', 'Ψ', 'Ø', 'Σ', '✦', '✧', '☍', '⌁', 
 const createEmptyGlitchStyles = () => Array.from({ length: ORIGINAL_TITLE.length }, () => null)
 import { initiateGhostnetExitTransition, isGhostnetExitTransitionActive } from 'lib/ghostnet-exit-transition'
 
+const GHOSTNET_NAV_PATH = '/ghostnet'
+
 const NAV_BUTTONS = [
   {
     name: 'Navigation',
@@ -37,7 +39,7 @@ const NAV_BUTTONS = [
   {
     name: 'GhostNet',
     abbr: 'GNet',
-    path: '/ghostnet'
+    path: GHOSTNET_NAV_PATH
   },
   {
     name: 'Log',
@@ -45,6 +47,180 @@ const NAV_BUTTONS = [
     path: '/log'
   }
 ]
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
+const randomBetween = (min, max) => min + Math.random() * (max - min)
+const formatPx = value => `${value.toFixed(1)}px`
+const formatPercent = value => `${value.toFixed(1)}%`
+
+const createNavButtonGlitchProfile = ({ outDelay, outDuration, inDelay, inDuration, emphasizeUnlock = false }) => {
+  const jitterLoop = Math.round(randomBetween(emphasizeUnlock ? 180 : 220, emphasizeUnlock ? 260 : 360))
+  const ghostLoop = Math.round(randomBetween(emphasizeUnlock ? 280 : 320, emphasizeUnlock ? 440 : 520))
+  const ghostOpacity = randomBetween(0.28, emphasizeUnlock ? 0.6 : 0.5).toFixed(2)
+  const shiftX = formatPx(randomBetween(-6, 6))
+  const shiftY = formatPx(randomBetween(-6, 5))
+  const tilt = `${randomBetween(-2.4, 2.4).toFixed(2)}deg`
+  const glowRadius = `${randomBetween(emphasizeUnlock ? 2.1 : 1.7, emphasizeUnlock ? 3.05 : 2.5).toFixed(2)}rem`
+  const glowOpacity = randomBetween(emphasizeUnlock ? 0.6 : 0.45, emphasizeUnlock ? 0.88 : 0.68).toFixed(2)
+  const saturation = randomBetween(emphasizeUnlock ? 1.22 : 1.12, emphasizeUnlock ? 1.46 : 1.36).toFixed(2)
+
+  const outScaleA = randomBetween(0.88, 0.96).toFixed(3)
+  const outScaleB = randomBetween(0.78, 0.9).toFixed(3)
+  const outScaleC = randomBetween(0.68, 0.82).toFixed(3)
+  const outScaleD = randomBetween(0.62, 0.76).toFixed(3)
+  const outTranslateA = formatPx(randomBetween(-12, -4))
+  const outTranslateB = formatPx(randomBetween(-10, -2))
+  const outTranslateC = formatPx(randomBetween(-15, -5))
+  const outTranslateD = formatPx(randomBetween(-18, -8))
+  const outOpacityA = randomBetween(0.25, 0.45).toFixed(2)
+  const outOpacityB = randomBetween(0.55, 0.88).toFixed(2)
+  const outOpacityC = randomBetween(0.18, 0.42).toFixed(2)
+
+  const inScaleStart = randomBetween(0.52, 0.68).toFixed(3)
+  const inScaleMidA = randomBetween(0.68, 0.86).toFixed(3)
+  const inScaleMidB = randomBetween(0.82, 0.98).toFixed(3)
+  const inScaleMidC = randomBetween(0.72, 0.94).toFixed(3)
+  const inTranslateStart = formatPx(randomBetween(9, 18))
+  const inTranslateA = formatPx(randomBetween(3, 11))
+  const inTranslateB = formatPx(randomBetween(-3, 6))
+  const inTranslateC = formatPx(randomBetween(-7, 2))
+
+  const clipStartTop = formatPercent(randomBetween(44, 58))
+  const clipStartBottom = formatPercent(randomBetween(34, 48))
+  const clipMidTopA = formatPercent(randomBetween(0, 6))
+  const clipMidBottomA = formatPercent(randomBetween(28, 44))
+  const clipMidTopB = formatPercent(randomBetween(6, 18))
+  const clipMidBottomB = formatPercent(clamp(randomBetween(-2, 14), 0, 50))
+  const clipMidTopC = formatPercent(randomBetween(0, 12))
+  const clipMidBottomC = formatPercent(randomBetween(32, 54))
+
+  return {
+    outDelay,
+    outDuration,
+    inDelay,
+    inDuration,
+    jitterLoop,
+    ghostLoop,
+    ghostOpacity,
+    shiftX,
+    shiftY,
+    tilt,
+    glowRadius,
+    glowOpacity,
+    saturation,
+    outScaleA,
+    outScaleB,
+    outScaleC,
+    outScaleD,
+    outTranslateA,
+    outTranslateB,
+    outTranslateC,
+    outTranslateD,
+    outOpacityA,
+    outOpacityB,
+    outOpacityC,
+    inScaleStart,
+    inScaleMidA,
+    inScaleMidB,
+    inScaleMidC,
+    inTranslateStart,
+    inTranslateA,
+    inTranslateB,
+    inTranslateC,
+    clipStartTop,
+    clipStartBottom,
+    clipMidTopA,
+    clipMidBottomA,
+    clipMidTopB,
+    clipMidBottomB,
+    clipMidTopC,
+    clipMidBottomC
+  }
+}
+
+const createNavGlitchProfiles = () => {
+  const profiles = {}
+  const nonGhostButtons = NAV_BUTTONS.filter(button => button.path !== GHOSTNET_NAV_PATH)
+
+  nonGhostButtons.forEach((button, index) => {
+    const baseDelay = 90 + index * 120
+    const outDelay = Math.round(randomBetween(baseDelay - 40, baseDelay + 160))
+    const outDuration = Math.round(randomBetween(420, 720))
+    const inDelay = outDelay + outDuration + Math.round(randomBetween(150, 280))
+    const inDuration = Math.round(randomBetween(760, 1180))
+    profiles[button.path] = createNavButtonGlitchProfile({ outDelay, outDuration, inDelay, inDuration })
+  })
+
+  const longestOut = nonGhostButtons.reduce((max, button) => {
+    const profile = profiles[button.path]
+    return Math.max(max, profile ? profile.outDelay + profile.outDuration : 0)
+  }, 0)
+
+  const ghostnetInDelay = longestOut + Math.round(randomBetween(240, 420))
+  const ghostnetInDuration = Math.round(randomBetween(880, 1280))
+
+  profiles[GHOSTNET_NAV_PATH] = createNavButtonGlitchProfile({
+    outDelay: 0,
+    outDuration: 0,
+    inDelay: ghostnetInDelay,
+    inDuration: ghostnetInDuration,
+    emphasizeUnlock: true
+  })
+
+  return profiles
+}
+
+const applyNavGlitchBase = (style, profile) => {
+  style['--ghostnet-assimilation-loop'] = `${profile.jitterLoop}ms`
+  style['--ghostnet-assimilation-ghost-loop'] = `${profile.ghostLoop}ms`
+  style['--ghostnet-assimilation-ghost-opacity'] = profile.ghostOpacity
+  style['--ghostnet-assimilation-shift-x'] = profile.shiftX
+  style['--ghostnet-assimilation-shift-y'] = profile.shiftY
+  style['--ghostnet-assimilation-tilt'] = profile.tilt
+  style['--ghostnet-assimilation-glow-radius'] = profile.glowRadius
+  style['--ghostnet-assimilation-glow-opacity'] = profile.glowOpacity
+  style['--ghostnet-assimilation-saturation'] = profile.saturation
+}
+
+const applyNavGlitchOut = (style, profile) => {
+  applyNavGlitchBase(style, profile)
+  style['--ghostnet-nav-glitch-out-delay'] = `${profile.outDelay}ms`
+  style['--ghostnet-nav-glitch-out-duration'] = `${profile.outDuration}ms`
+  style['--ghostnet-nav-glitch-out-scale-a'] = profile.outScaleA
+  style['--ghostnet-nav-glitch-out-scale-b'] = profile.outScaleB
+  style['--ghostnet-nav-glitch-out-scale-c'] = profile.outScaleC
+  style['--ghostnet-nav-glitch-out-scale-d'] = profile.outScaleD
+  style['--ghostnet-nav-glitch-out-translate-a'] = profile.outTranslateA
+  style['--ghostnet-nav-glitch-out-translate-b'] = profile.outTranslateB
+  style['--ghostnet-nav-glitch-out-translate-c'] = profile.outTranslateC
+  style['--ghostnet-nav-glitch-out-translate-d'] = profile.outTranslateD
+  style['--ghostnet-nav-glitch-out-opacity-a'] = profile.outOpacityA
+  style['--ghostnet-nav-glitch-out-opacity-b'] = profile.outOpacityB
+  style['--ghostnet-nav-glitch-out-opacity-c'] = profile.outOpacityC
+  style['--ghostnet-nav-glitch-out-opacity-d'] = '0'
+}
+
+const applyNavGlitchIn = (style, profile) => {
+  applyNavGlitchBase(style, profile)
+  style['--ghostnet-nav-glitch-in-delay'] = `${profile.inDelay}ms`
+  style['--ghostnet-nav-glitch-in-duration'] = `${profile.inDuration}ms`
+  style['--ghostnet-nav-glitch-in-scale-start'] = profile.inScaleStart
+  style['--ghostnet-nav-glitch-in-scale-mid-a'] = profile.inScaleMidA
+  style['--ghostnet-nav-glitch-in-scale-mid-b'] = profile.inScaleMidB
+  style['--ghostnet-nav-glitch-in-scale-mid-c'] = profile.inScaleMidC
+  style['--ghostnet-nav-glitch-in-translate-start'] = profile.inTranslateStart
+  style['--ghostnet-nav-glitch-in-translate-a'] = profile.inTranslateA
+  style['--ghostnet-nav-glitch-in-translate-b'] = profile.inTranslateB
+  style['--ghostnet-nav-glitch-in-translate-c'] = profile.inTranslateC
+  style['--ghostnet-nav-glitch-in-clip-start-top'] = profile.clipStartTop
+  style['--ghostnet-nav-glitch-in-clip-start-bottom'] = profile.clipStartBottom
+  style['--ghostnet-nav-glitch-in-clip-mid-top-a'] = profile.clipMidTopA
+  style['--ghostnet-nav-glitch-in-clip-mid-bottom-a'] = profile.clipMidBottomA
+  style['--ghostnet-nav-glitch-in-clip-mid-top-b'] = profile.clipMidTopB
+  style['--ghostnet-nav-glitch-in-clip-mid-bottom-b'] = profile.clipMidBottomB
+  style['--ghostnet-nav-glitch-in-clip-mid-top-c'] = profile.clipMidTopC
+  style['--ghostnet-nav-glitch-in-clip-mid-bottom-c'] = profile.clipMidBottomC
+}
 
 let IS_WINDOWS_APP = false
 
@@ -64,7 +240,7 @@ export default function Header ({ connected, active }) {
   const titleGlitchRevertTimeouts = useRef([])
   const activeTitleGlitchIndices = useRef(new Set())
   const currentPath = `/${(router.pathname.split('/')[1] || '').toLowerCase()}`
-  const isGhostnetRouteActive = currentPath === '/ghostnet'
+  const isGhostnetRouteActive = currentPath === GHOSTNET_NAV_PATH
   const [pirateModalVisible, setPirateModalVisible] = useState(false)
   const [pirateCipher, setPirateCipher] = useState('')
   const [pirateAttempts, setPirateAttempts] = useState(0)
@@ -78,6 +254,7 @@ export default function Header ({ connected, active }) {
   }
   const [navUnlocked, setNavUnlocked] = useState(initialNavUnlockStateRef.current)
   const [navRevealState, setNavRevealState] = useState(initialNavUnlockStateRef.current ? 'complete' : 'locked')
+  const [navGlitchProfiles, setNavGlitchProfiles] = useState(() => createNavGlitchProfiles())
   const [pendingNavReveal, setPendingNavReveal] = useState(false)
   const navRevealTimeouts = useRef([])
   const SECRET_CODE = 'ATLAS'
@@ -150,15 +327,33 @@ export default function Header ({ connected, active }) {
 
     if (!shouldStart) return
 
+    const profiles = createNavGlitchProfiles()
+    setNavGlitchProfiles(profiles)
+
     clearNavRevealTimeouts()
+
+    const nonGhostProfiles = NAV_BUTTONS
+      .filter(button => button.path !== GHOSTNET_NAV_PATH)
+      .map(button => profiles[button.path])
+      .filter(Boolean)
+
+    const allProfiles = NAV_BUTTONS
+      .map(button => profiles[button.path])
+      .filter(Boolean)
+
+    const longestOut = nonGhostProfiles.reduce((max, profile) => Math.max(max, profile.outDelay + profile.outDuration), 0)
+    const glitchInStart = longestOut + 180
 
     registerNavRevealTimeout(() => {
       setNavRevealState(prev => (prev === 'glitchOut' ? 'glitchIn' : prev))
-    }, 900)
+    }, glitchInStart)
+
+    const longestIn = allProfiles.reduce((max, profile) => Math.max(max, profile.inDelay + profile.inDuration), 0)
+    const completionDelay = longestIn + 320
 
     registerNavRevealTimeout(() => {
       setNavRevealState('complete')
-    }, 2400)
+    }, completionDelay)
   }, [clearNavRevealTimeouts, registerNavRevealTimeout])
 
   const closePirateModal = useCallback(() => {
@@ -529,19 +724,19 @@ export default function Header ({ connected, active }) {
   const navUnlockAnimating = navRevealState === 'glitchOut' || navRevealState === 'glitchIn'
   const ghostnetButtonVisible = navRevealState === 'glitchIn' || navRevealState === 'complete'
   const navigationButtons = NAV_BUTTONS.filter(button => {
-    if (button.path === '/ghostnet') {
+    if (button.path === GHOSTNET_NAV_PATH) {
       return ghostnetButtonVisible
     }
     return true
   })
 
   function handleNavigate (path) {
-    if (path === '/ghostnet') {
+    if (path === GHOSTNET_NAV_PATH) {
       if (isGhostnetAssimilationActive()) return
       initiateGhostnetAssimilation(() => router.push(path))
       return
     }
-    if (currentPath === '/ghostnet') {
+    if (currentPath === GHOSTNET_NAV_PATH) {
       if (isGhostnetExitTransitionActive()) return
       initiateGhostnetExitTransition(() => router.push(path))
       return
@@ -639,12 +834,14 @@ export default function Header ({ connected, active }) {
       >
         {navigationButtons.map((button, i) => {
           const isActive = button.path === currentPath
-          const isGhostNet = button.path === '/ghostnet'
+          const isGhostNet = button.path === GHOSTNET_NAV_PATH
           const exitActive = isGhostnetExitTransitionActive()
           const buttonClasses = [
             isActive ? 'button--active' : '',
             isGhostNet ? 'ghostnet-nav-button' : ''
           ]
+
+          const profile = navGlitchProfiles[button.path]
 
           if (navRevealState === 'glitchOut' && !isGhostNet) {
             buttonClasses.push('ghostnet-nav-button--glitch-phase', 'ghostnet-nav-button--glitch-out')
@@ -658,9 +855,11 @@ export default function Header ({ connected, active }) {
           }
 
           const buttonStyle = { fontSize: '1.5rem' }
-          if (navRevealState === 'glitchIn') {
-            const revealIndexDelay = isGhostNet ? 420 : i * 90
-            buttonStyle['--ghostnet-nav-glitch-delay'] = `${revealIndexDelay}ms`
+
+          if (navRevealState === 'glitchOut' && profile && !isGhostNet) {
+            applyNavGlitchOut(buttonStyle, profile)
+          } else if (navRevealState === 'glitchIn' && profile) {
+            applyNavGlitchIn(buttonStyle, profile)
           }
 
           return (

--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -48,205 +48,100 @@ const NAV_BUTTONS = [
   }
 ]
 
-const NAV_LOCKED_BUTTONS = NAV_BUTTONS.filter(button => button.path !== GHOSTNET_NAV_PATH)
-
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
 const randomBetween = (min, max) => min + Math.random() * (max - min)
 const formatPx = value => `${value.toFixed(1)}px`
-const formatPercent = value => `${value.toFixed(1)}%`
+const formatDeg = value => `${value.toFixed(1)}deg`
 
-const createNavButtonGlitchProfile = ({ outDelay, outDuration, inDelay, inDuration, emphasizeUnlock = false }) => {
-  const jitterLoop = Math.round(randomBetween(emphasizeUnlock ? 180 : 220, emphasizeUnlock ? 260 : 360))
-  const ghostLoop = Math.round(randomBetween(emphasizeUnlock ? 280 : 320, emphasizeUnlock ? 440 : 520))
-  const ghostOpacity = randomBetween(0.28, emphasizeUnlock ? 0.6 : 0.5).toFixed(2)
-  const shiftX = formatPx(randomBetween(-8, 8))
-  const shiftY = formatPx(randomBetween(-2.5, 2.5))
-  const tilt = `${randomBetween(-2.1, 2.1).toFixed(2)}deg`
-  const glowRadius = `${randomBetween(emphasizeUnlock ? 2.1 : 1.7, emphasizeUnlock ? 3.05 : 2.5).toFixed(2)}rem`
-  const glowOpacity = randomBetween(emphasizeUnlock ? 0.6 : 0.45, emphasizeUnlock ? 0.88 : 0.68).toFixed(2)
-  const saturation = randomBetween(emphasizeUnlock ? 1.22 : 1.12, emphasizeUnlock ? 1.46 : 1.36).toFixed(2)
+const createNavMotionProfile = ({ index, emphasizeGhost = false }) => {
+  const baseDelay = 90 + index * 120
+  const delay = Math.round(randomBetween(baseDelay - 50, baseDelay + 160))
+  const duration = Math.round(randomBetween(1100, 1600))
 
   const horizontalBias = Math.random() > 0.5 ? 1 : -1
-  const outScaleA = randomBetween(0.9, 0.97).toFixed(3)
-  const outScaleB = randomBetween(0.82, 0.92).toFixed(3)
-  const outScaleC = randomBetween(0.72, 0.86).toFixed(3)
-  const outScaleD = randomBetween(0.64, 0.8).toFixed(3)
-  const outTranslateXA = formatPx(randomBetween(6, 18) * horizontalBias)
-  const outTranslateXB = formatPx(randomBetween(10, 22) * horizontalBias)
-  const outTranslateXC = formatPx(randomBetween(18, 32) * horizontalBias)
-  const outTranslateXD = formatPx(randomBetween(26, 38) * horizontalBias)
-  const outTranslateYA = formatPx(randomBetween(-2.5, 2.5))
-  const outTranslateYB = formatPx(randomBetween(-2, 2))
-  const outTranslateYC = formatPx(randomBetween(-1.5, 1.5))
-  const outTranslateYD = formatPx(randomBetween(-1, 1))
-  const outOpacityA = randomBetween(0.25, 0.45).toFixed(2)
-  const outOpacityB = randomBetween(0.55, 0.88).toFixed(2)
-  const outOpacityC = randomBetween(0.18, 0.42).toFixed(2)
+  const amplitudeX = emphasizeGhost ? randomBetween(16, 26) : randomBetween(8, 18)
+  const amplitudeY = randomBetween(1.5, 4.2)
 
-  const inScaleStart = randomBetween(0.6, 0.74).toFixed(3)
-  const inScaleMidA = randomBetween(0.75, 0.9).toFixed(3)
-  const inScaleMidB = randomBetween(0.88, 1.01).toFixed(3)
-  const inScaleMidC = randomBetween(0.8, 0.96).toFixed(3)
-  const inTranslateStartX = formatPx(randomBetween(-26, 26))
-  const inTranslateAX = formatPx(randomBetween(-18, 18))
-  const inTranslateBX = formatPx(randomBetween(-9, 12))
-  const inTranslateCX = formatPx(randomBetween(-6, 8))
-  const inTranslateStartY = formatPx(randomBetween(-2.2, 2.2))
-  const inTranslateAY = formatPx(randomBetween(-1.8, 1.8))
-  const inTranslateBY = formatPx(randomBetween(-1.2, 1.2))
-  const inTranslateCY = formatPx(randomBetween(-0.8, 0.8))
+  const scaleXMin = emphasizeGhost ? randomBetween(0.32, 0.55) : randomBetween(0.74, 0.88)
+  const scaleXMid = emphasizeGhost ? randomBetween(0.62, 0.84) : randomBetween(0.82, 0.94)
+  const scaleXMax = emphasizeGhost ? randomBetween(0.94, 1.08) : randomBetween(0.92, 1.04)
+  const scaleYMin = emphasizeGhost ? randomBetween(0.74, 0.9) : randomBetween(0.86, 0.98)
+  const scaleYMid = emphasizeGhost ? randomBetween(0.86, 1.02) : randomBetween(0.92, 1.04)
+  const scaleYMax = emphasizeGhost ? randomBetween(0.96, 1.08) : randomBetween(0.96, 1.05)
 
-  const clipStartTop = formatPercent(randomBetween(38, 56))
-  const clipStartBottom = formatPercent(randomBetween(32, 48))
-  const clipMidTopA = formatPercent(randomBetween(0, 8))
-  const clipMidBottomA = formatPercent(randomBetween(26, 44))
-  const clipMidTopB = formatPercent(randomBetween(6, 18))
-  const clipMidBottomB = formatPercent(clamp(randomBetween(-2, 16), 0, 50))
-  const clipMidTopC = formatPercent(randomBetween(0, 14))
-  const clipMidBottomC = formatPercent(randomBetween(30, 52))
+  const xA = formatPx(amplitudeX * horizontalBias)
+  const xB = formatPx(randomBetween(amplitudeX * 0.45, amplitudeX * 0.9) * -horizontalBias)
+  const xC = formatPx(randomBetween(amplitudeX * 0.25, amplitudeX * 0.6) * horizontalBias)
+
+  const yA = formatPx(randomBetween(-amplitudeY, amplitudeY))
+  const yB = formatPx(randomBetween(-amplitudeY * 0.6, amplitudeY * 0.6))
+  const yC = formatPx(randomBetween(-amplitudeY * 0.4, amplitudeY * 0.4))
+
+  const hue = formatDeg(randomBetween(-14, 18))
+  const saturation = randomBetween(1.08, emphasizeGhost ? 1.42 : 1.28).toFixed(2)
+  const brightness = randomBetween(0.88, 1.08).toFixed(2)
+  const flashA = randomBetween(0.28, 0.6).toFixed(2)
+  const flashB = randomBetween(0.18, 0.46).toFixed(2)
+  const flashC = randomBetween(0.12, 0.32).toFixed(2)
 
   return {
-    outDelay,
-    outDuration,
-    inDelay,
-    inDuration,
-    jitterLoop,
-    ghostLoop,
-    ghostOpacity,
-    shiftX,
-    shiftY,
-    tilt,
-    glowRadius,
-    glowOpacity,
+    delay,
+    duration,
+    xA,
+    xB,
+    xC,
+    yA,
+    yB,
+    yC,
+    scaleXStart: emphasizeGhost ? clamp(scaleXMin, 0.18, 0.68) : clamp(scaleXMin, 0.65, 0.92),
+    scaleXMid,
+    scaleXMax,
+    scaleYStart: scaleYMin,
+    scaleYMid,
+    scaleYMax,
+    hue,
     saturation,
-    outScaleA,
-    outScaleB,
-    outScaleC,
-    outScaleD,
-    outTranslateXA,
-    outTranslateXB,
-    outTranslateXC,
-    outTranslateXD,
-    outTranslateYA,
-    outTranslateYB,
-    outTranslateYC,
-    outTranslateYD,
-    outOpacityA,
-    outOpacityB,
-    outOpacityC,
-    inScaleStart,
-    inScaleMidA,
-    inScaleMidB,
-    inScaleMidC,
-    inTranslateStartX,
-    inTranslateAX,
-    inTranslateBX,
-    inTranslateCX,
-    inTranslateStartY,
-    inTranslateAY,
-    inTranslateBY,
-    inTranslateCY,
-    clipStartTop,
-    clipStartBottom,
-    clipMidTopA,
-    clipMidBottomA,
-    clipMidTopB,
-    clipMidBottomB,
-    clipMidTopC,
-    clipMidBottomC
+    brightness,
+    flashA,
+    flashB,
+    flashC,
+    emphasizeGhost
   }
 }
 
-const createNavGlitchProfiles = () => {
+const createNavMotionProfiles = () => {
   const profiles = {}
-  const nonGhostButtons = NAV_LOCKED_BUTTONS
 
-  nonGhostButtons.forEach((button, index) => {
-    const baseDelay = 90 + index * 120
-    const outDelay = Math.round(randomBetween(baseDelay - 40, baseDelay + 160))
-    const outDuration = Math.round(randomBetween(420, 720))
-    const inDelay = outDelay + outDuration + Math.round(randomBetween(150, 280))
-    const inDuration = Math.round(randomBetween(760, 1180))
-    profiles[button.path] = createNavButtonGlitchProfile({ outDelay, outDuration, inDelay, inDuration })
-  })
-
-  const longestOut = nonGhostButtons.reduce((max, button) => {
-    const profile = profiles[button.path]
-    return Math.max(max, profile ? profile.outDelay + profile.outDuration : 0)
-  }, 0)
-
-  const ghostnetInDelay = longestOut + Math.round(randomBetween(240, 420))
-  const ghostnetInDuration = Math.round(randomBetween(880, 1280))
-
-  profiles[GHOSTNET_NAV_PATH] = createNavButtonGlitchProfile({
-    outDelay: 0,
-    outDuration: 0,
-    inDelay: ghostnetInDelay,
-    inDuration: ghostnetInDuration,
-    emphasizeUnlock: true
+  NAV_BUTTONS.forEach((button, index) => {
+    const emphasizeGhost = button.path === GHOSTNET_NAV_PATH
+    profiles[button.path] = createNavMotionProfile({ index, emphasizeGhost })
   })
 
   return profiles
 }
 
-const applyNavGlitchBase = (style, profile) => {
-  style['--ghostnet-assimilation-loop'] = `${profile.jitterLoop}ms`
-  style['--ghostnet-assimilation-ghost-loop'] = `${profile.ghostLoop}ms`
-  style['--ghostnet-assimilation-ghost-opacity'] = profile.ghostOpacity
-  style['--ghostnet-assimilation-shift-x'] = profile.shiftX
-  style['--ghostnet-assimilation-shift-y'] = profile.shiftY
-  style['--ghostnet-assimilation-tilt'] = profile.tilt
-  style['--ghostnet-assimilation-glow-radius'] = profile.glowRadius
-  style['--ghostnet-assimilation-glow-opacity'] = profile.glowOpacity
-  style['--ghostnet-assimilation-saturation'] = profile.saturation
-}
-
-const applyNavGlitchOut = (style, profile) => {
-  applyNavGlitchBase(style, profile)
-  style['--ghostnet-nav-glitch-out-delay'] = `${profile.outDelay}ms`
-  style['--ghostnet-nav-glitch-out-duration'] = `${profile.outDuration}ms`
-  style['--ghostnet-nav-glitch-out-scale-a'] = profile.outScaleA
-  style['--ghostnet-nav-glitch-out-scale-b'] = profile.outScaleB
-  style['--ghostnet-nav-glitch-out-scale-c'] = profile.outScaleC
-  style['--ghostnet-nav-glitch-out-scale-d'] = profile.outScaleD
-  style['--ghostnet-nav-glitch-out-translate-x-a'] = profile.outTranslateXA
-  style['--ghostnet-nav-glitch-out-translate-x-b'] = profile.outTranslateXB
-  style['--ghostnet-nav-glitch-out-translate-x-c'] = profile.outTranslateXC
-  style['--ghostnet-nav-glitch-out-translate-x-d'] = profile.outTranslateXD
-  style['--ghostnet-nav-glitch-out-translate-y-a'] = profile.outTranslateYA
-  style['--ghostnet-nav-glitch-out-translate-y-b'] = profile.outTranslateYB
-  style['--ghostnet-nav-glitch-out-translate-y-c'] = profile.outTranslateYC
-  style['--ghostnet-nav-glitch-out-translate-y-d'] = profile.outTranslateYD
-  style['--ghostnet-nav-glitch-out-opacity-a'] = profile.outOpacityA
-  style['--ghostnet-nav-glitch-out-opacity-b'] = profile.outOpacityB
-  style['--ghostnet-nav-glitch-out-opacity-c'] = profile.outOpacityC
-  style['--ghostnet-nav-glitch-out-opacity-d'] = '0'
-}
-
-const applyNavGlitchIn = (style, profile) => {
-  applyNavGlitchBase(style, profile)
-  style['--ghostnet-nav-glitch-in-delay'] = `${profile.inDelay}ms`
-  style['--ghostnet-nav-glitch-in-duration'] = `${profile.inDuration}ms`
-  style['--ghostnet-nav-glitch-in-scale-start'] = profile.inScaleStart
-  style['--ghostnet-nav-glitch-in-scale-mid-a'] = profile.inScaleMidA
-  style['--ghostnet-nav-glitch-in-scale-mid-b'] = profile.inScaleMidB
-  style['--ghostnet-nav-glitch-in-scale-mid-c'] = profile.inScaleMidC
-  style['--ghostnet-nav-glitch-in-translate-start-x'] = profile.inTranslateStartX
-  style['--ghostnet-nav-glitch-in-translate-x-a'] = profile.inTranslateAX
-  style['--ghostnet-nav-glitch-in-translate-x-b'] = profile.inTranslateBX
-  style['--ghostnet-nav-glitch-in-translate-x-c'] = profile.inTranslateCX
-  style['--ghostnet-nav-glitch-in-translate-start-y'] = profile.inTranslateStartY
-  style['--ghostnet-nav-glitch-in-translate-y-a'] = profile.inTranslateAY
-  style['--ghostnet-nav-glitch-in-translate-y-b'] = profile.inTranslateBY
-  style['--ghostnet-nav-glitch-in-translate-y-c'] = profile.inTranslateCY
-  style['--ghostnet-nav-glitch-in-clip-start-top'] = profile.clipStartTop
-  style['--ghostnet-nav-glitch-in-clip-start-bottom'] = profile.clipStartBottom
-  style['--ghostnet-nav-glitch-in-clip-mid-top-a'] = profile.clipMidTopA
-  style['--ghostnet-nav-glitch-in-clip-mid-bottom-a'] = profile.clipMidBottomA
-  style['--ghostnet-nav-glitch-in-clip-mid-top-b'] = profile.clipMidTopB
-  style['--ghostnet-nav-glitch-in-clip-mid-bottom-b'] = profile.clipMidBottomB
-  style['--ghostnet-nav-glitch-in-clip-mid-top-c'] = profile.clipMidTopC
-  style['--ghostnet-nav-glitch-in-clip-mid-bottom-c'] = profile.clipMidBottomC
+const applyNavMotionProfile = (style, profile) => {
+  if (!profile) return
+  style['--ghostnet-nav-motion-delay'] = `${profile.delay}ms`
+  style['--ghostnet-nav-motion-duration'] = `${profile.duration}ms`
+  style['--ghostnet-nav-motion-x-a'] = profile.xA
+  style['--ghostnet-nav-motion-x-b'] = profile.xB
+  style['--ghostnet-nav-motion-x-c'] = profile.xC
+  style['--ghostnet-nav-motion-y-a'] = profile.yA
+  style['--ghostnet-nav-motion-y-b'] = profile.yB
+  style['--ghostnet-nav-motion-y-c'] = profile.yC
+  style['--ghostnet-nav-motion-scale-x-start'] = profile.scaleXStart.toFixed(3)
+  style['--ghostnet-nav-motion-scale-x-mid'] = profile.scaleXMid.toFixed(3)
+  style['--ghostnet-nav-motion-scale-x-max'] = profile.scaleXMax.toFixed(3)
+  style['--ghostnet-nav-motion-scale-y-start'] = profile.scaleYStart.toFixed(3)
+  style['--ghostnet-nav-motion-scale-y-mid'] = profile.scaleYMid.toFixed(3)
+  style['--ghostnet-nav-motion-scale-y-max'] = profile.scaleYMax.toFixed(3)
+  style['--ghostnet-nav-motion-hue'] = profile.hue
+  style['--ghostnet-nav-motion-saturation'] = profile.saturation
+  style['--ghostnet-nav-motion-brightness'] = profile.brightness
+  style['--ghostnet-nav-motion-flash-a'] = profile.flashA
+  style['--ghostnet-nav-motion-flash-b'] = profile.flashB
+  style['--ghostnet-nav-motion-flash-c'] = profile.flashC
 }
 
 let IS_WINDOWS_APP = false
@@ -281,11 +176,9 @@ export default function Header ({ connected, active }) {
   }
   const [navUnlocked, setNavUnlocked] = useState(initialNavUnlockStateRef.current)
   const [navRevealState, setNavRevealState] = useState(initialNavUnlockStateRef.current ? 'complete' : 'locked')
-  const [navGlitchProfiles, setNavGlitchProfiles] = useState(() => createNavGlitchProfiles())
+  const [navMotionProfiles, setNavMotionProfiles] = useState(() => createNavMotionProfiles())
   const [pendingNavReveal, setPendingNavReveal] = useState(false)
   const navRevealTimeouts = useRef([])
-  const navGlitchInCompletedRef = useRef(new Set())
-  const navGlitchInTargetCountRef = useRef(NAV_BUTTONS.length)
   const SECRET_CODE = 'ATLAS'
 
   const clearTitleAnimationTimeouts = useCallback(() => {
@@ -349,41 +242,27 @@ export default function Header ({ connected, active }) {
     setNavRevealState(prev => {
       if (prev === 'locked') {
         shouldStart = true
-        return 'glitchOut'
+        return 'glitching'
       }
       return prev
     })
 
     if (!shouldStart) return
 
-    const profiles = createNavGlitchProfiles()
-    setNavGlitchProfiles(profiles)
+    const profiles = createNavMotionProfiles()
+    setNavMotionProfiles(profiles)
 
     clearNavRevealTimeouts()
 
-    const nonGhostProfiles = NAV_LOCKED_BUTTONS
-      .map(button => profiles[button.path])
-      .filter(Boolean)
-
-    const allProfiles = NAV_BUTTONS
-      .map(button => profiles[button.path])
-      .filter(Boolean)
-
-    const longestOut = nonGhostProfiles.reduce((max, profile) => Math.max(max, profile.outDelay + profile.outDuration), 0)
-    const glitchInStart = longestOut + 180
+    const longestDuration = NAV_BUTTONS.reduce((max, button) => {
+      const profile = profiles[button.path]
+      if (!profile) return max
+      return Math.max(max, profile.delay + profile.duration)
+    }, 0)
 
     registerNavRevealTimeout(() => {
-      setNavRevealState(prev => (prev === 'glitchOut' ? 'glitchOverlap' : prev))
-    }, glitchInStart)
-
-    const longestIn = allProfiles.reduce((max, profile) => Math.max(max, profile.inDelay + profile.inDuration), 0)
-    const completionDelay = longestIn + 320
-
-    registerNavRevealTimeout(() => {
-      if (navGlitchInCompletedRef.current.size >= navGlitchInTargetCountRef.current) {
-        setNavRevealState(prev => (prev === 'glitchOverlap' ? 'complete' : prev))
-      }
-    }, completionDelay)
+      setNavRevealState('complete')
+    }, longestDuration + 420)
   }, [clearNavRevealTimeouts, registerNavRevealTimeout])
 
   const closePirateModal = useCallback(() => {
@@ -725,23 +604,6 @@ export default function Header ({ connected, active }) {
   }, [navRevealState, pendingNavReveal, pirateModalVisible, setPendingNavReveal, startNavUnlockSequence])
 
   useEffect(() => {
-    if (navRevealState === 'glitchOverlap') {
-      navGlitchInCompletedRef.current = new Set()
-      navGlitchInTargetCountRef.current = NAV_BUTTONS.length
-    }
-  }, [navRevealState])
-
-  useEffect(() => {
-    if (navRevealState !== 'glitchOverlap') return undefined
-
-    const cancel = registerNavRevealTimeout(() => {
-      setNavRevealState(prev => (prev === 'glitchOverlap' ? 'complete' : prev))
-    }, 4800)
-
-    return cancel
-  }, [navRevealState, registerNavRevealTimeout])
-
-  useEffect(() => {
     if (!pirateModalVisible || pirateGlitch) return undefined
     const setTimeoutFn = typeof window !== 'undefined' ? window.setTimeout : setTimeout
     const clearTimeoutFn = typeof window !== 'undefined' ? window.clearTimeout : clearTimeout
@@ -767,24 +629,9 @@ export default function Header ({ connected, active }) {
   const accessibleTitle = (titleChars.join('').trimEnd()) || ORIGINAL_TITLE
   const assimilationComplete = titleAnimationState.current.completed
   const smallVisibleLimit = assimilationComplete ? TITLE_PREFIX_LENGTH + 1 : TITLE_PREFIX_LENGTH
-  const navUnlockAnimating = navRevealState === 'glitchOut' || navRevealState === 'glitchOverlap'
+  const navUnlockAnimating = navRevealState === 'glitching'
   const disableNavButtons = navUnlockAnimating
   const navTabIndex = disableNavButtons ? -1 : 1
-  const navPreVisible = navRevealState !== 'complete'
-  const navPreOverlay = navRevealState === 'glitchOverlap'
-  const navPostVisible = navRevealState === 'complete' || navRevealState === 'glitchOverlap'
-  const navPostGlitching = navRevealState === 'glitchOverlap'
-
-  const handleNavGlitchAnimationEnd = useCallback((buttonPath, event) => {
-    if (navRevealState !== 'glitchOverlap') return
-    if (!event?.animationName || event.animationName !== 'ghostnet-nav-button-glitch-in') return
-
-    navGlitchInCompletedRef.current.add(buttonPath)
-
-    if (navGlitchInCompletedRef.current.size >= navGlitchInTargetCountRef.current) {
-      setNavRevealState(prev => (prev === 'glitchOverlap' ? 'complete' : prev))
-    }
-  }, [navRevealState])
 
   function handleNavigate (path) {
     if (path === GHOSTNET_NAV_PATH) {
@@ -800,50 +647,48 @@ export default function Header ({ connected, active }) {
     router.push(path)
   }
 
-  const renderNavButton = (button, index, variant) => {
+  const renderNavButton = (button, index) => {
     const isActive = button.path === currentPath
     const isGhostNet = button.path === GHOSTNET_NAV_PATH
     const exitActive = isGhostnetExitTransitionActive()
     const buttonClasses = [
       isActive ? 'button--active' : '',
-      isGhostNet ? 'ghostnet-nav-button' : ''
+      isGhostNet ? 'ghostnet-nav-button ghostnet-nav-button--ghost' : ''
     ]
 
-    const profile = navGlitchProfiles[button.path]
     const buttonStyle = { fontSize: '1.5rem' }
+    const ghostCollapsed = !navUnlocked && navRevealState === 'locked' && isGhostNet
+    const profile = navMotionProfiles[button.path]
 
-    if (variant === 'pre') {
-      if ((navRevealState === 'glitchOut' || navRevealState === 'glitchOverlap') && profile) {
-        buttonClasses.push('ghostnet-nav-button--glitch-phase', 'ghostnet-nav-button--glitch-out')
-        applyNavGlitchOut(buttonStyle, profile)
-      }
-    } else if (variant === 'post') {
-      if (navRevealState === 'glitchOverlap' && profile) {
-        buttonClasses.push('ghostnet-nav-button--glitch-phase', 'ghostnet-nav-button--glitch-in')
-        if (isGhostNet) {
-          buttonClasses.push('ghostnet-nav-button--unlock')
-        }
-        applyNavGlitchIn(buttonStyle, profile)
+    if (ghostCollapsed) {
+      buttonClasses.push('ghostnet-nav-button--collapsed')
+    }
+
+    if (navUnlockAnimating && profile) {
+      buttonClasses.push('ghostnet-nav-button--glitching')
+      applyNavMotionProfile(buttonStyle, profile)
+      if (isGhostNet) {
+        buttonClasses.push('ghostnet-nav-button--ghost-reveal')
+      } else {
+        buttonClasses.push('ghostnet-nav-button--shift')
       }
     }
 
-    const disabled = disableNavButtons || isActive || (isGhostNet && isGhostnetAssimilationActive()) || exitActive
-
-    const animationEndHandler = variant === 'post'
-      ? event => handleNavGlitchAnimationEnd(button.path, event)
-      : undefined
+    const disabled = ghostCollapsed || disableNavButtons || isActive || (isGhostNet && (!navUnlocked || isGhostnetAssimilationActive())) || exitActive
+    const effectiveTabIndex = disabled ? -1 : navTabIndex
+    const ariaHidden = ghostCollapsed ? 'true' : undefined
 
     return (
       <button
-        key={`${variant}-${button.path}`}
+        key={button.path}
         data-primary-navigation={index + 1}
-        tabIndex={navTabIndex}
+        tabIndex={effectiveTabIndex}
         disabled={disabled}
+        aria-hidden={ariaHidden}
         aria-current={isActive ? 'page' : undefined}
         className={buttonClasses.filter(Boolean).join(' ')}
         onClick={() => handleNavigate(button.path)}
         style={buttonStyle}
-        onAnimationEnd={animationEndHandler}
       >
         <span className='visible-small'>{button.abbr}</span>
         <span className='hidden-small'>{button.name}</span>
@@ -939,32 +784,7 @@ export default function Header ({ connected, active }) {
         id='primaryNavigation'
         className={['button-group', navUnlockAnimating ? 'button-group--nav-unlock-animating' : ''].filter(Boolean).join(' ')}
       >
-        <div className='ghostnet-nav-stack'>
-          {navPreVisible && (
-            <div
-              className={[
-                'ghostnet-nav-track',
-                'ghostnet-nav-track--pre',
-                navPreOverlay ? 'ghostnet-nav-track--overlay' : ''
-              ].filter(Boolean).join(' ')}
-              aria-hidden={navPreOverlay ? 'true' : undefined}
-            >
-              {NAV_LOCKED_BUTTONS.map((button, i) => renderNavButton(button, i, 'pre'))}
-            </div>
-          )}
-          {navPostVisible && (
-            <div
-              className={[
-                'ghostnet-nav-track',
-                'ghostnet-nav-track--post',
-                navPostGlitching ? 'ghostnet-nav-track--glitching' : ''
-              ].filter(Boolean).join(' ')}
-              aria-hidden={navPostGlitching ? 'true' : undefined}
-            >
-              {NAV_BUTTONS.map((button, i) => renderNavButton(button, i, 'post'))}
-            </div>
-          )}
-        </div>
+        {NAV_BUTTONS.map((button, i) => renderNavButton(button, i))}
       </div>
       <hr className='bold' />
       <Settings visible={settingsVisible} toggleVisible={() => setSettingsVisible(!settingsVisible)} />

--- a/src/client/components/settings.js
+++ b/src/client/components/settings.js
@@ -6,7 +6,9 @@ import {
   ASSIMILATION_DURATION_MAX,
   ASSIMILATION_DURATION_DEFAULT,
   getAssimilationDurationSeconds,
-  saveAssimilationDurationSeconds
+  saveAssimilationDurationSeconds,
+  isGhostnetNavUnlocked,
+  setGhostnetNavUnlocked
 } from 'lib/ghostnet-settings'
 import packageJson from '../../../package.json'
 
@@ -60,6 +62,7 @@ function GhostnetSettings () {
   const patreonWindowFeatures = 'noopener,noreferrer'
   const [useMockData, setUseMockData] = useState(false)
   const [assimilationDuration, setAssimilationDuration] = useState(ASSIMILATION_DURATION_DEFAULT)
+  const [persistGhostnetNavUnlock, setPersistGhostnetNavUnlock] = useState(() => isGhostnetNavUnlocked())
   const [saved, setSaved] = useState(false)
 
   useEffect(() => {
@@ -67,6 +70,7 @@ function GhostnetSettings () {
       setUseMockData(window.localStorage.getItem('ghostnetUseMockData') === 'true')
     }
     setAssimilationDuration(getAssimilationDurationSeconds())
+    setPersistGhostnetNavUnlock(isGhostnetNavUnlocked())
   }, [])
 
   function handleSave(e) {
@@ -76,6 +80,7 @@ function GhostnetSettings () {
     }
     const sanitizedDuration = saveAssimilationDurationSeconds(assimilationDuration)
     setAssimilationDuration(sanitizedDuration)
+    setGhostnetNavUnlocked(persistGhostnetNavUnlock)
     setSaved(true)
     setTimeout(() => setSaved(false), 1500)
   }
@@ -93,6 +98,20 @@ function GhostnetSettings () {
           />
           <span>
             Enable Trade Route Layout Sandbox (use mock data)
+          </span>
+        </label>
+        <label style={{ display: 'flex', alignItems: 'flex-start', gap: '0.75rem', marginBottom: '1.5rem', fontSize: '1rem', lineHeight: 1.5 }}>
+          <input
+            type='checkbox'
+            checked={persistGhostnetNavUnlock}
+            onChange={event => setPersistGhostnetNavUnlock(event.target.checked)}
+          />
+          <span>
+            Keep GhostNet navigation unlocked after access is granted
+            <br />
+            <span className='text-muted' style={{ fontSize: '.9rem' }}>
+              Turn this off to re-run the unlock sequence on your next reload.
+            </span>
           </span>
         </label>
         <div style={{ marginBottom: '1.5rem' }}>

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -293,10 +293,14 @@
   --ghostnet-nav-glitch-out-scale-b: 0.85;
   --ghostnet-nav-glitch-out-scale-c: 0.74;
   --ghostnet-nav-glitch-out-scale-d: 0.68;
-  --ghostnet-nav-glitch-out-translate-a: -6px;
-  --ghostnet-nav-glitch-out-translate-b: -3px;
-  --ghostnet-nav-glitch-out-translate-c: -10px;
-  --ghostnet-nav-glitch-out-translate-d: -14px;
+  --ghostnet-nav-glitch-out-translate-x-a: -6px;
+  --ghostnet-nav-glitch-out-translate-x-b: -12px;
+  --ghostnet-nav-glitch-out-translate-x-c: -20px;
+  --ghostnet-nav-glitch-out-translate-x-d: -28px;
+  --ghostnet-nav-glitch-out-translate-y-a: 0px;
+  --ghostnet-nav-glitch-out-translate-y-b: 0px;
+  --ghostnet-nav-glitch-out-translate-y-c: 0px;
+  --ghostnet-nav-glitch-out-translate-y-d: 0px;
   --ghostnet-nav-glitch-out-opacity-a: 0.35;
   --ghostnet-nav-glitch-out-opacity-b: 0.82;
   --ghostnet-nav-glitch-out-opacity-c: 0.2;
@@ -305,10 +309,14 @@
   --ghostnet-nav-glitch-in-scale-mid-a: 0.74;
   --ghostnet-nav-glitch-in-scale-mid-b: 0.92;
   --ghostnet-nav-glitch-in-scale-mid-c: 0.84;
-  --ghostnet-nav-glitch-in-translate-start: 12px;
-  --ghostnet-nav-glitch-in-translate-a: 6px;
-  --ghostnet-nav-glitch-in-translate-b: 2px;
-  --ghostnet-nav-glitch-in-translate-c: -2px;
+  --ghostnet-nav-glitch-in-translate-start-x: 0px;
+  --ghostnet-nav-glitch-in-translate-x-a: 0px;
+  --ghostnet-nav-glitch-in-translate-x-b: 0px;
+  --ghostnet-nav-glitch-in-translate-x-c: 0px;
+  --ghostnet-nav-glitch-in-translate-start-y: 0px;
+  --ghostnet-nav-glitch-in-translate-y-a: 0px;
+  --ghostnet-nav-glitch-in-translate-y-b: 0px;
+  --ghostnet-nav-glitch-in-translate-y-c: 0px;
   --ghostnet-nav-glitch-in-clip-start-top: 52%;
   --ghostnet-nav-glitch-in-clip-start-bottom: 42%;
   --ghostnet-nav-glitch-in-clip-mid-top-a: 0%;
@@ -333,10 +341,8 @@
 .ghostnet-nav-button--glitch-out {
   --ghostnet-assimilation-glow-radius: 1.9rem;
   --ghostnet-assimilation-glow-opacity: 0.5;
-  --ghostnet-assimilation-shift-x: 4px;
-  --ghostnet-assimilation-shift-y: -6px;
   --ghostnet-assimilation-tilt: -1.6deg;
-  transform: scale(0.94) translateY(0);
+  transform: scale(0.94) translate3d(0, 0, 0);
   animation:
     ghostnet-nav-button-glitch-out var(--ghostnet-nav-glitch-out-duration, 720ms) steps(2, end) forwards,
     ghostnet-assimilation-jitter var(--ghostnet-assimilation-loop, 280ms) steps(2, end) infinite;
@@ -350,11 +356,13 @@
   filter: blur(2.4px) saturate(0.72) hue-rotate(-10deg);
   clip-path: inset(var(--ghostnet-nav-glitch-in-clip-start-top, 52%) 0 var(--ghostnet-nav-glitch-in-clip-start-bottom, 42%) 0);
   transform: scale(var(--ghostnet-nav-glitch-in-scale-start, 0.6))
-    translateY(var(--ghostnet-nav-glitch-in-translate-start, 12px));
+    translate3d(
+      var(--ghostnet-nav-glitch-in-translate-start-x, 0px),
+      var(--ghostnet-nav-glitch-in-translate-start-y, 0px),
+      0
+    );
   --ghostnet-assimilation-glow-radius: 2.35rem;
   --ghostnet-assimilation-glow-opacity: 0.65;
-  --ghostnet-assimilation-shift-x: 3px;
-  --ghostnet-assimilation-shift-y: -4px;
   --ghostnet-assimilation-tilt: 1deg;
   animation:
     ghostnet-nav-button-glitch-in var(--ghostnet-nav-glitch-in-duration, 1150ms) cubic-bezier(0.3, 0.74, 0.24, 1.02) forwards,
@@ -380,31 +388,47 @@
   0% {
     opacity: 1;
     filter: none;
-    transform: scale(1) translateY(0);
+    transform: scale(1) translate3d(0, 0, 0);
   }
   18% {
     opacity: var(--ghostnet-nav-glitch-out-opacity-a, 0.35);
     filter: blur(1.4px) saturate(1.2);
     transform: scale(var(--ghostnet-nav-glitch-out-scale-a, 0.92))
-      translateY(var(--ghostnet-nav-glitch-out-translate-a, -6px));
+      translate3d(
+        var(--ghostnet-nav-glitch-out-translate-x-a, -6px),
+        var(--ghostnet-nav-glitch-out-translate-y-a, 0px),
+        0
+      );
   }
   36% {
     opacity: var(--ghostnet-nav-glitch-out-opacity-b, 0.82);
     filter: blur(0.6px) saturate(1.08);
     transform: scale(var(--ghostnet-nav-glitch-out-scale-b, 0.85))
-      translateY(var(--ghostnet-nav-glitch-out-translate-b, -3px));
+      translate3d(
+        var(--ghostnet-nav-glitch-out-translate-x-b, -12px),
+        var(--ghostnet-nav-glitch-out-translate-y-b, 0px),
+        0
+      );
   }
   58% {
     opacity: var(--ghostnet-nav-glitch-out-opacity-c, 0.2);
     filter: blur(1.8px) saturate(0.74) hue-rotate(-4deg);
     transform: scale(var(--ghostnet-nav-glitch-out-scale-c, 0.74))
-      translateY(var(--ghostnet-nav-glitch-out-translate-c, -10px));
+      translate3d(
+        var(--ghostnet-nav-glitch-out-translate-x-c, -20px),
+        var(--ghostnet-nav-glitch-out-translate-y-c, 0px),
+        0
+      );
   }
   100% {
     opacity: var(--ghostnet-nav-glitch-out-opacity-d, 0);
     filter: blur(2.6px) saturate(0.62) hue-rotate(-6deg);
     transform: scale(var(--ghostnet-nav-glitch-out-scale-d, 0.68))
-      translateY(var(--ghostnet-nav-glitch-out-translate-d, -14px));
+      translate3d(
+        var(--ghostnet-nav-glitch-out-translate-x-d, -28px),
+        var(--ghostnet-nav-glitch-out-translate-y-d, 0px),
+        0
+      );
   }
 }
 
@@ -416,7 +440,11 @@
       var(--ghostnet-nav-glitch-in-clip-start-top, 52%) 0 var(--ghostnet-nav-glitch-in-clip-start-bottom, 42%) 0
     );
     transform: scale(var(--ghostnet-nav-glitch-in-scale-start, 0.6))
-      translateY(var(--ghostnet-nav-glitch-in-translate-start, 12px));
+      translate3d(
+        var(--ghostnet-nav-glitch-in-translate-start-x, 0px),
+        var(--ghostnet-nav-glitch-in-translate-start-y, 0px),
+        0
+      );
   }
   24% {
     opacity: 0.45;
@@ -425,7 +453,11 @@
       var(--ghostnet-nav-glitch-in-clip-mid-top-a, 0%) 0 var(--ghostnet-nav-glitch-in-clip-mid-bottom-a, 38%) 0
     );
     transform: scale(var(--ghostnet-nav-glitch-in-scale-mid-a, 0.74))
-      translateY(var(--ghostnet-nav-glitch-in-translate-a, 6px));
+      translate3d(
+        var(--ghostnet-nav-glitch-in-translate-x-a, 0px),
+        var(--ghostnet-nav-glitch-in-translate-y-a, 0px),
+        0
+      );
   }
   46% {
     opacity: 0.88;
@@ -434,7 +466,11 @@
       var(--ghostnet-nav-glitch-in-clip-mid-top-b, 12%) 0 var(--ghostnet-nav-glitch-in-clip-mid-bottom-b, 0%) 0
     );
     transform: scale(var(--ghostnet-nav-glitch-in-scale-mid-b, 0.92))
-      translateY(var(--ghostnet-nav-glitch-in-translate-b, 2px));
+      translate3d(
+        var(--ghostnet-nav-glitch-in-translate-x-b, 0px),
+        var(--ghostnet-nav-glitch-in-translate-y-b, 0px),
+        0
+      );
   }
   64% {
     opacity: 0.6;
@@ -443,12 +479,16 @@
       var(--ghostnet-nav-glitch-in-clip-mid-top-c, 0%) 0 var(--ghostnet-nav-glitch-in-clip-mid-bottom-c, 50%) 0
     );
     transform: scale(var(--ghostnet-nav-glitch-in-scale-mid-c, 0.84))
-      translateY(var(--ghostnet-nav-glitch-in-translate-c, -2px));
+      translate3d(
+        var(--ghostnet-nav-glitch-in-translate-x-c, 0px),
+        var(--ghostnet-nav-glitch-in-translate-y-c, 0px),
+        0
+      );
   }
   100% {
     opacity: 1;
     filter: none;
     clip-path: inset(0);
-    transform: scale(1) translateY(0);
+    transform: scale(1) translate3d(0, 0, 0);
   }
 }

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -259,270 +259,180 @@
 
 .button-group--nav-unlock-animating {
   pointer-events: none;
-  gap: 0.75rem;
-  justify-content: space-between;
 }
 
 .button-group--nav-unlock-animating button {
-  width: auto;
-  flex: 1 1 0;
-  transition: flex-basis 0.45s ease, width 0.45s ease;
+  pointer-events: none;
 }
 
-.ghostnet-nav-stack {
+.ghostnet-nav-button {
   position: relative;
-  width: 100%;
-  min-height: 3.8rem;
-}
-
-.ghostnet-nav-track {
-  display: flex;
-  gap: inherit;
-  width: 100%;
-}
-
-.ghostnet-nav-track--overlay {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-}
-
-.ghostnet-nav-track--overlay button {
-  pointer-events: none;
-}
-
-.ghostnet-nav-track--post {
-  position: relative;
-}
-
-.ghostnet-nav-track--glitching {
-  pointer-events: none;
-}
-
-.ghostnet-nav-track--glitching button {
-  pointer-events: none;
-}
-
-.ghostnet-nav-button--glitch-phase {
-  position: relative;
-  color: rgba(245, 241, 255, 0.84) !important;
-  border-color: rgba(140, 92, 255, 0.35) !important;
-  background: rgba(28, 22, 51, 0.72) !important;
-  box-shadow: 0 0 var(--ghostnet-assimilation-glow-radius, 1.5rem)
-    rgba(93, 46, 255, var(--ghostnet-assimilation-glow-opacity, 0.45));
-  filter: saturate(var(--ghostnet-assimilation-saturation, 1.25)) hue-rotate(-6deg);
-  transition: color 0.3s ease, background 0.4s ease, border-color 0.4s ease, opacity 0.45s ease, transform 0.4s ease,
-    filter 0.45s ease, box-shadow 0.45s ease;
   overflow: hidden;
-  --ghostnet-assimilation-loop: 280ms;
-  --ghostnet-assimilation-ghost-loop: 360ms;
-  --ghostnet-assimilation-ghost-opacity: 0.4;
-  --ghostnet-assimilation-saturation: 1.25;
   transform-origin: center;
-  --ghostnet-nav-glitch-out-delay: 0ms;
-  --ghostnet-nav-glitch-out-duration: 720ms;
-  --ghostnet-nav-glitch-in-delay: 0ms;
-  --ghostnet-nav-glitch-in-duration: 1150ms;
-  --ghostnet-nav-glitch-out-scale-a: 0.92;
-  --ghostnet-nav-glitch-out-scale-b: 0.85;
-  --ghostnet-nav-glitch-out-scale-c: 0.74;
-  --ghostnet-nav-glitch-out-scale-d: 0.68;
-  --ghostnet-nav-glitch-out-translate-x-a: -6px;
-  --ghostnet-nav-glitch-out-translate-x-b: -12px;
-  --ghostnet-nav-glitch-out-translate-x-c: -20px;
-  --ghostnet-nav-glitch-out-translate-x-d: -28px;
-  --ghostnet-nav-glitch-out-translate-y-a: 0px;
-  --ghostnet-nav-glitch-out-translate-y-b: 0px;
-  --ghostnet-nav-glitch-out-translate-y-c: 0px;
-  --ghostnet-nav-glitch-out-translate-y-d: 0px;
-  --ghostnet-nav-glitch-out-opacity-a: 0.35;
-  --ghostnet-nav-glitch-out-opacity-b: 0.82;
-  --ghostnet-nav-glitch-out-opacity-c: 0.2;
-  --ghostnet-nav-glitch-out-opacity-d: 0;
-  --ghostnet-nav-glitch-in-scale-start: 0.6;
-  --ghostnet-nav-glitch-in-scale-mid-a: 0.74;
-  --ghostnet-nav-glitch-in-scale-mid-b: 0.92;
-  --ghostnet-nav-glitch-in-scale-mid-c: 0.84;
-  --ghostnet-nav-glitch-in-translate-start-x: 0px;
-  --ghostnet-nav-glitch-in-translate-x-a: 0px;
-  --ghostnet-nav-glitch-in-translate-x-b: 0px;
-  --ghostnet-nav-glitch-in-translate-x-c: 0px;
-  --ghostnet-nav-glitch-in-translate-start-y: 0px;
-  --ghostnet-nav-glitch-in-translate-y-a: 0px;
-  --ghostnet-nav-glitch-in-translate-y-b: 0px;
-  --ghostnet-nav-glitch-in-translate-y-c: 0px;
-  --ghostnet-nav-glitch-in-clip-start-top: 52%;
-  --ghostnet-nav-glitch-in-clip-start-bottom: 42%;
-  --ghostnet-nav-glitch-in-clip-mid-top-a: 0%;
-  --ghostnet-nav-glitch-in-clip-mid-bottom-a: 38%;
-  --ghostnet-nav-glitch-in-clip-mid-top-b: 12%;
-  --ghostnet-nav-glitch-in-clip-mid-bottom-b: 0%;
-  --ghostnet-nav-glitch-in-clip-mid-top-c: 0%;
-  --ghostnet-nav-glitch-in-clip-mid-bottom-c: 50%;
 }
 
-.ghostnet-nav-button--glitch-phase::before {
+.ghostnet-nav-button--ghost {
+  transform-origin: center right;
+}
+
+.ghostnet-nav-button--collapsed {
+  transform: scaleX(0);
+  opacity: 0;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-width: 0;
+  flex: 0 0 0;
+  max-width: 0;
+  pointer-events: none;
+}
+
+.ghostnet-nav-button--collapsed .visible-small,
+.ghostnet-nav-button--collapsed .hidden-small {
+  opacity: 0;
+}
+
+.ghostnet-nav-button--glitching {
+  --ghostnet-nav-motion-animation: ghostnet-nav-button-motion;
+  --ghostnet-nav-motion-delay: 0ms;
+  --ghostnet-nav-motion-duration: 1200ms;
+  --ghostnet-nav-motion-x-a: 0px;
+  --ghostnet-nav-motion-x-b: 0px;
+  --ghostnet-nav-motion-x-c: 0px;
+  --ghostnet-nav-motion-y-a: 0px;
+  --ghostnet-nav-motion-y-b: 0px;
+  --ghostnet-nav-motion-y-c: 0px;
+  --ghostnet-nav-motion-scale-x-start: 1;
+  --ghostnet-nav-motion-scale-x-mid: 1;
+  --ghostnet-nav-motion-scale-x-max: 1;
+  --ghostnet-nav-motion-scale-y-start: 1;
+  --ghostnet-nav-motion-scale-y-mid: 1;
+  --ghostnet-nav-motion-scale-y-max: 1;
+  --ghostnet-nav-motion-hue: 0deg;
+  --ghostnet-nav-motion-saturation: 1.2;
+  --ghostnet-nav-motion-brightness: 1;
+  --ghostnet-nav-motion-flash-a: 0.4;
+  --ghostnet-nav-motion-flash-b: 0.3;
+  --ghostnet-nav-motion-flash-c: 0.2;
+  animation: var(--ghostnet-nav-motion-animation) var(--ghostnet-nav-motion-duration) cubic-bezier(0.36, 0.7, 0.24, 1.02)
+    var(--ghostnet-nav-motion-delay) forwards;
+  filter:
+    hue-rotate(var(--ghostnet-nav-motion-hue, 0deg))
+    saturate(var(--ghostnet-nav-motion-saturation, 1.18))
+    brightness(var(--ghostnet-nav-motion-brightness, 1));
+  box-shadow: 0 0 1.4rem rgba(93, 46, 255, 0.35);
+}
+
+.ghostnet-nav-button--glitching::after {
   content: '';
   position: absolute;
-  inset: -3px;
-  border: 1px solid rgba(93, 46, 255, 0.2);
+  inset: -2px;
+  border-radius: inherit;
   pointer-events: none;
+  background: linear-gradient(180deg, rgba(93, 46, 255, 0.35), rgba(41, 243, 195, 0.18));
   mix-blend-mode: screen;
-  opacity: var(--ghostnet-assimilation-ghost-opacity, 0.4);
-  animation: ghostnet-assimilation-ghost var(--ghostnet-assimilation-ghost-loop, 360ms) steps(2, end) infinite;
-}
-
-.ghostnet-nav-button--glitch-out {
-  --ghostnet-assimilation-glow-radius: 1.9rem;
-  --ghostnet-assimilation-glow-opacity: 0.5;
-  --ghostnet-assimilation-tilt: -1.6deg;
-  transform: scale(0.94) translate3d(0, 0, 0);
-  animation:
-    ghostnet-nav-button-glitch-out var(--ghostnet-nav-glitch-out-duration, 720ms) steps(2, end) forwards,
-    ghostnet-assimilation-jitter var(--ghostnet-assimilation-loop, 280ms) steps(2, end) infinite;
-  animation-delay:
-    var(--ghostnet-nav-glitch-out-delay, 0ms),
-    calc(var(--ghostnet-nav-glitch-out-delay, 0ms) + var(--ghostnet-assimilation-loop, 280ms) * 0.75);
-}
-
-.ghostnet-nav-button--glitch-in {
   opacity: 0;
-  filter: blur(2.4px) saturate(0.72) hue-rotate(-10deg);
-  clip-path: inset(var(--ghostnet-nav-glitch-in-clip-start-top, 52%) 0 var(--ghostnet-nav-glitch-in-clip-start-bottom, 42%) 0);
-  transform: scale(var(--ghostnet-nav-glitch-in-scale-start, 0.6))
-    translate3d(
-      var(--ghostnet-nav-glitch-in-translate-start-x, 0px),
-      var(--ghostnet-nav-glitch-in-translate-start-y, 0px),
-      0
-    );
-  --ghostnet-assimilation-glow-radius: 2.35rem;
-  --ghostnet-assimilation-glow-opacity: 0.65;
-  --ghostnet-assimilation-tilt: 1deg;
-  animation:
-    ghostnet-nav-button-glitch-in var(--ghostnet-nav-glitch-in-duration, 1150ms) cubic-bezier(0.3, 0.74, 0.24, 1.02) forwards,
-    ghostnet-assimilation-jitter var(--ghostnet-assimilation-loop, 280ms) steps(2, end) infinite;
-  animation-delay:
-    var(--ghostnet-nav-glitch-in-delay, 0ms),
-    calc(var(--ghostnet-nav-glitch-in-delay, 0ms) + var(--ghostnet-nav-glitch-in-duration, 1150ms) * 0.7);
+  animation: ghostnet-nav-button-flash var(--ghostnet-nav-motion-duration) linear var(--ghostnet-nav-motion-delay) forwards;
 }
 
-.ghostnet-nav-button--glitch-in::before {
-  opacity: 0.45;
+.ghostnet-nav-button--ghost-reveal {
+  --ghostnet-nav-motion-animation: ghostnet-nav-button-reveal;
+  opacity: 0;
 }
 
-.ghostnet-nav-button--unlock {
-  --ghostnet-assimilation-glow-radius: 2.7rem;
-  --ghostnet-assimilation-glow-opacity: 0.75;
-  --ghostnet-assimilation-loop: 230ms;
-  --ghostnet-nav-glitch-in-delay: 320ms;
-  --ghostnet-nav-glitch-in-duration: 1280ms;
+.ghostnet-nav-button--shift {
+  transform-origin: center;
 }
 
-@keyframes ghostnet-nav-button-glitch-out {
+@keyframes ghostnet-nav-button-motion {
   0% {
-    opacity: 1;
-    filter: none;
-    transform: scale(1) translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0) scaleX(1) scaleY(1);
   }
-  18% {
-    opacity: var(--ghostnet-nav-glitch-out-opacity-a, 0.35);
-    filter: blur(1.4px) saturate(1.2);
-    transform: scale(var(--ghostnet-nav-glitch-out-scale-a, 0.92))
-      translate3d(
-        var(--ghostnet-nav-glitch-out-translate-x-a, -6px),
-        var(--ghostnet-nav-glitch-out-translate-y-a, 0px),
-        0
-      );
+
+  22% {
+    transform:
+      translate3d(var(--ghostnet-nav-motion-x-a, 0px), var(--ghostnet-nav-motion-y-a, 0px), 0)
+      scaleX(var(--ghostnet-nav-motion-scale-x-start, 0.92))
+      scaleY(var(--ghostnet-nav-motion-scale-y-start, 0.96));
   }
-  36% {
-    opacity: var(--ghostnet-nav-glitch-out-opacity-b, 0.82);
-    filter: blur(0.6px) saturate(1.08);
-    transform: scale(var(--ghostnet-nav-glitch-out-scale-b, 0.85))
-      translate3d(
-        var(--ghostnet-nav-glitch-out-translate-x-b, -12px),
-        var(--ghostnet-nav-glitch-out-translate-y-b, 0px),
-        0
-      );
+
+  48% {
+    transform:
+      translate3d(var(--ghostnet-nav-motion-x-b, 0px), var(--ghostnet-nav-motion-y-b, 0px), 0)
+      scaleX(var(--ghostnet-nav-motion-scale-x-mid, 0.96))
+      scaleY(var(--ghostnet-nav-motion-scale-y-mid, 0.98));
   }
-  58% {
-    opacity: var(--ghostnet-nav-glitch-out-opacity-c, 0.2);
-    filter: blur(1.8px) saturate(0.74) hue-rotate(-4deg);
-    transform: scale(var(--ghostnet-nav-glitch-out-scale-c, 0.74))
-      translate3d(
-        var(--ghostnet-nav-glitch-out-translate-x-c, -20px),
-        var(--ghostnet-nav-glitch-out-translate-y-c, 0px),
-        0
-      );
+
+  74% {
+    transform:
+      translate3d(var(--ghostnet-nav-motion-x-c, 0px), var(--ghostnet-nav-motion-y-c, 0px), 0)
+      scaleX(var(--ghostnet-nav-motion-scale-x-max, 1.02))
+      scaleY(var(--ghostnet-nav-motion-scale-y-max, 1.02));
   }
+
   100% {
-    opacity: var(--ghostnet-nav-glitch-out-opacity-d, 0);
-    filter: blur(2.6px) saturate(0.62) hue-rotate(-6deg);
-    transform: scale(var(--ghostnet-nav-glitch-out-scale-d, 0.68))
-      translate3d(
-        var(--ghostnet-nav-glitch-out-translate-x-d, -28px),
-        var(--ghostnet-nav-glitch-out-translate-y-d, 0px),
-        0
-      );
+    transform: translate3d(0, 0, 0) scaleX(1) scaleY(1);
   }
 }
 
-@keyframes ghostnet-nav-button-glitch-in {
+@keyframes ghostnet-nav-button-reveal {
+  0% {
+    transform:
+      translate3d(var(--ghostnet-nav-motion-x-a, 0px), var(--ghostnet-nav-motion-y-a, 0px), 0)
+      scaleX(0.05)
+      scaleY(var(--ghostnet-nav-motion-scale-y-start, 0.74));
+    opacity: 0;
+  }
+
+  28% {
+    transform:
+      translate3d(var(--ghostnet-nav-motion-x-a, 0px), var(--ghostnet-nav-motion-y-a, 0px), 0)
+      scaleX(var(--ghostnet-nav-motion-scale-x-start, 0.82))
+      scaleY(var(--ghostnet-nav-motion-scale-y-start, 0.9));
+    opacity: 0.45;
+  }
+
+  56% {
+    transform:
+      translate3d(var(--ghostnet-nav-motion-x-b, 0px), var(--ghostnet-nav-motion-y-b, 0px), 0)
+      scaleX(var(--ghostnet-nav-motion-scale-x-mid, 0.94))
+      scaleY(var(--ghostnet-nav-motion-scale-y-mid, 0.98));
+    opacity: 0.8;
+  }
+
+  82% {
+    transform:
+      translate3d(var(--ghostnet-nav-motion-x-c, 0px), var(--ghostnet-nav-motion-y-c, 0px), 0)
+      scaleX(var(--ghostnet-nav-motion-scale-x-max, 1.05))
+      scaleY(var(--ghostnet-nav-motion-scale-y-max, 1.05));
+    opacity: 0.95;
+  }
+
+  100% {
+    transform: translate3d(0, 0, 0) scaleX(1) scaleY(1);
+    opacity: 1;
+  }
+}
+
+@keyframes ghostnet-nav-button-flash {
   0% {
     opacity: 0;
-    filter: blur(2.4px) saturate(0.72) hue-rotate(-10deg);
-    clip-path: inset(
-      var(--ghostnet-nav-glitch-in-clip-start-top, 52%) 0 var(--ghostnet-nav-glitch-in-clip-start-bottom, 42%) 0
-    );
-    transform: scale(var(--ghostnet-nav-glitch-in-scale-start, 0.6))
-      translate3d(
-        var(--ghostnet-nav-glitch-in-translate-start-x, 0px),
-        var(--ghostnet-nav-glitch-in-translate-start-y, 0px),
-        0
-      );
   }
+
   24% {
-    opacity: 0.45;
-    filter: blur(1.6px) saturate(0.86) hue-rotate(-5deg);
-    clip-path: inset(
-      var(--ghostnet-nav-glitch-in-clip-mid-top-a, 0%) 0 var(--ghostnet-nav-glitch-in-clip-mid-bottom-a, 38%) 0
-    );
-    transform: scale(var(--ghostnet-nav-glitch-in-scale-mid-a, 0.74))
-      translate3d(
-        var(--ghostnet-nav-glitch-in-translate-x-a, 0px),
-        var(--ghostnet-nav-glitch-in-translate-y-a, 0px),
-        0
-      );
+    opacity: var(--ghostnet-nav-motion-flash-a, 0.4);
   }
-  46% {
-    opacity: 0.88;
-    filter: blur(0.9px) saturate(1.12) hue-rotate(3deg);
-    clip-path: inset(
-      var(--ghostnet-nav-glitch-in-clip-mid-top-b, 12%) 0 var(--ghostnet-nav-glitch-in-clip-mid-bottom-b, 0%) 0
-    );
-    transform: scale(var(--ghostnet-nav-glitch-in-scale-mid-b, 0.92))
-      translate3d(
-        var(--ghostnet-nav-glitch-in-translate-x-b, 0px),
-        var(--ghostnet-nav-glitch-in-translate-y-b, 0px),
-        0
-      );
+
+  56% {
+    opacity: var(--ghostnet-nav-motion-flash-b, 0.3);
   }
-  64% {
-    opacity: 0.6;
-    filter: blur(1.1px) saturate(1.18) hue-rotate(-2deg);
-    clip-path: inset(
-      var(--ghostnet-nav-glitch-in-clip-mid-top-c, 0%) 0 var(--ghostnet-nav-glitch-in-clip-mid-bottom-c, 50%) 0
-    );
-    transform: scale(var(--ghostnet-nav-glitch-in-scale-mid-c, 0.84))
-      translate3d(
-        var(--ghostnet-nav-glitch-in-translate-x-c, 0px),
-        var(--ghostnet-nav-glitch-in-translate-y-c, 0px),
-        0
-      );
+
+  82% {
+    opacity: var(--ghostnet-nav-motion-flash-c, 0.2);
   }
+
   100% {
-    opacity: 1;
-    filter: none;
-    clip-path: inset(0);
-    transform: scale(1) translate3d(0, 0, 0);
+    opacity: 0;
   }
 }

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -9,6 +9,81 @@
   display: inline-flex;
 }
 
+.header-utility-tray {
+  position: absolute;
+  top: 0.65rem;
+  right: 1.5rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 1.5rem;
+  pointer-events: none;
+}
+
+.header-utility-tray > * {
+  pointer-events: auto;
+}
+
+.header-utility-clock {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-align: right;
+  color: rgba(245, 241, 255, 0.82);
+}
+
+.header-utility-clock__time {
+  font-size: 2.25rem;
+  line-height: 1;
+  letter-spacing: 0.2em;
+  text-shadow: 0 0 0.6rem rgba(93, 46, 255, 0.4);
+}
+
+.header-utility-clock__date {
+  font-size: 1.05rem;
+  line-height: 1;
+  letter-spacing: 0.32em;
+}
+
+.header-utility-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.header-utility-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.2rem;
+  height: 3.2rem;
+  padding: 0.25rem;
+  border-radius: 50%;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.header-utility-button .icon {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.header-utility-button--signal .icon {
+  font-size: 2.6rem;
+  transition: opacity 0.2s ease, filter 0.2s ease;
+}
+
+.header-utility-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 0.2rem rgba(41, 243, 195, 0.4);
+}
+
+.header-utility-button:disabled {
+  cursor: default;
+}
+
 .ghostnet-title-morph__char {
   display: inline-block;
   width: 1ch;
@@ -36,19 +111,19 @@
 .pirate-access-button:hover,
 .pirate-access-button:focus-visible {
   color: #5D2EFF;
-  transform: translateY(-0.08rem);
+  transform: translateY(-0.1rem);
 }
 
 .pirate-access-icon {
   display: inline-block;
-  font-size: 3rem;
+  font-size: 2.8rem;
   line-height: 1;
   transition: text-shadow 0.18s ease;
 }
 
 .pirate-access-button:hover .pirate-access-icon,
 .pirate-access-button:focus-visible .pirate-access-icon {
-  text-shadow: 0 0 0.6rem rgba(93, 46, 255, 0.5);
+  text-shadow: 0 0 0.75rem rgba(93, 46, 255, 0.55);
 }
 
 .sr-only {
@@ -76,18 +151,86 @@
 
 .pirate-password-dialog {
   position: relative;
-  width: min(90vw, 36rem);
-  padding: 3rem;
-  border: 1px solid rgba(140, 92, 255, 0.35);
-  border-radius: 1.2rem;
-  background: rgba(28, 22, 51, 0.92);
-  box-shadow: 0 0 2.4rem rgba(93, 46, 255, 0.45);
+  width: min(90vw, 38rem);
+  padding: 3.6rem 3.2rem 3.1rem;
+  border: 1px solid rgba(140, 92, 255, 0.45);
+  border-radius: 1.3rem;
+  background: linear-gradient(160deg, rgba(28, 22, 51, 0.94), rgba(28, 22, 51, 0.86)) padding-box;
+  box-shadow:
+    0 2.2rem 3.8rem rgba(13, 11, 26, 0.72),
+    0 0 2.6rem rgba(93, 46, 255, 0.55);
+  backdrop-filter: blur(0.45rem) saturate(1.12);
   text-align: center;
   overflow: hidden;
 }
 
 .pirate-password-dialog--glitch {
   animation: pirateDialogGlitch 1.1s ease forwards;
+}
+
+.pirate-password-dialog::before {
+  content: '';
+  position: absolute;
+  inset: 0.75rem;
+  border-radius: 0.95rem;
+  border: 1px solid rgba(93, 46, 255, 0.32);
+  background: radial-gradient(circle at 20% 20%, rgba(93, 46, 255, 0.22), transparent 55%),
+    radial-gradient(circle at 80% 25%, rgba(41, 243, 195, 0.12), transparent 45%);
+  opacity: 0.85;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.pirate-password-dialog::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(93, 46, 255, 0.24), transparent 28%);
+  opacity: 0.55;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.pirate-password-dialog__chrome {
+  position: absolute;
+  top: 1.1rem;
+  left: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid rgba(140, 92, 255, 0.28);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.pirate-password-dialog__chrome-light {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  box-shadow: 0 0 0.55rem currentColor;
+  opacity: 0.88;
+}
+
+.pirate-password-dialog__chrome-light--primary {
+  color: rgba(41, 243, 195, 0.95);
+}
+
+.pirate-password-dialog__chrome-light--secondary {
+  color: rgba(93, 46, 255, 0.85);
+}
+
+.pirate-password-dialog__chrome-light--tertiary {
+  color: rgba(255, 95, 193, 0.9);
+}
+
+.pirate-password-dialog__body {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
 }
 
 .pirate-password-title {
@@ -109,16 +252,18 @@
   margin-bottom: 0.8rem;
 }
 
+
 .pirate-password-input {
   width: 100%;
   padding: 1.1rem 1.5rem;
   font-size: 1.6rem;
   color: #F5F1FF;
-  background: rgba(13, 11, 26, 0.88);
-  border: 1px solid rgba(140, 92, 255, 0.35);
+  background: rgba(13, 11, 26, 0.9);
+  border: 1px solid rgba(140, 92, 255, 0.42);
   border-radius: 0.9rem;
   letter-spacing: 0.3em;
   text-align: center;
+  box-shadow: inset 0 0 0.8rem rgba(93, 46, 255, 0.18);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -134,16 +279,26 @@
 
 .pirate-password-submit {
   margin-top: 2rem;
-  padding: 0.9rem 2.2rem;
+  padding: 1rem 2.6rem;
   font-size: 1.2rem;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.22em;
+  box-shadow: 0 0 1.2rem rgba(93, 46, 255, 0.35);
 }
 
 .pirate-password-feedback {
   min-height: 2.4rem;
-  margin-top: 1.5rem;
+  margin-top: 1.6rem;
   font-size: 1.1rem;
   letter-spacing: 0.12em;
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(13, 11, 26, 0.65);
+  border: 1px solid rgba(140, 92, 255, 0.25);
+  box-shadow: inset 0 0 0.9rem rgba(93, 46, 255, 0.22);
+}
+
+.pirate-password-feedback:empty {
+  display: none;
 }
 
 .pirate-password-feedback--error {

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -27,3 +27,178 @@
   text-shadow: 0 0 0.32rem rgba(93, 46, 255, 0.55), 0 0 0.14rem rgba(41, 243, 195, 0.35);
   filter: blur(0.038rem) contrast(1.06) saturate(1.05);
 }
+
+.pirate-access-button {
+  color: #F5F1FF;
+  transition: color 0.18s ease, transform 0.2s ease;
+}
+
+.pirate-access-button:hover,
+.pirate-access-button:focus-visible {
+  color: #5D2EFF;
+  transform: translateY(-0.08rem);
+}
+
+.pirate-access-icon {
+  display: inline-block;
+  font-size: 3rem;
+  line-height: 1;
+  transition: text-shadow 0.18s ease;
+}
+
+.pirate-access-button:hover .pirate-access-icon,
+.pirate-access-button:focus-visible .pirate-access-icon {
+  text-shadow: 0 0 0.6rem rgba(93, 46, 255, 0.5);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.pirate-password-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(13, 11, 26, 0.92);
+  z-index: 9999;
+  backdrop-filter: blur(0.2rem);
+}
+
+.pirate-password-dialog {
+  position: relative;
+  width: min(90vw, 36rem);
+  padding: 3rem;
+  border: 1px solid rgba(140, 92, 255, 0.35);
+  border-radius: 1.2rem;
+  background: rgba(28, 22, 51, 0.92);
+  box-shadow: 0 0 2.4rem rgba(93, 46, 255, 0.45);
+  text-align: center;
+  overflow: hidden;
+}
+
+.pirate-password-dialog--glitch {
+  animation: pirateDialogGlitch 1.1s ease forwards;
+}
+
+.pirate-password-title {
+  font-size: 2.6rem;
+  letter-spacing: 0.14em;
+  margin-bottom: 1rem;
+}
+
+.pirate-password-subtitle {
+  font-size: 1.2rem;
+  margin: 0 0 2rem 0;
+  color: rgba(245, 241, 255, 0.68);
+}
+
+.pirate-password-label {
+  display: block;
+  font-size: 1rem;
+  letter-spacing: 0.3em;
+  margin-bottom: 0.8rem;
+}
+
+.pirate-password-input {
+  width: 100%;
+  padding: 1.1rem 1.5rem;
+  font-size: 1.6rem;
+  color: #F5F1FF;
+  background: rgba(13, 11, 26, 0.88);
+  border: 1px solid rgba(140, 92, 255, 0.35);
+  border-radius: 0.9rem;
+  letter-spacing: 0.3em;
+  text-align: center;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pirate-password-input:focus {
+  outline: none;
+  border-color: #29F3C3;
+  box-shadow: 0 0 0 0.2rem rgba(41, 243, 195, 0.3);
+}
+
+.pirate-password-input--error {
+  border-color: #FF5FC1;
+}
+
+.pirate-password-submit {
+  margin-top: 2rem;
+  padding: 0.9rem 2.2rem;
+  font-size: 1.2rem;
+  letter-spacing: 0.18em;
+}
+
+.pirate-password-feedback {
+  min-height: 2.4rem;
+  margin-top: 1.5rem;
+  font-size: 1.1rem;
+  letter-spacing: 0.12em;
+}
+
+.pirate-password-feedback--error {
+  color: #FF5FC1;
+}
+
+.pirate-password-feedback--locked {
+  color: #FF5FC1;
+}
+
+.pirate-password-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.pirate-password-success__icon {
+  font-size: 6rem;
+  color: #29F3C3;
+  text-shadow: 0 0 1.8rem rgba(41, 243, 195, 0.55);
+}
+
+.pirate-password-success__text {
+  font-size: 1.8rem;
+  letter-spacing: 0.2em;
+  color: rgba(245, 241, 255, 0.88);
+}
+
+@keyframes pirateDialogGlitch {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 1;
+    filter: none;
+  }
+  20% {
+    transform: translate3d(-4px, 3px, 0) skewX(-3deg);
+  }
+  40% {
+    transform: translate3d(6px, -4px, 0) skewX(2deg);
+    clip-path: inset(0 0 38% 0);
+  }
+  60% {
+    transform: translate3d(-8px, 4px, 0) scale(1.02) skewX(-6deg);
+    opacity: 0.7;
+  }
+  80% {
+    transform: translate3d(10px, -8px, 0) scale(0.96) skewX(4deg);
+    opacity: 0.4;
+    filter: hue-rotate(-40deg) saturate(1.3);
+  }
+  100% {
+    transform: translate3d(-80px, 42px, 0) scale(1.2) skewX(-18deg);
+    opacity: 0;
+    filter: blur(0.4rem);
+  }
+}

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -9,81 +9,6 @@
   display: inline-flex;
 }
 
-.header-utility-tray {
-  position: absolute;
-  top: 0.65rem;
-  right: 1.5rem;
-  display: flex;
-  align-items: flex-start;
-  gap: 1.5rem;
-  pointer-events: none;
-}
-
-.header-utility-tray > * {
-  pointer-events: auto;
-}
-
-.header-utility-clock {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.35rem;
-  font-size: 0.95rem;
-  letter-spacing: 0.18em;
-  text-align: right;
-  color: rgba(245, 241, 255, 0.82);
-}
-
-.header-utility-clock__time {
-  font-size: 2.25rem;
-  line-height: 1;
-  letter-spacing: 0.2em;
-  text-shadow: 0 0 0.6rem rgba(93, 46, 255, 0.4);
-}
-
-.header-utility-clock__date {
-  font-size: 1.05rem;
-  line-height: 1;
-  letter-spacing: 0.32em;
-}
-
-.header-utility-controls {
-  display: flex;
-  align-items: center;
-  gap: 0.85rem;
-}
-
-.header-utility-button {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 3.2rem;
-  height: 3.2rem;
-  padding: 0.25rem;
-  border-radius: 50%;
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
-}
-
-.header-utility-button .icon {
-  font-size: 2rem;
-  line-height: 1;
-}
-
-.header-utility-button--signal .icon {
-  font-size: 2.6rem;
-  transition: opacity 0.2s ease, filter 0.2s ease;
-}
-
-.header-utility-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 0.2rem rgba(41, 243, 195, 0.4);
-}
-
-.header-utility-button:disabled {
-  cursor: default;
-}
-
 .ghostnet-title-morph__char {
   display: inline-block;
   width: 1ch;
@@ -101,41 +26,6 @@
 .ghostnet-title-morph__char--glitch {
   text-shadow: 0 0 0.32rem rgba(93, 46, 255, 0.55), 0 0 0.14rem rgba(41, 243, 195, 0.35);
   filter: blur(0.038rem) contrast(1.06) saturate(1.05);
-}
-
-.pirate-access-button {
-  color: #F5F1FF;
-  transition: color 0.18s ease, transform 0.2s ease;
-}
-
-.pirate-access-button:hover,
-.pirate-access-button:focus-visible {
-  color: #5D2EFF;
-  transform: translateY(-0.1rem);
-}
-
-.pirate-access-icon {
-  display: inline-block;
-  font-size: 2.8rem;
-  line-height: 1;
-  transition: text-shadow 0.18s ease;
-}
-
-.pirate-access-button:hover .pirate-access-icon,
-.pirate-access-button:focus-visible .pirate-access-icon {
-  text-shadow: 0 0 0.75rem rgba(93, 46, 255, 0.55);
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }
 
 .pirate-password-overlay {
@@ -368,59 +258,83 @@
 }
 
 .ghostnet-nav-button--glitch-out {
-  --ghostnet-assimilation-glow-radius: 2.1rem;
-  --ghostnet-assimilation-glow-opacity: 0.62;
-  --ghostnet-assimilation-shift-x: 8px;
-  --ghostnet-assimilation-shift-y: -12px;
-  --ghostnet-assimilation-tilt: -2.4deg;
+  --ghostnet-assimilation-glow-radius: 1.9rem;
+  --ghostnet-assimilation-glow-opacity: 0.5;
+  --ghostnet-assimilation-shift-x: 4px;
+  --ghostnet-assimilation-shift-y: -6px;
+  --ghostnet-assimilation-tilt: -1.6deg;
+  animation: ghostnet-nav-button-glitch-out 0.72s steps(2, end) forwards;
 }
 
 .ghostnet-nav-button--glitch-in {
   position: relative;
   opacity: 0;
-  transform: scale(0.9) translate3d(0, -26px, 0);
-  filter: blur(3.2px) saturate(0.68) hue-rotate(-14deg);
-  --ghostnet-assimilation-glow-radius: 2.6rem;
-  --ghostnet-assimilation-glow-opacity: 0.7;
-  --ghostnet-assimilation-shift-x: 5px;
-  --ghostnet-assimilation-shift-y: -6px;
-  --ghostnet-assimilation-tilt: 1.8deg;
+  filter: blur(2.4px) saturate(0.72) hue-rotate(-10deg);
+  clip-path: inset(50% 0 40% 0);
+  --ghostnet-assimilation-glow-radius: 2.35rem;
+  --ghostnet-assimilation-glow-opacity: 0.65;
+  --ghostnet-assimilation-shift-x: 3px;
+  --ghostnet-assimilation-shift-y: -4px;
+  --ghostnet-assimilation-tilt: 1deg;
   animation:
-    ghostnet-nav-button-glitch-in 1.45s cubic-bezier(0.28, 0.73, 0.26, 1.02) forwards,
+    ghostnet-nav-button-glitch-in 1.15s cubic-bezier(0.3, 0.74, 0.24, 1.02) forwards,
     ghostnet-assimilation-jitter var(--ghostnet-assimilation-loop, 280ms) steps(2, end) infinite;
   animation-delay:
     var(--ghostnet-nav-glitch-delay, 0ms),
-    calc(var(--ghostnet-nav-glitch-delay, 0ms) + 1.1s);
+    calc(var(--ghostnet-nav-glitch-delay, 0ms) + 0.95s);
 }
 
 .ghostnet-nav-button--glitch-in::before {
-  opacity: 0.55;
+  opacity: 0.45;
+}
+
+@keyframes ghostnet-nav-button-glitch-out {
+  0% {
+    opacity: 1;
+    filter: none;
+  }
+  18% {
+    opacity: 0.35;
+    filter: blur(1.4px) saturate(1.2);
+  }
+  36% {
+    opacity: 0.82;
+    filter: blur(0.6px) saturate(1.08);
+  }
+  58% {
+    opacity: 0.2;
+    filter: blur(1.8px) saturate(0.74) hue-rotate(-4deg);
+  }
+  100% {
+    opacity: 0;
+    filter: blur(2.6px) saturate(0.62) hue-rotate(-6deg);
+  }
 }
 
 @keyframes ghostnet-nav-button-glitch-in {
   0% {
     opacity: 0;
-    transform: scale(0.9) translate3d(0, -26px, 0);
-    filter: blur(3.2px) saturate(0.68) hue-rotate(-14deg);
+    filter: blur(2.4px) saturate(0.72) hue-rotate(-10deg);
+    clip-path: inset(52% 0 42% 0);
   }
-  32% {
-    opacity: 0.38;
-    transform: scale(1.02) translate3d(0, -8px, 0);
-    filter: blur(2.1px) saturate(0.82) hue-rotate(-4deg);
+  24% {
+    opacity: 0.45;
+    filter: blur(1.6px) saturate(0.86) hue-rotate(-5deg);
+    clip-path: inset(0 0 38% 0);
   }
-  58% {
-    opacity: 0.85;
-    transform: scale(0.98) translate3d(0, 4px, 0);
-    filter: blur(1px) saturate(1.08) hue-rotate(3deg);
+  46% {
+    opacity: 0.88;
+    filter: blur(0.9px) saturate(1.12) hue-rotate(3deg);
+    clip-path: inset(12% 0 0 0);
   }
-  75% {
-    opacity: 0.95;
-    transform: scale(1.01) translate3d(0, -2px, 0);
-    filter: blur(0.42px) saturate(1.04) hue-rotate(0deg);
+  64% {
+    opacity: 0.6;
+    filter: blur(1.1px) saturate(1.18) hue-rotate(-2deg);
+    clip-path: inset(0 0 50% 0);
   }
   100% {
     opacity: 1;
-    transform: scale(1) translate3d(0, 0, 0);
     filter: none;
+    clip-path: inset(0);
   }
 }

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -165,11 +165,24 @@
 }
 
 .pirate-password-dialog--glitch {
-  animation: pirateDialogGlitch 1.1s ease forwards;
+  --ghostnet-assimilation-glow-radius: 2.4rem;
+  --ghostnet-assimilation-glow-opacity: 0.65;
+  --ghostnet-assimilation-shift-x: 6px;
+  --ghostnet-assimilation-shift-y: -5px;
+  --ghostnet-assimilation-tilt: -1.6deg;
+  animation: none !important;
 }
 
-.pirate-password-dialog::before {
-  content: '';
+.pirate-password-dialog--glitch.ghostnet-assimilation-target {
+  animation: none !important;
+}
+
+.pirate-password-dialog--glitch.ghostnet-assimilation-target::before {
+  opacity: 0.5;
+  z-index: 1;
+}
+
+.pirate-password-dialog__inner-frame {
   position: absolute;
   inset: 0.75rem;
   border-radius: 0.95rem;
@@ -181,14 +194,18 @@
   z-index: 0;
 }
 
-.pirate-password-dialog::after {
-  content: '';
+.pirate-password-dialog__surface-glow {
   position: absolute;
   inset: 0;
   background: linear-gradient(180deg, rgba(93, 46, 255, 0.24), transparent 28%);
   opacity: 0.55;
   pointer-events: none;
   z-index: 0;
+  transition: opacity 0.35s ease;
+}
+
+.pirate-password-dialog--glitch .pirate-password-dialog__surface-glow {
+  opacity: 0.2;
 }
 
 .pirate-password-dialog__chrome {
@@ -233,6 +250,12 @@
   gap: 1.4rem;
 }
 
+.pirate-password-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .pirate-password-title {
   font-size: 2.6rem;
   letter-spacing: 0.14em;
@@ -243,18 +266,25 @@
   font-size: 1.2rem;
   margin: 0 0 2rem 0;
   color: rgba(245, 241, 255, 0.68);
+  max-width: 24rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .pirate-password-label {
   display: block;
   font-size: 1rem;
   letter-spacing: 0.3em;
-  margin-bottom: 0.8rem;
+  margin: 0 auto 0.8rem;
+  width: 100%;
+  max-width: 25rem;
 }
 
 
 .pirate-password-input {
   width: 100%;
+  max-width: 25rem;
+  margin: 0 auto;
   padding: 1.1rem 1.5rem;
   font-size: 1.6rem;
   color: #F5F1FF;
@@ -279,6 +309,8 @@
 
 .pirate-password-submit {
   margin-top: 2rem;
+  width: 100%;
+  max-width: 17rem;
   padding: 1rem 2.6rem;
   font-size: 1.2rem;
   letter-spacing: 0.22em;
@@ -287,7 +319,9 @@
 
 .pirate-password-feedback {
   min-height: 2.4rem;
-  margin-top: 1.6rem;
+  margin: 1.6rem auto 0;
+  width: 100%;
+  max-width: 26rem;
   font-size: 1.1rem;
   letter-spacing: 0.12em;
   padding: 0.85rem 1rem;
@@ -327,33 +361,4 @@
   font-size: 1.8rem;
   letter-spacing: 0.2em;
   color: rgba(245, 241, 255, 0.88);
-}
-
-@keyframes pirateDialogGlitch {
-  0% {
-    transform: translate3d(0, 0, 0) scale(1);
-    opacity: 1;
-    filter: none;
-  }
-  20% {
-    transform: translate3d(-4px, 3px, 0) skewX(-3deg);
-  }
-  40% {
-    transform: translate3d(6px, -4px, 0) skewX(2deg);
-    clip-path: inset(0 0 38% 0);
-  }
-  60% {
-    transform: translate3d(-8px, 4px, 0) scale(1.02) skewX(-6deg);
-    opacity: 0.7;
-  }
-  80% {
-    transform: translate3d(10px, -8px, 0) scale(0.96) skewX(4deg);
-    opacity: 0.4;
-    filter: hue-rotate(-40deg) saturate(1.3);
-  }
-  100% {
-    transform: translate3d(-80px, 42px, 0) scale(1.2) skewX(-18deg);
-    opacity: 0;
-    filter: blur(0.4rem);
-  }
 }

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -28,7 +28,7 @@
   filter: blur(0.038rem) contrast(1.06) saturate(1.05);
 }
 
-.pirate-password-overlay {
+.pirate-cipher-overlay {
   position: fixed;
   inset: 0;
   display: flex;
@@ -39,7 +39,7 @@
   backdrop-filter: blur(0.2rem);
 }
 
-.pirate-password-dialog {
+.pirate-cipher-dialog {
   position: relative;
   width: min(90vw, 38rem);
   padding: 3.6rem 3.2rem 3.1rem;
@@ -54,7 +54,7 @@
   overflow: hidden;
 }
 
-.pirate-password-dialog--glitch {
+.pirate-cipher-dialog--glitch {
   --ghostnet-assimilation-glow-radius: 2.4rem;
   --ghostnet-assimilation-glow-opacity: 0.65;
   --ghostnet-assimilation-shift-x: 6px;
@@ -63,16 +63,16 @@
   animation: none !important;
 }
 
-.pirate-password-dialog--glitch.ghostnet-assimilation-target {
+.pirate-cipher-dialog--glitch.ghostnet-assimilation-target {
   animation: none !important;
 }
 
-.pirate-password-dialog--glitch.ghostnet-assimilation-target::before {
+.pirate-cipher-dialog--glitch.ghostnet-assimilation-target::before {
   opacity: 0.5;
   z-index: 1;
 }
 
-.pirate-password-dialog__inner-frame {
+.pirate-cipher-dialog__inner-frame {
   position: absolute;
   inset: 0.75rem;
   border-radius: 0.95rem;
@@ -84,7 +84,7 @@
   z-index: 0;
 }
 
-.pirate-password-dialog__surface-glow {
+.pirate-cipher-dialog__surface-glow {
   position: absolute;
   inset: 0;
   background: linear-gradient(180deg, rgba(93, 46, 255, 0.24), transparent 28%);
@@ -94,11 +94,11 @@
   transition: opacity 0.35s ease;
 }
 
-.pirate-password-dialog--glitch .pirate-password-dialog__surface-glow {
+.pirate-cipher-dialog--glitch .pirate-cipher-dialog__surface-glow {
   opacity: 0.2;
 }
 
-.pirate-password-dialog__chrome {
+.pirate-cipher-dialog__chrome {
   position: absolute;
   top: 1.1rem;
   left: 1.5rem;
@@ -112,7 +112,7 @@
   z-index: 1;
 }
 
-.pirate-password-dialog__chrome-light {
+.pirate-cipher-dialog__chrome-light {
   width: 0.7rem;
   height: 0.7rem;
   border-radius: 50%;
@@ -120,19 +120,19 @@
   opacity: 0.88;
 }
 
-.pirate-password-dialog__chrome-light--primary {
+.pirate-cipher-dialog__chrome-light--primary {
   color: rgba(41, 243, 195, 0.95);
 }
 
-.pirate-password-dialog__chrome-light--secondary {
+.pirate-cipher-dialog__chrome-light--secondary {
   color: rgba(93, 46, 255, 0.85);
 }
 
-.pirate-password-dialog__chrome-light--tertiary {
+.pirate-cipher-dialog__chrome-light--tertiary {
   color: rgba(255, 95, 193, 0.9);
 }
 
-.pirate-password-dialog__body {
+.pirate-cipher-dialog__body {
   position: relative;
   z-index: 2;
   display: flex;
@@ -140,19 +140,19 @@
   gap: 1.4rem;
 }
 
-.pirate-password-form {
+.pirate-cipher-form {
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-.pirate-password-title {
+.pirate-cipher-title {
   font-size: 2.6rem;
   letter-spacing: 0.14em;
   margin-bottom: 1rem;
 }
 
-.pirate-password-subtitle {
+.pirate-cipher-subtitle {
   font-size: 1.2rem;
   margin: 0 0 2rem 0;
   color: rgba(245, 241, 255, 0.68);
@@ -161,43 +161,47 @@
   margin-right: auto;
 }
 
-.pirate-password-label {
+.pirate-cipher-label {
   display: block;
-  font-size: 1rem;
-  letter-spacing: 0.3em;
+  font-size: 1.2rem;
+  letter-spacing: 0.4em;
   margin: 0 auto 0.8rem;
   width: 100%;
   max-width: 25rem;
 }
 
 
-.pirate-password-input {
+.pirate-cipher-input {
   width: 100%;
   max-width: 25rem;
   margin: 0 auto;
-  padding: 1.1rem 1.5rem;
-  font-size: 1.6rem;
+  padding: 1.4rem 2rem;
+  font-size: 3.2rem;
+  font-weight: 600;
+  line-height: 1;
   color: #F5F1FF;
   background: rgba(13, 11, 26, 0.9);
   border: 1px solid rgba(140, 92, 255, 0.42);
   border-radius: 0.9rem;
-  letter-spacing: 0.3em;
+  letter-spacing: 0.6em;
   text-align: center;
+  text-transform: uppercase;
   box-shadow: inset 0 0 0.8rem rgba(93, 46, 255, 0.18);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  caret-color: #29F3C3;
 }
 
-.pirate-password-input:focus {
+.pirate-cipher-input:focus {
   outline: none;
   border-color: #29F3C3;
   box-shadow: 0 0 0 0.2rem rgba(41, 243, 195, 0.3);
 }
 
-.pirate-password-input--error {
+.pirate-cipher-input--error {
   border-color: #FF5FC1;
 }
 
-.pirate-password-submit {
+.pirate-cipher-submit {
   margin-top: 2rem;
   width: 100%;
   max-width: 17rem;
@@ -207,7 +211,7 @@
   box-shadow: 0 0 1.2rem rgba(93, 46, 255, 0.35);
 }
 
-.pirate-password-feedback {
+.pirate-cipher-feedback {
   min-height: 2.4rem;
   margin: 1.6rem auto 0;
   width: 100%;
@@ -221,19 +225,19 @@
   box-shadow: inset 0 0 0.9rem rgba(93, 46, 255, 0.22);
 }
 
-.pirate-password-feedback:empty {
+.pirate-cipher-feedback:empty {
   display: none;
 }
 
-.pirate-password-feedback--error {
+.pirate-cipher-feedback--error {
   color: #FF5FC1;
 }
 
-.pirate-password-feedback--locked {
+.pirate-cipher-feedback--locked {
   color: #FF5FC1;
 }
 
-.pirate-password-success {
+.pirate-cipher-success {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -241,13 +245,13 @@
   gap: 1.5rem;
 }
 
-.pirate-password-success__icon {
+.pirate-cipher-success__icon {
   font-size: 6rem;
   color: #29F3C3;
   text-shadow: 0 0 1.8rem rgba(41, 243, 195, 0.55);
 }
 
-.pirate-password-success__text {
+.pirate-cipher-success__text {
   font-size: 1.8rem;
   letter-spacing: 0.2em;
   color: rgba(245, 241, 255, 0.88);
@@ -255,6 +259,14 @@
 
 .button-group--nav-unlock-animating {
   pointer-events: none;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.button-group--nav-unlock-animating button {
+  width: auto;
+  flex: 1 1 0;
+  transition: flex-basis 0.45s ease, width 0.45s ease;
 }
 
 .ghostnet-nav-button--glitch-phase {
@@ -272,6 +284,7 @@
   --ghostnet-assimilation-ghost-loop: 360ms;
   --ghostnet-assimilation-ghost-opacity: 0.4;
   --ghostnet-assimilation-saturation: 1.25;
+  transform-origin: center;
 }
 
 .ghostnet-nav-button--glitch-phase::before {
@@ -291,6 +304,7 @@
   --ghostnet-assimilation-shift-x: 4px;
   --ghostnet-assimilation-shift-y: -6px;
   --ghostnet-assimilation-tilt: -1.6deg;
+  transform: scale(0.94) translateY(0);
   animation:
     ghostnet-nav-button-glitch-out 0.72s steps(2, end) forwards,
     ghostnet-assimilation-jitter var(--ghostnet-assimilation-loop, 280ms) steps(2, end) infinite;
@@ -300,6 +314,7 @@
   opacity: 0;
   filter: blur(2.4px) saturate(0.72) hue-rotate(-10deg);
   clip-path: inset(50% 0 40% 0);
+  transform: scale(0.68) translateY(16px);
   --ghostnet-assimilation-glow-radius: 2.35rem;
   --ghostnet-assimilation-glow-opacity: 0.65;
   --ghostnet-assimilation-shift-x: 3px;
@@ -317,26 +332,38 @@
   opacity: 0.45;
 }
 
+.ghostnet-nav-button--unlock {
+  --ghostnet-assimilation-glow-radius: 2.7rem;
+  --ghostnet-assimilation-glow-opacity: 0.75;
+  --ghostnet-assimilation-loop: 230ms;
+  --ghostnet-nav-glitch-delay: 320ms;
+}
+
 @keyframes ghostnet-nav-button-glitch-out {
   0% {
     opacity: 1;
     filter: none;
+    transform: scale(1) translateY(0);
   }
   18% {
     opacity: 0.35;
     filter: blur(1.4px) saturate(1.2);
+    transform: scale(0.92) translateY(-6px);
   }
   36% {
     opacity: 0.82;
     filter: blur(0.6px) saturate(1.08);
+    transform: scale(0.85) translateY(-3px);
   }
   58% {
     opacity: 0.2;
     filter: blur(1.8px) saturate(0.74) hue-rotate(-4deg);
+    transform: scale(0.74) translateY(-10px);
   }
   100% {
     opacity: 0;
     filter: blur(2.6px) saturate(0.62) hue-rotate(-6deg);
+    transform: scale(0.68) translateY(-14px);
   }
 }
 
@@ -345,25 +372,30 @@
     opacity: 0;
     filter: blur(2.4px) saturate(0.72) hue-rotate(-10deg);
     clip-path: inset(52% 0 42% 0);
+    transform: scale(0.6) translateY(12px);
   }
   24% {
     opacity: 0.45;
     filter: blur(1.6px) saturate(0.86) hue-rotate(-5deg);
     clip-path: inset(0 0 38% 0);
+    transform: scale(0.74) translateY(6px);
   }
   46% {
     opacity: 0.88;
     filter: blur(0.9px) saturate(1.12) hue-rotate(3deg);
     clip-path: inset(12% 0 0 0);
+    transform: scale(0.92) translateY(2px);
   }
   64% {
     opacity: 0.6;
     filter: blur(1.1px) saturate(1.18) hue-rotate(-2deg);
     clip-path: inset(0 0 50% 0);
+    transform: scale(0.84) translateY(-2px);
   }
   100% {
     opacity: 1;
     filter: none;
     clip-path: inset(0);
+    transform: scale(1) translateY(0);
   }
 }

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -269,6 +269,40 @@
   transition: flex-basis 0.45s ease, width 0.45s ease;
 }
 
+.ghostnet-nav-stack {
+  position: relative;
+  width: 100%;
+  min-height: 3.8rem;
+}
+
+.ghostnet-nav-track {
+  display: flex;
+  gap: inherit;
+  width: 100%;
+}
+
+.ghostnet-nav-track--overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.ghostnet-nav-track--overlay button {
+  pointer-events: none;
+}
+
+.ghostnet-nav-track--post {
+  position: relative;
+}
+
+.ghostnet-nav-track--glitching {
+  pointer-events: none;
+}
+
+.ghostnet-nav-track--glitching button {
+  pointer-events: none;
+}
+
 .ghostnet-nav-button--glitch-phase {
   position: relative;
   color: rgba(245, 241, 255, 0.84) !important;

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -362,3 +362,65 @@
   letter-spacing: 0.2em;
   color: rgba(245, 241, 255, 0.88);
 }
+
+.button-group--nav-unlock-animating {
+  pointer-events: none;
+}
+
+.ghostnet-nav-button--glitch-out {
+  --ghostnet-assimilation-glow-radius: 2.1rem;
+  --ghostnet-assimilation-glow-opacity: 0.62;
+  --ghostnet-assimilation-shift-x: 8px;
+  --ghostnet-assimilation-shift-y: -12px;
+  --ghostnet-assimilation-tilt: -2.4deg;
+}
+
+.ghostnet-nav-button--glitch-in {
+  position: relative;
+  opacity: 0;
+  transform: scale(0.9) translate3d(0, -26px, 0);
+  filter: blur(3.2px) saturate(0.68) hue-rotate(-14deg);
+  --ghostnet-assimilation-glow-radius: 2.6rem;
+  --ghostnet-assimilation-glow-opacity: 0.7;
+  --ghostnet-assimilation-shift-x: 5px;
+  --ghostnet-assimilation-shift-y: -6px;
+  --ghostnet-assimilation-tilt: 1.8deg;
+  animation:
+    ghostnet-nav-button-glitch-in 1.45s cubic-bezier(0.28, 0.73, 0.26, 1.02) forwards,
+    ghostnet-assimilation-jitter var(--ghostnet-assimilation-loop, 280ms) steps(2, end) infinite;
+  animation-delay:
+    var(--ghostnet-nav-glitch-delay, 0ms),
+    calc(var(--ghostnet-nav-glitch-delay, 0ms) + 1.1s);
+}
+
+.ghostnet-nav-button--glitch-in::before {
+  opacity: 0.55;
+}
+
+@keyframes ghostnet-nav-button-glitch-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.9) translate3d(0, -26px, 0);
+    filter: blur(3.2px) saturate(0.68) hue-rotate(-14deg);
+  }
+  32% {
+    opacity: 0.38;
+    transform: scale(1.02) translate3d(0, -8px, 0);
+    filter: blur(2.1px) saturate(0.82) hue-rotate(-4deg);
+  }
+  58% {
+    opacity: 0.85;
+    transform: scale(0.98) translate3d(0, 4px, 0);
+    filter: blur(1px) saturate(1.08) hue-rotate(3deg);
+  }
+  75% {
+    opacity: 0.95;
+    transform: scale(1.01) translate3d(0, -2px, 0);
+    filter: blur(0.42px) saturate(1.04) hue-rotate(0deg);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translate3d(0, 0, 0);
+    filter: none;
+  }
+}

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -285,6 +285,38 @@
   --ghostnet-assimilation-ghost-opacity: 0.4;
   --ghostnet-assimilation-saturation: 1.25;
   transform-origin: center;
+  --ghostnet-nav-glitch-out-delay: 0ms;
+  --ghostnet-nav-glitch-out-duration: 720ms;
+  --ghostnet-nav-glitch-in-delay: 0ms;
+  --ghostnet-nav-glitch-in-duration: 1150ms;
+  --ghostnet-nav-glitch-out-scale-a: 0.92;
+  --ghostnet-nav-glitch-out-scale-b: 0.85;
+  --ghostnet-nav-glitch-out-scale-c: 0.74;
+  --ghostnet-nav-glitch-out-scale-d: 0.68;
+  --ghostnet-nav-glitch-out-translate-a: -6px;
+  --ghostnet-nav-glitch-out-translate-b: -3px;
+  --ghostnet-nav-glitch-out-translate-c: -10px;
+  --ghostnet-nav-glitch-out-translate-d: -14px;
+  --ghostnet-nav-glitch-out-opacity-a: 0.35;
+  --ghostnet-nav-glitch-out-opacity-b: 0.82;
+  --ghostnet-nav-glitch-out-opacity-c: 0.2;
+  --ghostnet-nav-glitch-out-opacity-d: 0;
+  --ghostnet-nav-glitch-in-scale-start: 0.6;
+  --ghostnet-nav-glitch-in-scale-mid-a: 0.74;
+  --ghostnet-nav-glitch-in-scale-mid-b: 0.92;
+  --ghostnet-nav-glitch-in-scale-mid-c: 0.84;
+  --ghostnet-nav-glitch-in-translate-start: 12px;
+  --ghostnet-nav-glitch-in-translate-a: 6px;
+  --ghostnet-nav-glitch-in-translate-b: 2px;
+  --ghostnet-nav-glitch-in-translate-c: -2px;
+  --ghostnet-nav-glitch-in-clip-start-top: 52%;
+  --ghostnet-nav-glitch-in-clip-start-bottom: 42%;
+  --ghostnet-nav-glitch-in-clip-mid-top-a: 0%;
+  --ghostnet-nav-glitch-in-clip-mid-bottom-a: 38%;
+  --ghostnet-nav-glitch-in-clip-mid-top-b: 12%;
+  --ghostnet-nav-glitch-in-clip-mid-bottom-b: 0%;
+  --ghostnet-nav-glitch-in-clip-mid-top-c: 0%;
+  --ghostnet-nav-glitch-in-clip-mid-bottom-c: 50%;
 }
 
 .ghostnet-nav-button--glitch-phase::before {
@@ -306,26 +338,30 @@
   --ghostnet-assimilation-tilt: -1.6deg;
   transform: scale(0.94) translateY(0);
   animation:
-    ghostnet-nav-button-glitch-out 0.72s steps(2, end) forwards,
+    ghostnet-nav-button-glitch-out var(--ghostnet-nav-glitch-out-duration, 720ms) steps(2, end) forwards,
     ghostnet-assimilation-jitter var(--ghostnet-assimilation-loop, 280ms) steps(2, end) infinite;
+  animation-delay:
+    var(--ghostnet-nav-glitch-out-delay, 0ms),
+    calc(var(--ghostnet-nav-glitch-out-delay, 0ms) + var(--ghostnet-assimilation-loop, 280ms) * 0.75);
 }
 
 .ghostnet-nav-button--glitch-in {
   opacity: 0;
   filter: blur(2.4px) saturate(0.72) hue-rotate(-10deg);
-  clip-path: inset(50% 0 40% 0);
-  transform: scale(0.68) translateY(16px);
+  clip-path: inset(var(--ghostnet-nav-glitch-in-clip-start-top, 52%) 0 var(--ghostnet-nav-glitch-in-clip-start-bottom, 42%) 0);
+  transform: scale(var(--ghostnet-nav-glitch-in-scale-start, 0.6))
+    translateY(var(--ghostnet-nav-glitch-in-translate-start, 12px));
   --ghostnet-assimilation-glow-radius: 2.35rem;
   --ghostnet-assimilation-glow-opacity: 0.65;
   --ghostnet-assimilation-shift-x: 3px;
   --ghostnet-assimilation-shift-y: -4px;
   --ghostnet-assimilation-tilt: 1deg;
   animation:
-    ghostnet-nav-button-glitch-in 1.15s cubic-bezier(0.3, 0.74, 0.24, 1.02) forwards,
+    ghostnet-nav-button-glitch-in var(--ghostnet-nav-glitch-in-duration, 1150ms) cubic-bezier(0.3, 0.74, 0.24, 1.02) forwards,
     ghostnet-assimilation-jitter var(--ghostnet-assimilation-loop, 280ms) steps(2, end) infinite;
   animation-delay:
-    var(--ghostnet-nav-glitch-delay, 0ms),
-    calc(var(--ghostnet-nav-glitch-delay, 0ms) + 0.95s);
+    var(--ghostnet-nav-glitch-in-delay, 0ms),
+    calc(var(--ghostnet-nav-glitch-in-delay, 0ms) + var(--ghostnet-nav-glitch-in-duration, 1150ms) * 0.7);
 }
 
 .ghostnet-nav-button--glitch-in::before {
@@ -336,7 +372,8 @@
   --ghostnet-assimilation-glow-radius: 2.7rem;
   --ghostnet-assimilation-glow-opacity: 0.75;
   --ghostnet-assimilation-loop: 230ms;
-  --ghostnet-nav-glitch-delay: 320ms;
+  --ghostnet-nav-glitch-in-delay: 320ms;
+  --ghostnet-nav-glitch-in-duration: 1280ms;
 }
 
 @keyframes ghostnet-nav-button-glitch-out {
@@ -346,24 +383,28 @@
     transform: scale(1) translateY(0);
   }
   18% {
-    opacity: 0.35;
+    opacity: var(--ghostnet-nav-glitch-out-opacity-a, 0.35);
     filter: blur(1.4px) saturate(1.2);
-    transform: scale(0.92) translateY(-6px);
+    transform: scale(var(--ghostnet-nav-glitch-out-scale-a, 0.92))
+      translateY(var(--ghostnet-nav-glitch-out-translate-a, -6px));
   }
   36% {
-    opacity: 0.82;
+    opacity: var(--ghostnet-nav-glitch-out-opacity-b, 0.82);
     filter: blur(0.6px) saturate(1.08);
-    transform: scale(0.85) translateY(-3px);
+    transform: scale(var(--ghostnet-nav-glitch-out-scale-b, 0.85))
+      translateY(var(--ghostnet-nav-glitch-out-translate-b, -3px));
   }
   58% {
-    opacity: 0.2;
+    opacity: var(--ghostnet-nav-glitch-out-opacity-c, 0.2);
     filter: blur(1.8px) saturate(0.74) hue-rotate(-4deg);
-    transform: scale(0.74) translateY(-10px);
+    transform: scale(var(--ghostnet-nav-glitch-out-scale-c, 0.74))
+      translateY(var(--ghostnet-nav-glitch-out-translate-c, -10px));
   }
   100% {
-    opacity: 0;
+    opacity: var(--ghostnet-nav-glitch-out-opacity-d, 0);
     filter: blur(2.6px) saturate(0.62) hue-rotate(-6deg);
-    transform: scale(0.68) translateY(-14px);
+    transform: scale(var(--ghostnet-nav-glitch-out-scale-d, 0.68))
+      translateY(var(--ghostnet-nav-glitch-out-translate-d, -14px));
   }
 }
 
@@ -371,26 +412,38 @@
   0% {
     opacity: 0;
     filter: blur(2.4px) saturate(0.72) hue-rotate(-10deg);
-    clip-path: inset(52% 0 42% 0);
-    transform: scale(0.6) translateY(12px);
+    clip-path: inset(
+      var(--ghostnet-nav-glitch-in-clip-start-top, 52%) 0 var(--ghostnet-nav-glitch-in-clip-start-bottom, 42%) 0
+    );
+    transform: scale(var(--ghostnet-nav-glitch-in-scale-start, 0.6))
+      translateY(var(--ghostnet-nav-glitch-in-translate-start, 12px));
   }
   24% {
     opacity: 0.45;
     filter: blur(1.6px) saturate(0.86) hue-rotate(-5deg);
-    clip-path: inset(0 0 38% 0);
-    transform: scale(0.74) translateY(6px);
+    clip-path: inset(
+      var(--ghostnet-nav-glitch-in-clip-mid-top-a, 0%) 0 var(--ghostnet-nav-glitch-in-clip-mid-bottom-a, 38%) 0
+    );
+    transform: scale(var(--ghostnet-nav-glitch-in-scale-mid-a, 0.74))
+      translateY(var(--ghostnet-nav-glitch-in-translate-a, 6px));
   }
   46% {
     opacity: 0.88;
     filter: blur(0.9px) saturate(1.12) hue-rotate(3deg);
-    clip-path: inset(12% 0 0 0);
-    transform: scale(0.92) translateY(2px);
+    clip-path: inset(
+      var(--ghostnet-nav-glitch-in-clip-mid-top-b, 12%) 0 var(--ghostnet-nav-glitch-in-clip-mid-bottom-b, 0%) 0
+    );
+    transform: scale(var(--ghostnet-nav-glitch-in-scale-mid-b, 0.92))
+      translateY(var(--ghostnet-nav-glitch-in-translate-b, 2px));
   }
   64% {
     opacity: 0.6;
     filter: blur(1.1px) saturate(1.18) hue-rotate(-2deg);
-    clip-path: inset(0 0 50% 0);
-    transform: scale(0.84) translateY(-2px);
+    clip-path: inset(
+      var(--ghostnet-nav-glitch-in-clip-mid-top-c, 0%) 0 var(--ghostnet-nav-glitch-in-clip-mid-bottom-c, 50%) 0
+    );
+    transform: scale(var(--ghostnet-nav-glitch-in-scale-mid-c, 0.84))
+      translateY(var(--ghostnet-nav-glitch-in-translate-c, -2px));
   }
   100% {
     opacity: 1;

--- a/src/client/css/ui/header.css
+++ b/src/client/css/ui/header.css
@@ -257,17 +257,46 @@
   pointer-events: none;
 }
 
+.ghostnet-nav-button--glitch-phase {
+  position: relative;
+  color: rgba(245, 241, 255, 0.84) !important;
+  border-color: rgba(140, 92, 255, 0.35) !important;
+  background: rgba(28, 22, 51, 0.72) !important;
+  box-shadow: 0 0 var(--ghostnet-assimilation-glow-radius, 1.5rem)
+    rgba(93, 46, 255, var(--ghostnet-assimilation-glow-opacity, 0.45));
+  filter: saturate(var(--ghostnet-assimilation-saturation, 1.25)) hue-rotate(-6deg);
+  transition: color 0.3s ease, background 0.4s ease, border-color 0.4s ease, opacity 0.45s ease, transform 0.4s ease,
+    filter 0.45s ease, box-shadow 0.45s ease;
+  overflow: hidden;
+  --ghostnet-assimilation-loop: 280ms;
+  --ghostnet-assimilation-ghost-loop: 360ms;
+  --ghostnet-assimilation-ghost-opacity: 0.4;
+  --ghostnet-assimilation-saturation: 1.25;
+}
+
+.ghostnet-nav-button--glitch-phase::before {
+  content: '';
+  position: absolute;
+  inset: -3px;
+  border: 1px solid rgba(93, 46, 255, 0.2);
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: var(--ghostnet-assimilation-ghost-opacity, 0.4);
+  animation: ghostnet-assimilation-ghost var(--ghostnet-assimilation-ghost-loop, 360ms) steps(2, end) infinite;
+}
+
 .ghostnet-nav-button--glitch-out {
   --ghostnet-assimilation-glow-radius: 1.9rem;
   --ghostnet-assimilation-glow-opacity: 0.5;
   --ghostnet-assimilation-shift-x: 4px;
   --ghostnet-assimilation-shift-y: -6px;
   --ghostnet-assimilation-tilt: -1.6deg;
-  animation: ghostnet-nav-button-glitch-out 0.72s steps(2, end) forwards;
+  animation:
+    ghostnet-nav-button-glitch-out 0.72s steps(2, end) forwards,
+    ghostnet-assimilation-jitter var(--ghostnet-assimilation-loop, 280ms) steps(2, end) infinite;
 }
 
 .ghostnet-nav-button--glitch-in {
-  position: relative;
   opacity: 0;
   filter: blur(2.4px) saturate(0.72) hue-rotate(-10deg);
   clip-path: inset(50% 0 40% 0);

--- a/src/client/lib/ghostnet-settings.js
+++ b/src/client/lib/ghostnet-settings.js
@@ -2,6 +2,7 @@ export const ASSIMILATION_DURATION_STORAGE_KEY = 'ghostnetAssimilationDuration'
 export const ASSIMILATION_DURATION_DEFAULT = 8
 export const ASSIMILATION_DURATION_MIN = 2
 export const ASSIMILATION_DURATION_MAX = 8
+export const GHOSTNET_NAV_UNLOCK_KEY = 'ghostnetNavUnlocked'
 
 function clampDuration (value) {
   if (!Number.isFinite(value)) return ASSIMILATION_DURATION_DEFAULT
@@ -34,4 +35,34 @@ export function saveAssimilationDurationSeconds (value) {
     }
   }
   return sanitized
+}
+
+function coerceBoolean (value) {
+  return value === true || value === 'true'
+}
+
+export function isGhostnetNavUnlocked () {
+  if (typeof window === 'undefined' || !window.localStorage) return false
+
+  try {
+    const stored = window.localStorage.getItem(GHOSTNET_NAV_UNLOCK_KEY)
+    return coerceBoolean(stored)
+  } catch (error) {
+    return false
+  }
+}
+
+export function setGhostnetNavUnlocked (unlocked) {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    try {
+      if (coerceBoolean(unlocked)) {
+        window.localStorage.setItem(GHOSTNET_NAV_UNLOCK_KEY, 'true')
+      } else {
+        window.localStorage.setItem(GHOSTNET_NAV_UNLOCK_KEY, 'false')
+      }
+    } catch (error) {
+      // Ignore storage write failures
+    }
+  }
+  return coerceBoolean(unlocked)
 }


### PR DESCRIPTION
## Summary
- add a security access icon to the header that summons a password challenge with success and failure feedback
- layer in dedicated styling, focus management, and glitch exit animation for the challenge overlay
- reuse the built-in shield glyph for the trigger and remove the custom pirate skull assets

## Testing
- npm test -- --runInBand *(fails: Ghost Net page heading expectation in existing test suite)*
- npm run build:client *(fails: Next.js SWC binary unavailable in container)*
- npm run start *(terminates after launching the service because the Next.js dev server cannot compile without the SWC binary)*

------
https://chatgpt.com/codex/tasks/task_e_68ded13f597c8323899d05f2fbd4ad97