### PR TITLE
Refine GhostNet assimilation timing

### DIFF
--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -601,7 +601,7 @@ body.ghostnet-assimilation-forced::after {
 body.ghostnet-assimilation-forced .ghostnet-assimilation-target,
 .ghostnet-assimilation-force-fade {
   opacity: 0;
-  transform: scale(0.95) translate3d(0, -14px, 0);
+  transform: scale(0.96) translate3d(0, -4px, 0);
   filter: blur(2px) saturate(0.6) hue-rotate(-4deg);
 }
 
@@ -651,7 +651,7 @@ body.ghostnet-assimilation-forced .ghostnet-assimilation-target::before,
 
 .ghostnet-assimilation-target.ghostnet-assimilation-remove {
   opacity: 0;
-  transform: scale(0.94) translate3d(0, -8px, 0);
+  transform: scale(0.945) translate3d(0, -3px, 0);
   filter: blur(3px) contrast(0.65) saturate(0.85);
 }
 
@@ -685,7 +685,7 @@ body.ghostnet-assimilation-forced .ghostnet-assimilation-target::before,
   }
   100% {
     opacity: 0;
-    transform: translate3d(0, -12px, 0) scale(0.55);
+    transform: translate3d(0, -6px, 0) scale(0.55);
     filter: blur(3px) hue-rotate(12deg);
   }
 }

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -651,7 +651,7 @@ body.ghostnet-assimilation-forced .ghostnet-assimilation-target::before,
 
 .ghostnet-assimilation-target.ghostnet-assimilation-remove {
   opacity: 0;
-  transform: scale(0.94) translate3d(0, -12px, 0);
+  transform: scale(0.94) translate3d(0, -8px, 0);
   filter: blur(3px) contrast(0.65) saturate(0.85);
 }
 
@@ -679,13 +679,13 @@ body.ghostnet-assimilation-forced .ghostnet-assimilation-target::before,
   }
   35% {
     opacity: 0.8;
-    transform: translate3d(var(--ghostnet-assimilation-shift-x, 2px), calc(var(--ghostnet-assimilation-shift-y, -2px)), 0)
+    transform: translate3d(var(--ghostnet-assimilation-shift-x, 2px), calc(var(--ghostnet-assimilation-shift-y, -1px)), 0)
       scale(1.05);
     filter: hue-rotate(-12deg) saturate(1.5);
   }
   100% {
     opacity: 0;
-    transform: translate3d(0, -18px, 0) scale(0.55);
+    transform: translate3d(0, -12px, 0) scale(0.55);
     filter: blur(3px) hue-rotate(12deg);
   }
 }

--- a/src/client/lib/ghostnet-assimilation.js
+++ b/src/client/lib/ghostnet-assimilation.js
@@ -25,9 +25,9 @@ const EFFECT_BLOCKED_CLASS_COMBINATIONS = [
   ['scrollable', 'layout__panel--secondary-navigation']
 ]
 const NAVIGATION_EXCLUSION_SELECTOR = '#primaryNavigation'
-const FORCED_FADE_CLEANUP_DELAY = 560
-const STABILIZATION_START_DELAY = 120
-const OVERLAY_REMOVAL_DELAY = 640
+const FORCED_FADE_CLEANUP_DELAY = 420
+const STABILIZATION_START_DELAY = 80
+const OVERLAY_REMOVAL_DELAY = 520
 const DEFAULT_EFFECT_DURATION = ASSIMILATION_DURATION_DEFAULT * 1000
 const MAX_CHARACTER_ANIMATIONS = 4800
 const MIN_TOP_LEVEL_GROUPS = 5
