### PR TITLE
Expand GhostNet INARA telemetry stream

### DIFF
--- a/src/client/lib/ghostnet-terminal-feed.js
+++ b/src/client/lib/ghostnet-terminal-feed.js
@@ -1,0 +1,61 @@
+const listeners = new Set()
+let requestCounter = 0
+
+function emit (event) {
+  listeners.forEach(listener => {
+    try {
+      listener(event)
+    } catch (err) {
+      // swallow listener errors so one subscriber doesn't break others
+      if (process.env.NODE_ENV === 'development') {
+        console.error('GhostNet terminal listener failed', err)
+      }
+    }
+  })
+}
+
+export function subscribeToGhostnetTerminal (listener) {
+  if (typeof listener !== 'function') return () => {}
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function createRequestId () {
+  const base = Date.now().toString(36)
+  const suffix = (requestCounter++).toString(36).padStart(3, '0')
+  const random = Math.random().toString(36).slice(2, 7)
+  return `inara-${base}-${suffix}-${random}`
+}
+
+export function beginInaraRequest (meta = {}) {
+  const id = createRequestId()
+  emit({
+    type: 'inara:start',
+    id,
+    meta: {
+      ...(meta && typeof meta === 'object' ? meta : {}),
+      timestamp: Date.now()
+    }
+  })
+  return id
+}
+
+export function completeInaraRequest (id, payload = {}) {
+  if (!id) return
+  emit({
+    type: 'inara:stream',
+    id,
+    payload
+  })
+}
+
+export function failInaraRequest (id, payload = {}) {
+  if (!id) return
+  emit({
+    type: 'inara:fail',
+    id,
+    payload
+  })
+}

--- a/src/client/pages/api/ghostnet-missions.js
+++ b/src/client/pages/api/ghostnet-missions.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch'
 import https from 'https'
 import { load } from 'cheerio'
+import { createGhostnetTransmission } from './ghostnet-transmission-utils.js'
 
 const BASE_URL = 'https://inara.cz'
 const MINING_MISSION_TYPE = 7
@@ -109,12 +110,18 @@ export default async function handler (req, res) {
 
     const html = await response.text()
     const missions = parseMissions(html, targetSystem)
+    const ghostnetTransmission = createGhostnetTransmission(html, {
+      url,
+      tag: 'missions',
+      meta: { targetSystem, missionCount: missions.length }
+    })
 
     res.status(200).json({
       missions,
       targetSystem,
       sourceUrl: url,
-      message: `Showing nearby mining mission factions near ${targetSystem}.`
+      message: `Showing nearby mining mission factions near ${targetSystem}.`,
+      ghostnetTransmission
     })
   } catch (error) {
     res.status(500).json({

--- a/src/client/pages/api/ghostnet-pristine-mining.js
+++ b/src/client/pages/api/ghostnet-pristine-mining.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch'
 import https from 'https'
 import { load } from 'cheerio'
+import { createGhostnetTransmission } from './ghostnet-transmission-utils.js'
 
 const BASE_URL = 'https://inara.cz'
 const ipv4HttpsAgent = new https.Agent({ family: 4 })
@@ -152,12 +153,18 @@ export default async function handler (req, res) {
 
     const html = await response.text()
     const locations = parseBodies(html, targetSystem)
+    const ghostnetTransmission = createGhostnetTransmission(html, {
+      url,
+      tag: 'pristine-mining',
+      meta: { targetSystem, locationCount: locations.length }
+    })
 
     res.status(200).json({
       locations,
       targetSystem,
       sourceUrl: url,
-      message: `Showing pristine mining locations within ${MAX_DISTANCE_LY} Ly of ${targetSystem}.`
+      message: `Showing pristine mining locations within ${MAX_DISTANCE_LY} Ly of ${targetSystem}.`,
+      ghostnetTransmission
     })
   } catch (error) {
     res.status(500).json({

--- a/src/client/pages/api/ghostnet-transmission-utils.js
+++ b/src/client/pages/api/ghostnet-transmission-utils.js
@@ -1,0 +1,112 @@
+const GLYPH_SAFE_REGEX = /[^\x09\x0A\x0D\x20-\x7E]/g
+const WHITESPACE_REGEX = /\s+/g
+const DEFAULT_MAX_STREAM_LENGTH = Number(process.env.ICARUS_GHOSTNET_STREAM_LIMIT || 1600)
+
+function ensureString (value) {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (Buffer.isBuffer(value)) {
+    try { return value.toString('utf8') } catch (err) { return value.toString() }
+  }
+  try {
+    return JSON.stringify(value)
+  } catch (err) {
+    return String(value)
+  }
+}
+
+function sanitizeGhostnetPayload (raw, { maxLength = DEFAULT_MAX_STREAM_LENGTH } = {}) {
+  const base = ensureString(raw)
+  const filtered = base.replace(GLYPH_SAFE_REGEX, '')
+  const collapsed = filtered.replace(WHITESPACE_REGEX, '')
+  if (maxLength > 0 && collapsed.length > maxLength) {
+    return collapsed.slice(0, maxLength)
+  }
+  return collapsed
+}
+
+function escapeXml (value = '') {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function buildGhostnetXmlSnapshot ({ sanitizedText, url = null, tag = 'response', meta = {} } = {}) {
+  const lines = []
+  lines.push(`<GhostNetTransmission tag="${escapeXml(tag)}">`)
+  lines.push(`  <Source>INARA</Source>`)
+  if (url) {
+    lines.push(`  <Endpoint>${escapeXml(url)}</Endpoint>`)
+  }
+  lines.push(`  <CapturedAt>${escapeXml(new Date().toISOString())}</CapturedAt>`)
+  lines.push(`  <Payload length="${sanitizedText.length}">`)
+  if (sanitizedText.length === 0) {
+    lines.push('    <Segment />')
+  } else {
+    const segmentSize = 96
+    for (let index = 0; index < sanitizedText.length; index += segmentSize) {
+      const segment = sanitizedText.slice(index, index + segmentSize)
+      lines.push(`    <Segment>${escapeXml(segment)}</Segment>`)
+    }
+  }
+  lines.push('  </Payload>')
+
+  const metaEntries = meta && typeof meta === 'object'
+    ? Object.entries(meta).filter(([, value]) => value !== null && value !== undefined)
+    : []
+  if (metaEntries.length > 0) {
+    lines.push('  <Meta>')
+    metaEntries.forEach(([key, value]) => {
+      const safeKey = String(key || '').replace(/[^a-zA-Z0-9_-]/g, '') || 'Field'
+      lines.push(`    <${safeKey}>${escapeXml(String(value))}</${safeKey}>`)
+    })
+    lines.push('  </Meta>')
+  }
+
+  lines.push('</GhostNetTransmission>')
+  return lines.join('\n')
+}
+
+export function createGhostnetTransmission (raw, { url = null, tag = 'response', meta = {}, maxLength } = {}) {
+  const sanitizedText = sanitizeGhostnetPayload(raw, { maxLength })
+  return {
+    sanitizedText,
+    xml: buildGhostnetXmlSnapshot({ sanitizedText, url, tag, meta }),
+    url,
+    tag,
+    meta: {
+      ...(meta && typeof meta === 'object' ? meta : {}),
+      length: sanitizedText.length
+    }
+  }
+}
+
+export function mergeGhostnetTransmissions (entries = [], { tag = 'batch' } = {}) {
+  const segments = Array.isArray(entries) ? entries.filter(Boolean) : []
+  if (segments.length === 0) return null
+  if (segments.length === 1) {
+    const [single] = segments
+    return { ...single, segments }
+  }
+
+  const sanitizedText = segments.map(segment => segment.sanitizedText || '').join('')
+  const xmlLines = ['<?xml version="1.0" encoding="UTF-8"?>', `<GhostNetTransmissionBatch tag="${escapeXml(tag)}">`]
+  segments.forEach(segment => {
+    const body = (segment.xml || '').split('\n').map(line => `  ${line}`).join('\n')
+    xmlLines.push(body)
+  })
+  xmlLines.push('</GhostNetTransmissionBatch>')
+
+  return {
+    sanitizedText,
+    xml: xmlLines.join('\n'),
+    segments
+  }
+}
+
+export function sanitizeGhostnetPayloadForPreview (raw, options = {}) {
+  return sanitizeGhostnetPayload(raw, options)
+}

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -54,6 +54,98 @@
   pointer-events: none;
 }
 
+.hero {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2.5rem;
+  margin-bottom: 2.75rem;
+  padding: 2.4rem 2.8rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--ghostnet-border-regular);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 82%, transparent);
+  box-shadow: 0 24px 48px -32px var(--ghostnet-shadow-deep);
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, color-mix(in srgb, var(--ghostnet-color-primary-light) 32%, transparent) 0%, transparent 55%),
+    radial-gradient(circle at bottom right, color-mix(in srgb, var(--ghostnet-color-primary-dark) 28%, transparent) 0%, transparent 60%);
+  opacity: 0.45;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.heroContent {
+  position: relative;
+  flex: 1 1 420px;
+  max-width: 640px;
+  z-index: 1;
+}
+
+.heroTitle {
+  font-size: clamp(2.4rem, 2.9vw, 3.1rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+  color: var(--ghostnet-ink);
+}
+
+.heroSubtitle {
+  margin: 0;
+  max-width: 52ch;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--ghostnet-text-soft);
+}
+
+.heroStatus {
+  position: relative;
+  flex: 0 1 280px;
+  border-radius: 1.1rem;
+  border: 1px solid var(--ghostnet-border-regular);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent);
+  box-shadow: 0 20px 36px -28px var(--ghostnet-shadow);
+  padding: 1.75rem 1.9rem;
+  z-index: 1;
+}
+
+.heroStatusList {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.heroStatusItem {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.85rem;
+  row-gap: 0.25rem;
+  align-items: baseline;
+}
+
+.heroStatusLabel {
+  margin: 0;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ghostnet-text-soft);
+}
+
+.heroStatusValue {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ghostnet-accent);
+}
+
 .arrival {
   animation: ghostnetArrivalSurface 4.2s cubic-bezier(0.45, 0, 0.2, 1) forwards;
 }


### PR DESCRIPTION
## Summary
- add a dedicated GhostNet status line when an INARA request begins streaming
- render the full sanitized INARA payload in phased glyph-to-text chunks before the XML dump
- introduce a helper to chunk sanitized payloads for the streaming overlay

## Testing
- npm test -- --runInBand
- npm run build:client *(fails: missing SWC binary for linux/x64)*
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68ded5fae2d08323bd0a16d038d77af4