@@ -771,7 +771,9 @@ function scheduleJitter (element) {
   const amplitudeBase = 7
   const amplitude = amplitudeBase * (0.35 + intensity * 0.85)
   const shiftX = (Math.random() - 0.5) * amplitude
-  const verticalAttenuation = 0.6 - Math.min(0.25, eased * 0.35)
+  const verticalFloor = 0.02
+  const verticalRange = 0.12
+  const verticalAttenuation = verticalFloor + verticalRange * Math.pow(Math.max(intensity, 0), 1.2)
   const shiftY = (Math.random() - 0.5) * amplitude * verticalAttenuation
   const tilt = (Math.random() - 0.5) * (2.5 - intensity * 1.5)
   const saturation = 0.85 + intensity * 0.6

--- a/src/client/lib/ghostnet-assimilation.js
+++ b/src/client/lib/ghostnet-assimilation.js
@@ -25,9 +25,9 @@ const EFFECT_BLOCKED_CLASS_COMBINATIONS = [
   ['scrollable', 'layout__panel--secondary-navigation']
 ]
 const NAVIGATION_EXCLUSION_SELECTOR = '#primaryNavigation'
-const FORCED_FADE_CLEANUP_DELAY = 720
-const STABILIZATION_START_DELAY = 180
-const OVERLAY_REMOVAL_DELAY = 820
+const FORCED_FADE_CLEANUP_DELAY = 560
+const STABILIZATION_START_DELAY = 120
+const OVERLAY_REMOVAL_DELAY = 640
 const DEFAULT_EFFECT_DURATION = ASSIMILATION_DURATION_DEFAULT * 1000
 const MAX_CHARACTER_ANIMATIONS = 4800
 const MIN_TOP_LEVEL_GROUPS = 5
@@ -765,13 +765,14 @@ function scheduleJitter (element) {
 
   const elapsed = Math.max(0, performance.now() - assimilationStartTime)
   const progress = Math.min(1, elapsed / effectDurationMs)
-  const eased = Math.pow(progress, 1.45)
+  const eased = Math.pow(progress, 1.25)
   const intensity = Math.max(0, 1 - eased)
 
   const amplitudeBase = 7
   const amplitude = amplitudeBase * (0.35 + intensity * 0.85)
   const shiftX = (Math.random() - 0.5) * amplitude
-  const shiftY = (Math.random() - 0.5) * amplitude
+  const verticalAttenuation = 0.6 - Math.min(0.25, eased * 0.35)
+  const shiftY = (Math.random() - 0.5) * amplitude * verticalAttenuation
   const tilt = (Math.random() - 0.5) * (2.5 - intensity * 1.5)
   const saturation = 0.85 + intensity * 0.6
   const glowRadius = 0.75 + intensity * 1.35

--- a/src/client/lib/ghostnet-settings.js
+++ b/src/client/lib/ghostnet-settings.js
@@ -1,5 +1,5 @@
 export const ASSIMILATION_DURATION_STORAGE_KEY = 'ghostnetAssimilationDuration'
-export const ASSIMILATION_DURATION_DEFAULT = 6
+export const ASSIMILATION_DURATION_DEFAULT = 5
 export const ASSIMILATION_DURATION_MIN = 2
 export const ASSIMILATION_DURATION_MAX = 8
 

--- a/src/client/lib/ghostnet-settings.js
+++ b/src/client/lib/ghostnet-settings.js
@@ -1,5 +1,5 @@
 export const ASSIMILATION_DURATION_STORAGE_KEY = 'ghostnetAssimilationDuration'
-export const ASSIMILATION_DURATION_DEFAULT = 8
+export const ASSIMILATION_DURATION_DEFAULT = 6
 export const ASSIMILATION_DURATION_MIN = 2
 export const ASSIMILATION_DURATION_MAX = 8
 


### PR DESCRIPTION
## Summary
- soften the GhostNet assimilation overlay stabilization timings for a faster wrap-up
- dampen vertical jitter and text lift to calm the stabilization phase visuals
- shorten the default assimilation duration to accelerate the overall transition

## Testing
- npm test -- --runInBand --config jest.config.js *(fails: existing GhostNet hero heading assertion still unresolved)*
- npm run build:client *(fails: Next.js unable to load required SWC binary in container)*
- npm run start *(fails: proxy cannot reach Next.js dev server on port 3000 inside container)*

------
https://chatgpt.com/codex/tasks/task_e_68df187ecc148323b78c59841ef76b8c