### PR TITLE
Add Ghost Net engineering opportunities page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Ensure every UI adjustment remains responsive and accessible across a wide range of device sizes.
 - Where it adds value, introduce tasteful animations and micro-interactions to help the interface feel vibrant and alive.
 - Mirror the structural patterns and layout conventions of other Icarus pages so the product feels cohesive, while still honoring GhostNet's unique identity.
+- GhostNet pages must never render beneath the secondary navigation rail—always supply navigation items through the `<Panel>` component so it applies the `layout__panel--secondary-navigation` spacing instead of mounting `PanelNavigation` manually.
 - Keep data tables outside of `SectionFrame` containers; tables should rely on GhostNet table shells (`dataTableContainer`, `dataTable`) for structure instead of being nested inside section frames.
 - Table rows must never expand inline like a drawer. Selecting a row should always open a dedicated full-page view in the workspace, mirroring the behavior on the Find Trade Routes page. This ensures a clean experience on smaller displays.
 - Before introducing a new layout or page, inspect existing GhostNet surfaces and lift their structure directly—copy the baseline layout (navigation placement, section frames, typographic hierarchy, spacing rhythm) and adjust only the dynamic content. When in doubt, start from an existing component file and refactor it into shared primitives instead of authoring novel markup.

--- a/src/client/pages/api/ghostnet-engineer-workshop.js
+++ b/src/client/pages/api/ghostnet-engineer-workshop.js
@@ -1,0 +1,27 @@
+export default async function handler (req, res) {
+  const { marketId } = req.query
+
+  if (!marketId) {
+    res.status(400).json({ error: 'marketId is required' })
+    return
+  }
+
+  try {
+    const response = await fetch(`https://www.edsm.net/api-system-v1/stations/market?marketId=${encodeURIComponent(marketId)}`)
+    if (!response.ok) {
+      res.status(502).json({ error: 'Unable to fetch workshop details.' })
+      return
+    }
+
+    const data = await response.json()
+    const stationName = data?.sName || data?.station?.name || null
+    const systemName = data?.name || data?.system?.name || null
+
+    res.status(200).json({
+      stationName,
+      systemName
+    })
+  } catch (error) {
+    res.status(500).json({ error: 'Unable to fetch workshop details.' })
+  }
+}

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -3606,6 +3606,7 @@ export default function GhostnetPage() {
     { name: 'Commodity Trade', icon: 'cargo', active: activeTab === 'commodityTrade', onClick: () => setActiveTab('commodityTrade') },
     { name: 'Missions', icon: 'asteroid-base', active: activeTab === 'missions', onClick: () => setActiveTab('missions') },
     { name: 'Pristine Mining Locations', icon: 'planet-ringed', active: activeTab === 'pristineMining', onClick: () => setActiveTab('pristineMining') },
+    { name: 'Engineering Opportunities', icon: 'engineer', active: false, url: '/ghostnet/engineering' },
     { name: 'Search', icon: 'search', type: 'SEARCH', active: false }
 
   ]), [activeTab])

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -780,6 +780,117 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   margin-top: 0.45rem;
 }
 
+.opportunityIntro {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.opportunityName {
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+  font-size: 1.05rem;
+}
+
+.gradeBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--ghostnet-border-regular);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent);
+  color: var(--ghostnet-accent);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-top: 0.85rem;
+}
+
+.moduleTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.65rem;
+}
+
+.moduleTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 22%, transparent);
+  color: var(--ghostnet-text-soft);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.materialList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.materialItem {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.25rem;
+  align-items: baseline;
+}
+
+.materialName {
+  color: var(--ghostnet-ink);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.materialCount {
+  color: var(--ghostnet-muted);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+}
+
+.engineerList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.engineerItem {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.engineerName {
+  color: var(--ghostnet-ink);
+  font-weight: 600;
+}
+
+.engineerMeta {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+  color: var(--ghostnet-text-soft);
+  font-size: 0.85rem;
+}
+
+.engineerStatus {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ghostnet-muted);
+}
+
+.engineerStatusUnlocked {
+  color: var(--ghostnet-accent);
+}
+
 .tableIndicatorPlaceholder {
   color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   font-size: 0.82rem;

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -840,18 +840,24 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   justify-content: space-between;
   gap: 1.25rem;
   align-items: baseline;
+  flex-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .materialName {
   color: var(--ghostnet-ink);
   font-weight: 600;
   font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .materialCount {
   color: var(--ghostnet-muted);
   font-size: 0.85rem;
   letter-spacing: 0.08em;
+  flex-shrink: 0;
 }
 
 .engineerList {
@@ -865,6 +871,41 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 .engineerItem {
   display: grid;
   gap: 0.25rem;
+}
+
+.engineerStateLocked .engineerName,
+.engineerStateLocked .engineeringDetailEngineerName {
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 45%, transparent);
+}
+
+.engineerStateLocked .engineerMeta,
+.engineerStateLocked .engineeringDetailMetaValue,
+.engineerStateLocked .engineeringDetailEngineerProgress {
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 35%, transparent);
+}
+
+.engineerStateLocked .engineerStatus {
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 30%, transparent);
+}
+
+.engineerStateUnlocked .engineerStatus,
+.engineerStateUnlocked .engineeringDetailEngineerProgress {
+  color: var(--ghostnet-text-soft);
+}
+
+.engineerStateMastered .engineerName,
+.engineerStateMastered .engineeringDetailEngineerName {
+  color: var(--ghostnet-color-success);
+}
+
+.engineerStateMastered .engineerMeta,
+.engineerStateMastered .engineeringDetailMetaValue,
+.engineerStateMastered .engineeringDetailEngineerProgress {
+  color: color-mix(in srgb, var(--ghostnet-color-success) 70%, transparent);
+}
+
+.engineerStateMastered .engineerStatus {
+  color: var(--ghostnet-color-success);
 }
 
 .engineerName {
@@ -980,6 +1021,257 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   gap: 0.5rem;
   text-align: center;
   flex: 1;
+}
+
+.engineeringDetailContainer {
+  padding: 2.25rem 2.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.engineeringDetailBackRow {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.engineeringDetailStatus {
+  color: var(--ghostnet-text-soft);
+  font-size: 0.92rem;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 24%, transparent);
+  border-radius: 1.25rem;
+  padding: 1.25rem 1.75rem;
+}
+
+.engineeringDetailContent {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.engineeringDetailHeader {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2.25rem 2.5rem;
+  border-radius: 1.75rem;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--ghostnet-color-primary-dark) 78%, transparent),
+    color-mix(in srgb, var(--ghostnet-color-primary) 65%, transparent)
+  );
+  box-shadow: 0 1.75rem 3.5rem var(--ghostnet-shadow);
+}
+
+.engineeringDetailHeading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 40rem;
+}
+
+.engineeringDetailLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
+}
+
+.engineeringDetailTitle {
+  font-size: 2.25rem;
+  margin: 0;
+  color: var(--ghostnet-color-text-strong);
+  text-shadow: 0 0 1.5rem color-mix(in srgb, var(--ghostnet-color-primary) 55%, transparent);
+}
+
+.engineeringDetailSubtitle {
+  margin: 0;
+  color: var(--ghostnet-text-soft);
+  font-size: 0.92rem;
+}
+
+.engineeringDetailGrade {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.65rem;
+  text-align: right;
+}
+
+.engineeringDetailGradeLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.68rem;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 68%, transparent);
+}
+
+.engineeringDetailGradeValue {
+  font-size: 2.65rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--ghostnet-accent);
+  text-shadow: 0 0 1.65rem color-mix(in srgb, var(--ghostnet-color-primary) 60%, transparent);
+}
+
+.engineeringDetailGrid {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 1100px) {
+  .engineeringDetailGrid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+}
+
+.engineeringDetailSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 2rem 2.25rem;
+  border-radius: 1.5rem;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--ghostnet-color-primary-dark) 72%, transparent),
+    color-mix(in srgb, var(--ghostnet-color-background) 90%, transparent)
+  );
+  box-shadow: 0 1.35rem 2.75rem color-mix(in srgb, var(--ghostnet-shadow) 85%, transparent);
+}
+
+.engineeringDetailSectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.engineeringDetailSectionTitle {
+  margin: 0;
+  font-size: 1.15rem;
+  color: var(--ghostnet-color-text-strong);
+}
+
+.engineeringDetailSectionHint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ghostnet-text-soft);
+}
+
+.engineeringDetailMaterialList {
+  gap: 0.6rem;
+}
+
+.engineeringDetailFeatureList {
+  display: grid;
+  gap: 1rem;
+}
+
+.engineeringDetailFeatureItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1.25rem;
+}
+
+.engineeringDetailFeatureName {
+  color: var(--ghostnet-color-text-strong);
+  font-weight: 600;
+}
+
+.engineeringDetailFeatureValue {
+  color: var(--ghostnet-accent);
+  font-size: 0.92rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.engineeringDetailEngineerGrid {
+  display: grid;
+  gap: 1.75rem;
+}
+
+@media (min-width: 900px) {
+  .engineeringDetailEngineerGrid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+}
+
+.engineeringDetailEngineerCard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.75rem 1.9rem;
+  border-radius: 1.4rem;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 82%, transparent);
+  box-shadow: 0 1.25rem 2.25rem color-mix(in srgb, var(--ghostnet-shadow) 75%, transparent);
+}
+
+.engineeringDetailEngineerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+}
+
+.engineeringDetailEngineerIdentity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.engineeringDetailEngineerName {
+  margin: 0;
+  font-size: 1.25rem;
+  color: var(--ghostnet-color-text-strong);
+  font-weight: 600;
+}
+
+.engineeringDetailEngineerGradeBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
+  color: var(--ghostnet-text-soft);
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.engineeringDetailMetaGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.25rem 1.5rem;
+}
+
+.engineeringDetailMetaBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.engineeringDetailMetaLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.65rem;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
+}
+
+.engineeringDetailMetaValue {
+  color: var(--ghostnet-color-text-strong);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.engineeringDetailEngineerProgress {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--ghostnet-text-soft);
 }
 
 .routeDetailLabel {

--- a/src/client/pages/ghostnet/engineering-utils.js
+++ b/src/client/pages/ghostnet/engineering-utils.js
@@ -1,0 +1,134 @@
+import distance from '../../../shared/distance'
+
+const NAVIGATION_ITEMS = [
+  { key: 'ghostnet', name: 'Ghost Net', icon: 'route', url: '/ghostnet' },
+  { key: 'engineering', name: 'Engineering Opportunities', icon: 'engineer', url: '/ghostnet/engineering' },
+  { key: 'search', name: 'Search', icon: 'search', url: '/ghostnet/search' },
+  { key: 'outfitting', name: 'Outfitting', icon: 'wrench', url: '/ghostnet/outfitting' }
+]
+
+export const MATERIAL_EVENTS = new Set([
+  'Materials',
+  'MaterialCollected',
+  'MaterialDiscarded',
+  'MaterialTrade',
+  'EngineerCraft'
+])
+
+export const TRAVEL_EVENTS = new Set(['Location', 'FSDJump'])
+
+export function getEngineeringNavigation (activeKey = 'engineering') {
+  return NAVIGATION_ITEMS.map(item => ({
+    ...item,
+    active: item.key === activeKey
+  }))
+}
+
+export function formatNumber (value) {
+  if (typeof value !== 'number') return '0'
+  return value.toLocaleString(undefined, { maximumFractionDigits: 0 })
+}
+
+export function normaliseBlueprintSymbol (symbol) {
+  return typeof symbol === 'string' ? symbol.trim().toLowerCase() : ''
+}
+
+export function createCraftableBlueprintSummary (blueprints = []) {
+  const summaries = []
+
+  blueprints.forEach(blueprint => {
+    const grades = Array.isArray(blueprint?.grades) ? [...blueprint.grades] : []
+    grades.sort((a, b) => a.grade - b.grade)
+
+    let craftableGrade = null
+    grades.forEach(grade => {
+      if (!Array.isArray(grade?.components)) return
+      const canCraft = grade.components.every(component => {
+        const cost = Number(component?.cost) || 0
+        const count = Number(component?.count) || 0
+        return count >= cost
+      })
+
+      if (canCraft) {
+        craftableGrade = {
+          ...grade,
+          components: grade.components.map(component => ({
+            ...component,
+            cost: Number(component?.cost) || 0,
+            count: Number(component?.count) || 0
+          }))
+        }
+      }
+    })
+
+    if (!craftableGrade) return
+
+    const engineerEntries = Object.entries(blueprint?.engineers || {}).map(([name, info]) => ({
+      name,
+      grades: Array.isArray(info?.grades) ? info.grades : [],
+      system: info?.system || '',
+      location: info?.location,
+      progress: info?.progress || '',
+      rank: typeof info?.rank === 'number' ? info.rank : 0,
+      marketId: info?.marketId || null
+    }))
+
+    const capableEngineers = engineerEntries.filter(engineer =>
+      engineer.grades.some(grade => Number(grade) >= craftableGrade.grade)
+    )
+
+    if (capableEngineers.length === 0) return
+
+    const unlockedEngineers = capableEngineers.filter(engineer => engineer.rank > 0)
+
+    summaries.push({
+      blueprint,
+      grade: craftableGrade,
+      engineers: unlockedEngineers.length > 0 ? unlockedEngineers : capableEngineers
+    })
+  })
+
+  return summaries
+}
+
+export function getEngineerProgressState (engineer, targetGrade) {
+  const grades = Array.isArray(engineer?.grades)
+    ? engineer.grades.map(grade => Number(grade)).filter(value => !Number.isNaN(value))
+    : []
+
+  const highestGradeOffered = grades.length > 0 ? Math.max(...grades) : 0
+  const rank = typeof engineer?.rank === 'number' ? engineer.rank : 0
+  const normalisedTarget = Number(targetGrade) || 0
+  const hasUnlocked = rank > 0
+  const workshopMastered = hasUnlocked && highestGradeOffered > 0 && rank >= highestGradeOffered
+
+  let state = 'locked'
+  let label = engineer?.progress || 'Not yet unlocked'
+
+  if (workshopMastered) {
+    state = 'mastered'
+    label = 'All grades unlocked'
+  } else if (hasUnlocked) {
+    state = 'unlocked'
+    if (normalisedTarget > 0) {
+      if (rank >= normalisedTarget) {
+        label = `Ready for Grade ${normalisedTarget}`
+      } else if (highestGradeOffered > 0) {
+        label = `Grade ${rank} unlocked`
+      } else {
+        label = `Unlocked`
+      }
+    } else {
+      label = `Grade ${rank} unlocked`
+    }
+  }
+
+  return { state, label, highestGradeOffered, rank }
+}
+
+export function getEngineerDistanceLy (currentSystem, engineer) {
+  const hasLocation = Array.isArray(engineer?.location) && engineer.location.length === 3
+  if (!hasLocation || !currentSystem?.position) return null
+  const ly = distance(currentSystem.position, engineer.location)
+  return Number.isFinite(ly) ? ly : null
+}

--- a/src/client/pages/ghostnet/engineering-utils.js
+++ b/src/client/pages/ghostnet/engineering-utils.js
@@ -1,12 +1,5 @@
 import distance from '../../../shared/distance'
 
-const NAVIGATION_ITEMS = [
-  { key: 'ghostnet', name: 'Ghost Net', icon: 'route', url: '/ghostnet' },
-  { key: 'engineering', name: 'Engineering Opportunities', icon: 'engineer', url: '/ghostnet/engineering' },
-  { key: 'search', name: 'Search', icon: 'search', url: '/ghostnet/search' },
-  { key: 'outfitting', name: 'Outfitting', icon: 'wrench', url: '/ghostnet/outfitting' }
-]
-
 export const MATERIAL_EVENTS = new Set([
   'Materials',
   'MaterialCollected',
@@ -16,13 +9,6 @@ export const MATERIAL_EVENTS = new Set([
 ])
 
 export const TRAVEL_EVENTS = new Set(['Location', 'FSDJump'])
-
-export function getEngineeringNavigation (activeKey = 'engineering') {
-  return NAVIGATION_ITEMS.map(item => ({
-    ...item,
-    active: item.key === activeKey
-  }))
-}
 
 export function formatNumber (value) {
   if (typeof value !== 'number') return '0'

--- a/src/client/pages/ghostnet/engineering.js
+++ b/src/client/pages/ghostnet/engineering.js
@@ -1,0 +1,322 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import Layout from 'components/layout'
+import Panel from 'components/panel'
+import PanelNavigation from 'components/panel-navigation'
+import { useSocket, sendEvent, eventListener } from 'lib/socket'
+import distance from '../../../shared/distance'
+import styles from '../ghostnet.module.css'
+
+const NAV_ITEMS = [
+  { name: 'Ghost Net', icon: 'route', url: '/ghostnet', active: false },
+  { name: 'Engineering Opportunities', icon: 'engineer', url: '/ghostnet/engineering', active: true },
+  { name: 'Search', icon: 'search', url: '/ghostnet/search', active: false },
+  { name: 'Outfitting', icon: 'wrench', url: '/ghostnet/outfitting', active: false }
+]
+
+const MATERIAL_EVENTS = new Set([
+  'Materials',
+  'MaterialCollected',
+  'MaterialDiscarded',
+  'MaterialTrade',
+  'EngineerCraft'
+])
+
+const TRAVEL_EVENTS = new Set(['Location', 'FSDJump'])
+
+function formatNumber (value) {
+  if (typeof value !== 'number') return '0'
+  return value.toLocaleString(undefined, { maximumFractionDigits: 0 })
+}
+
+function createCraftableBlueprintSummary (blueprints = []) {
+  const summaries = []
+
+  blueprints.forEach(blueprint => {
+    const grades = Array.isArray(blueprint?.grades) ? [...blueprint.grades] : []
+    grades.sort((a, b) => a.grade - b.grade)
+
+    let craftableGrade = null
+    grades.forEach(grade => {
+      if (!Array.isArray(grade.components)) return
+      const canCraft = grade.components.every(component => {
+        const cost = Number(component?.cost) || 0
+        const count = Number(component?.count) || 0
+        return count >= cost
+      })
+
+      if (canCraft) {
+        craftableGrade = {
+          ...grade,
+          components: grade.components.map(component => ({
+            ...component,
+            cost: Number(component?.cost) || 0,
+            count: Number(component?.count) || 0
+          }))
+        }
+      }
+    })
+
+    if (!craftableGrade) return
+
+    const engineerEntries = Object.entries(blueprint?.engineers || {}).map(([name, info]) => ({
+      name,
+      grades: Array.isArray(info?.grades) ? info.grades : [],
+      system: info?.system || '',
+      location: info?.location,
+      progress: info?.progress || '',
+      rank: typeof info?.rank === 'number' ? info.rank : 0
+    }))
+
+    const capableEngineers = engineerEntries.filter(engineer =>
+      engineer.grades.some(grade => grade >= craftableGrade.grade)
+    )
+
+    if (capableEngineers.length === 0) return
+
+    const unlockedEngineers = capableEngineers.filter(engineer => engineer.rank > 0)
+
+    summaries.push({
+      blueprint,
+      grade: craftableGrade,
+      engineers: unlockedEngineers.length > 0 ? unlockedEngineers : capableEngineers
+    })
+  })
+
+  return summaries
+}
+
+export default function GhostnetEngineeringOpportunitiesPage () {
+  const { connected, active, ready } = useSocket()
+  const [craftable, setCraftable] = useState([])
+  const [currentSystem, setCurrentSystem] = useState(null)
+  const [componentReady, setComponentReady] = useState(false)
+
+  const recomputeCraftable = useCallback((nextBlueprints) => {
+    const summaries = createCraftableBlueprintSummary(nextBlueprints)
+    setCraftable(summaries)
+  }, [])
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || !document.body) return undefined
+    document.body.classList.add('ghostnet-theme')
+    return () => document.body.classList.remove('ghostnet-theme')
+  }, [])
+
+  useEffect(() => {
+    if (!connected) return
+    let cancelled = false
+
+    async function load () {
+      try {
+        const blueprintData = await sendEvent('getBlueprints')
+        if (!cancelled && Array.isArray(blueprintData)) {
+          recomputeCraftable(blueprintData)
+        }
+        const system = await sendEvent('getSystem')
+        if (!cancelled && system?.address) setCurrentSystem(system)
+      } finally {
+        if (!cancelled) setComponentReady(true)
+      }
+    }
+
+    load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [connected, recomputeCraftable])
+
+  useEffect(() => eventListener('newLogEntry', async (log) => {
+    if (MATERIAL_EVENTS.has(log.event)) {
+      const blueprintData = await sendEvent('getBlueprints')
+      if (Array.isArray(blueprintData)) {
+        recomputeCraftable(blueprintData)
+      }
+    }
+
+    if (TRAVEL_EVENTS.has(log.event)) {
+      const system = await sendEvent('getSystem')
+      if (system?.address) setCurrentSystem(system)
+    }
+  }), [recomputeCraftable])
+
+  useEffect(() => eventListener('gameStateChange', async () => {
+    const blueprintData = await sendEvent('getBlueprints')
+    if (Array.isArray(blueprintData)) {
+      recomputeCraftable(blueprintData)
+    }
+  }), [recomputeCraftable])
+
+  const craftableCount = craftable.length
+  const highestGradeReady = useMemo(() => {
+    return craftable.reduce((acc, item) => Math.max(acc, item?.grade?.grade || 0), 0)
+  }, [craftable])
+
+  const unlockedEngineerCount = useMemo(() => {
+    const names = new Set()
+    craftable.forEach(item => {
+      item.engineers.forEach(engineer => {
+        if (engineer?.name) names.add(engineer.name)
+      })
+    })
+    return names.size
+  }, [craftable])
+
+  return (
+    <Layout connected={connected} active={active} ready={ready} loader={!componentReady}>
+      <PanelNavigation items={NAV_ITEMS} />
+      <Panel layout='full-width' scrollable>
+        <div className={styles.ghostnet}>
+          <div className={styles.hero}>
+            <div className={styles.heroHeader}>
+              <h1 className={styles.heroTitle}>Engineering Opportunities</h1>
+              <p className={styles.heroSubtitle}>
+                Manifest scan highlights every modification you can commission right now, based on your live material stores.
+              </p>
+            </div>
+            <aside className={styles.heroStatus} role='complementary' aria-label='Engineering status'>
+              <dl className={styles.heroStatusList}>
+                <div className={styles.heroStatusItem}>
+                  <dt className={styles.heroStatusLabel}>Blueprints Ready</dt>
+                  <dd className={styles.heroStatusValue}>{craftableCount}</dd>
+                </div>
+                <div className={styles.heroStatusItem}>
+                  <dt className={styles.heroStatusLabel}>Highest Grade</dt>
+                  <dd className={styles.heroStatusValue}>G{highestGradeReady || 0}</dd>
+                </div>
+                <div className={styles.heroStatusItem}>
+                  <dt className={styles.heroStatusLabel}>Engineers Unlocked</dt>
+                  <dd className={styles.heroStatusValue}>{unlockedEngineerCount}</dd>
+                </div>
+              </dl>
+            </aside>
+          </div>
+
+          <div className={styles.shell}>
+            <div className={styles.sectionGroup}>
+              <div className={`${styles.sectionFrame} ${styles.sectionPadding}`}>
+                <div className={styles.opportunityIntro}>
+                  <p className={styles.sectionHint}>
+                    Track the optimal workshop to visit for each upgrade. We surface only the blueprints you can afford this
+                    moment, factoring in material trades and recent crafts.
+                  </p>
+                  <p className={styles.sectionHint}>
+                    Material tallies update as the Ghost Net ingests new journal entries, so keep the console running while you
+                    gather resources.
+                  </p>
+                </div>
+              </div>
+
+              <div className={styles.tableSection}>
+                <div className={styles.tableSectionHeader}>
+                  <div>
+                    <h2 className={styles.tableSectionTitle}>Ready for fabrication</h2>
+                    <p className={styles.sectionHint}>
+                      Choose a target blueprint to plan your jump route and confirm material sufficiency before you arrive.
+                    </p>
+                  </div>
+                </div>
+
+                {!componentReady && (
+                  <div className={styles.tableIdleState}>Synchronising manifest…</div>
+                )}
+
+                {componentReady && craftable.length === 0 && (
+                  <div className={styles.tableEmptyState}>
+                    No blueprints are currently within reach. Top up on materials or unlock additional engineers to expand the
+                    list.
+                  </div>
+                )}
+
+                {componentReady && craftable.length > 0 && (
+                  <div className={styles.dataTableContainer}>
+                    <table className={`${styles.dataTable} ${styles.dataTableDense}`}>
+                      <thead>
+                        <tr>
+                          <th>Blueprint</th>
+                          <th className='hidden-medium'>Grade</th>
+                          <th>Materials Ready</th>
+                          <th>Workshop Destination</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {craftable.map(item => {
+                          const moduleList = Array.isArray(item.blueprint?.modules) ? item.blueprint.modules : []
+                          return (
+                            <tr key={item.blueprint.symbol} data-ghostnet-table-row='visible'>
+                              <td>
+                                <div className={styles.opportunityName}>{item.blueprint.name}</div>
+                                <div className={styles.tableSubtext}>{item.blueprint.originalName}</div>
+                                {moduleList.length > 0 && (
+                                  <div className={styles.moduleTags}>
+                                    {moduleList.map(module => (
+                                      <span key={`${item.blueprint.symbol}_${module}`} className={styles.moduleTag}>
+                                        {module}
+                                      </span>
+                                    ))}
+                                  </div>
+                                )}
+                                <div className={`${styles.gradeBadge} visible-medium`}>G{item.grade.grade}</div>
+                              </td>
+                              <td className='hidden-medium'>
+                                <div className={styles.gradeBadge}>G{item.grade.grade}</div>
+                              </td>
+                              <td>
+                                <ul className={styles.materialList}>
+                                  {item.grade.components.map(component => (
+                                    <li
+                                      key={`${item.blueprint.symbol}_${item.grade.grade}_${component.symbol || component.name}`}
+                                      className={styles.materialItem}
+                                    >
+                                      <span className={styles.materialName}>{component.name}</span>
+                                      <span className={styles.materialCount}>
+                                        {formatNumber(component.cost)} / {formatNumber(component.count)}
+                                      </span>
+                                    </li>
+                                  ))}
+                                </ul>
+                              </td>
+                              <td>
+                                <ul className={styles.engineerList}>
+                                  {item.engineers.map(engineer => {
+                                    const hasLocation = Array.isArray(engineer.location) && engineer.location.length === 3
+                                    const distanceLy = hasLocation && currentSystem?.position
+                                      ? distance(currentSystem.position, engineer.location)
+                                      : 0
+                                    return (
+                                      <li key={`${item.blueprint.symbol}_${engineer.name}`} className={styles.engineerItem}>
+                                        <span className={styles.engineerName}>{engineer.name}</span>
+                                        <span className={styles.engineerMeta}>
+                                          <span>{engineer.system || 'Unknown System'}</span>
+                                          {distanceLy > 0 && (
+                                            <span>{distanceLy.toFixed(1)} Ly</span>
+                                          )}
+                                        </span>
+                                        <span
+                                          className={`${styles.engineerStatus} ${engineer.rank > 0 ? styles.engineerStatusUnlocked : ''}`}
+                                        >
+                                          {engineer.rank > 0
+                                            ? `Grade ${engineer.rank} unlocked`
+                                            : (engineer.progress || 'Not yet unlocked')}
+                                        </span>
+                                      </li>
+                                    )
+                                  })}
+                                </ul>
+                              </td>
+                            </tr>
+                          )
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </Panel>
+    </Layout>
+  )
+}
+

--- a/src/client/pages/ghostnet/engineering.js
+++ b/src/client/pages/ghostnet/engineering.js
@@ -9,8 +9,7 @@ import {
   createCraftableBlueprintSummary,
   formatNumber,
   getEngineerDistanceLy,
-  getEngineerProgressState,
-  getEngineeringNavigation
+  getEngineerProgressState
 } from './engineering-utils'
 import styles from '../ghostnet.module.css'
 
@@ -20,7 +19,14 @@ export default function GhostnetEngineeringOpportunitiesPage () {
   const [currentSystem, setCurrentSystem] = useState(null)
   const [componentReady, setComponentReady] = useState(false)
   const router = useRouter()
-  const navigationItems = useMemo(() => getEngineeringNavigation('engineering'), [])
+  const navigationItems = useMemo(() => ([
+    { name: 'Trade Routes', icon: 'route', onClick: () => router.push('/ghostnet') },
+    { name: 'Commodity Trade', icon: 'cargo', onClick: () => router.push('/ghostnet') },
+    { name: 'Missions', icon: 'asteroid-base', onClick: () => router.push('/ghostnet') },
+    { name: 'Pristine Mining Locations', icon: 'planet-ringed', onClick: () => router.push('/ghostnet') },
+    { name: 'Engineering Opportunities', icon: 'engineer', active: true },
+    { name: 'Search', icon: 'search', type: 'SEARCH', active: false }
+  ]), [router])
 
   const recomputeCraftable = useCallback((nextBlueprints) => {
     const summaries = createCraftableBlueprintSummary(nextBlueprints)

--- a/src/client/pages/ghostnet/engineering.js
+++ b/src/client/pages/ghostnet/engineering.js
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import Layout from 'components/layout'
 import Panel from 'components/panel'
-import PanelNavigation from 'components/panel-navigation'
 import { useSocket, sendEvent, eventListener } from 'lib/socket'
 import distance from '../../../shared/distance'
 import styles from '../ghostnet.module.css'
@@ -164,8 +163,7 @@ export default function GhostnetEngineeringOpportunitiesPage () {
 
   return (
     <Layout connected={connected} active={active} ready={ready} loader={!componentReady}>
-      <PanelNavigation items={NAV_ITEMS} />
-      <Panel layout='full-width' scrollable>
+      <Panel layout='full-width' scrollable navigation={NAV_ITEMS}>
         <div className={styles.ghostnet}>
           <div className={styles.hero}>
             <div className={styles.heroHeader}>

--- a/src/client/pages/ghostnet/engineering/[symbol].js
+++ b/src/client/pages/ghostnet/engineering/[symbol].js
@@ -1,0 +1,341 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/router'
+import Layout from 'components/layout'
+import Panel from 'components/panel'
+import { useSocket, sendEvent, eventListener } from 'lib/socket'
+import {
+  MATERIAL_EVENTS,
+  TRAVEL_EVENTS,
+  createCraftableBlueprintSummary,
+  formatNumber,
+  getEngineerDistanceLy,
+  getEngineerProgressState,
+  getEngineeringNavigation,
+  normaliseBlueprintSymbol
+} from '../engineering-utils'
+import styles from '../../ghostnet.module.css'
+
+function formatFeatureValue (feature) {
+  if (!feature || !Array.isArray(feature.value) || feature.value.length === 0) return 'Unknown'
+  const [min, max] = feature.value
+  const format = (value) => {
+    if (typeof value !== 'number' || Number.isNaN(value)) return '—'
+    if (feature.type === 'percentage') {
+      const scaled = value * 100
+      const precision = Math.abs(scaled) < 10 ? 1 : 0
+      return `${scaled > 0 ? '+' : ''}${scaled.toFixed(precision)}%`
+    }
+    const precision = Math.abs(value) < 10 ? 2 : 1
+    return `${value > 0 ? '+' : ''}${value.toFixed(precision)}`
+  }
+
+  const minText = format(min)
+  const maxText = format(max)
+  if (minText === maxText) return minText
+  return `${minText} → ${maxText}`
+}
+
+export default function EngineeringBlueprintDetailPage () {
+  const { connected, active, ready } = useSocket()
+  const router = useRouter()
+  const navigationItems = useMemo(() => getEngineeringNavigation('engineering'), [])
+  const [componentReady, setComponentReady] = useState(false)
+  const [currentSystem, setCurrentSystem] = useState(null)
+  const [blueprintSummary, setBlueprintSummary] = useState(null)
+  const [workshopDetails, setWorkshopDetails] = useState({})
+  const [workshopErrors, setWorkshopErrors] = useState({})
+  const [loadingWorkshops, setLoadingWorkshops] = useState(false)
+
+  const selectedSymbol = useMemo(() => {
+    return normaliseBlueprintSymbol(router.query.symbol)
+  }, [router.query.symbol])
+
+  const updateSummaryFromBlueprints = useCallback((blueprints) => {
+    const summaries = createCraftableBlueprintSummary(Array.isArray(blueprints) ? blueprints : [])
+    const match = summaries.find(item => normaliseBlueprintSymbol(item.blueprint?.symbol) === selectedSymbol)
+    setBlueprintSummary(match || null)
+  }, [selectedSymbol])
+
+  useEffect(() => {
+    if (!selectedSymbol) setComponentReady(true)
+  }, [selectedSymbol])
+
+  useEffect(() => {
+    setWorkshopDetails({})
+    setWorkshopErrors({})
+    setLoadingWorkshops(false)
+  }, [selectedSymbol])
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || !document.body) return undefined
+    document.body.classList.add('ghostnet-theme')
+    return () => document.body.classList.remove('ghostnet-theme')
+  }, [])
+
+  useEffect(() => {
+    if (!connected || !selectedSymbol) return
+    let cancelled = false
+
+    async function load () {
+      try {
+        const blueprintData = await sendEvent('getBlueprints')
+        if (!cancelled) updateSummaryFromBlueprints(blueprintData)
+        const system = await sendEvent('getSystem')
+        if (!cancelled && system?.address) setCurrentSystem(system)
+      } finally {
+        if (!cancelled) setComponentReady(true)
+      }
+    }
+
+    setComponentReady(false)
+    load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [connected, selectedSymbol, updateSummaryFromBlueprints])
+
+  useEffect(() => eventListener('newLogEntry', async (log) => {
+    if (MATERIAL_EVENTS.has(log.event)) {
+      const blueprintData = await sendEvent('getBlueprints')
+      updateSummaryFromBlueprints(blueprintData)
+    }
+
+    if (TRAVEL_EVENTS.has(log.event)) {
+      const system = await sendEvent('getSystem')
+      if (system?.address) setCurrentSystem(system)
+    }
+  }), [updateSummaryFromBlueprints])
+
+  useEffect(() => eventListener('gameStateChange', async () => {
+    const blueprintData = await sendEvent('getBlueprints')
+    updateSummaryFromBlueprints(blueprintData)
+  }), [updateSummaryFromBlueprints])
+
+  useEffect(() => {
+    if (!blueprintSummary) return
+    const pendingMarketIds = blueprintSummary.engineers
+      .map(engineer => engineer?.marketId)
+      .filter(Boolean)
+      .map(id => String(id))
+      .filter(id => !workshopDetails[id] && !workshopErrors[id])
+
+    if (pendingMarketIds.length === 0) return
+
+    let cancelled = false
+    setLoadingWorkshops(true)
+
+    async function loadWorkshops () {
+      for (const marketId of pendingMarketIds) {
+        try {
+          const response = await fetch(`/api/ghostnet-engineer-workshop?marketId=${encodeURIComponent(marketId)}`)
+          if (!response.ok) throw new Error('Request failed')
+          const data = await response.json()
+          if (!cancelled) {
+            setWorkshopDetails(prev => ({
+              ...prev,
+              [marketId]: {
+                stationName: data?.stationName || null,
+                systemName: data?.systemName || null
+              }
+            }))
+          }
+        } catch (error) {
+          if (!cancelled) {
+            setWorkshopErrors(prev => ({ ...prev, [marketId]: true }))
+          }
+        }
+      }
+
+      if (!cancelled) setLoadingWorkshops(false)
+    }
+
+    loadWorkshops()
+
+    return () => {
+      cancelled = true
+    }
+  }, [blueprintSummary, workshopDetails, workshopErrors])
+
+  const handleBack = useCallback(() => {
+    router.push('/ghostnet/engineering')
+  }, [router])
+
+  const moduleList = useMemo(() => {
+    if (!blueprintSummary?.blueprint?.modules) return []
+    return Array.isArray(blueprintSummary.blueprint.modules)
+      ? blueprintSummary.blueprint.modules
+      : [blueprintSummary.blueprint.modules]
+  }, [blueprintSummary?.blueprint?.modules])
+
+  const featureEntries = useMemo(() => {
+    if (!blueprintSummary?.grade?.features) return []
+    return Object.entries(blueprintSummary.grade.features)
+  }, [blueprintSummary?.grade?.features])
+
+  const gradeLabel = blueprintSummary?.grade?.grade ? `G${blueprintSummary.grade.grade}` : 'G0'
+
+  return (
+    <Layout connected={connected} active={active} ready={ready} loader={!componentReady}>
+      <Panel layout='full-width' scrollable navigation={navigationItems}>
+        <div className={styles.ghostnet}>
+          <div className={styles.engineeringDetailContainer}>
+            <div className={styles.engineeringDetailBackRow}>
+              <button type='button' className={styles.routeDetailBackButton} onClick={handleBack}>
+                Back to manifest
+              </button>
+            </div>
+
+            {!componentReady && (
+              <div className={styles.engineeringDetailStatus}>Synchronising manifest…</div>
+            )}
+
+            {componentReady && !blueprintSummary && (
+              <div className={styles.engineeringDetailStatus}>
+                No craftable blueprint matches that manifest entry right now. Gather more materials or refresh your logs.
+              </div>
+            )}
+
+            {componentReady && blueprintSummary && (
+              <div className={styles.engineeringDetailContent}>
+                <header className={styles.engineeringDetailHeader}>
+                  <div className={styles.engineeringDetailHeading}>
+                    <span className={styles.engineeringDetailLabel}>Blueprint</span>
+                    <h1 className={styles.engineeringDetailTitle}>{blueprintSummary.blueprint.name}</h1>
+                    <p className={styles.engineeringDetailSubtitle}>{blueprintSummary.blueprint.originalName}</p>
+                    {moduleList.length > 0 && (
+                      <div className={styles.moduleTags}>
+                        {moduleList.map(module => (
+                          <span key={`module-${module}`} className={styles.moduleTag}>{module}</span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <div className={styles.engineeringDetailGrade}>
+                    <span className={styles.engineeringDetailGradeLabel}>Ready Grade</span>
+                    <span className={styles.engineeringDetailGradeValue}>{gradeLabel}</span>
+                  </div>
+                </header>
+
+                <div className={styles.engineeringDetailGrid}>
+                  <section className={styles.engineeringDetailSection}>
+                    <div className={styles.engineeringDetailSectionHeader}>
+                      <h2 className={styles.engineeringDetailSectionTitle}>Materials on hand</h2>
+                      <p className={styles.engineeringDetailSectionHint}>
+                        Ghost Net confirmed you can craft this grade without additional gathering. Tally stays live with new journal events.
+                      </p>
+                    </div>
+                    <ul className={`${styles.materialList} ${styles.engineeringDetailMaterialList}`}>
+                      {blueprintSummary.grade.components.map(component => (
+                        <li
+                          key={`${blueprintSummary.blueprint.symbol}_${blueprintSummary.grade.grade}_${component.symbol || component.name}`}
+                          className={styles.materialItem}
+                        >
+                          <span className={styles.materialName}>{component.name}</span>
+                          <span className={styles.materialCount}>
+                            {formatNumber(component.cost)} / {formatNumber(component.count)}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+
+                  <section className={styles.engineeringDetailSection}>
+                    <div className={styles.engineeringDetailSectionHeader}>
+                      <h2 className={styles.engineeringDetailSectionTitle}>Performance outlook</h2>
+                      <p className={styles.engineeringDetailSectionHint}>
+                        Compare the expected stat shifts for this grade so you can decide whether to commission it now or hold for a higher tier.
+                      </p>
+                    </div>
+                    {featureEntries.length === 0 ? (
+                      <div className={styles.engineeringDetailStatus}>No feature deltas available for this grade.</div>
+                    ) : (
+                      <ul className={styles.engineeringDetailFeatureList}>
+                        {featureEntries.map(([name, feature]) => (
+                          <li key={name} className={styles.engineeringDetailFeatureItem}>
+                            <span className={styles.engineeringDetailFeatureName}>{name}</span>
+                            <span className={styles.engineeringDetailFeatureValue}>{formatFeatureValue(feature)}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </section>
+
+                  <section className={styles.engineeringDetailSection}>
+                    <div className={styles.engineeringDetailSectionHeader}>
+                      <h2 className={styles.engineeringDetailSectionTitle}>Available workshops</h2>
+                      <p className={styles.engineeringDetailSectionHint}>
+                        Prioritise the engineer closest to your current position or the workshop with the highest unlocked grade.
+                      </p>
+                    </div>
+                    <div className={styles.engineeringDetailEngineerGrid}>
+                      {blueprintSummary.engineers.map(engineer => {
+                        const { state, label, highestGradeOffered, rank } = getEngineerProgressState(engineer, blueprintSummary.grade.grade)
+                        const distanceLy = getEngineerDistanceLy(currentSystem, engineer)
+                        const marketId = engineer?.marketId ? String(engineer.marketId) : null
+                        const workshopInfo = marketId ? workshopDetails[marketId] : null
+                        const stationName = workshopInfo?.stationName || 'Unknown Workshop'
+                        const systemName = workshopInfo?.systemName || engineer.system || 'Unknown System'
+                        const gradeNumbers = Array.isArray(engineer.grades)
+                          ? engineer.grades.map(Number).filter(value => !Number.isNaN(value)).sort((a, b) => a - b)
+                          : []
+                        const gradeRange = gradeNumbers.length > 0
+                          ? `G${gradeNumbers[0]}${gradeNumbers[gradeNumbers.length - 1] !== gradeNumbers[0] ? ` – G${gradeNumbers[gradeNumbers.length - 1]}` : ''}`
+                          : 'Unavailable'
+                        const accessStatus = rank > 0
+                          ? `Unlocked up to G${rank}${highestGradeOffered ? ` of ${gradeRange}` : ''}`
+                          : engineer.progress || 'Invite pending'
+                        const distanceText = typeof distanceLy === 'number' && distanceLy > 0
+                          ? `${distanceLy.toFixed(1)} Ly from current system`
+                          : 'Distance unknown'
+                        const cardStateClass = state === 'locked'
+                          ? styles.engineerStateLocked
+                          : state === 'mastered'
+                            ? styles.engineerStateMastered
+                            : styles.engineerStateUnlocked
+
+                        return (
+                          <article key={`${blueprintSummary.blueprint.symbol}_${engineer.name}`} className={`${styles.engineeringDetailEngineerCard} ${cardStateClass}`}>
+                            <header className={styles.engineeringDetailEngineerHeader}>
+                              <div className={styles.engineeringDetailEngineerIdentity}>
+                                <h3 className={styles.engineeringDetailEngineerName}>{engineer.name}</h3>
+                                <span className={styles.engineerStatus}>{label}</span>
+                              </div>
+                              <div className={styles.engineeringDetailEngineerGradeBadge}>{gradeRange}</div>
+                            </header>
+                            <div className={styles.engineeringDetailMetaGrid}>
+                              <div className={styles.engineeringDetailMetaBlock}>
+                                <span className={styles.engineeringDetailMetaLabel}>System</span>
+                                <span className={styles.engineeringDetailMetaValue}>{systemName}</span>
+                              </div>
+                              <div className={styles.engineeringDetailMetaBlock}>
+                                <span className={styles.engineeringDetailMetaLabel}>Workshop</span>
+                                <span className={styles.engineeringDetailMetaValue}>{stationName}</span>
+                              </div>
+                              <div className={styles.engineeringDetailMetaBlock}>
+                                <span className={styles.engineeringDetailMetaLabel}>Distance</span>
+                                <span className={styles.engineeringDetailMetaValue}>{distanceText}</span>
+                              </div>
+                              <div className={styles.engineeringDetailMetaBlock}>
+                                <span className={styles.engineeringDetailMetaLabel}>Access</span>
+                                <span className={styles.engineeringDetailMetaValue}>{accessStatus}</span>
+                              </div>
+                            </div>
+                            <p className={styles.engineeringDetailEngineerProgress}>{engineer.progress || 'Invite progress unknown'}</p>
+                          </article>
+                        )
+                      })}
+                    </div>
+                    {loadingWorkshops && (
+                      <div className={styles.engineeringDetailStatus}>Fetching workshop manifests…</div>
+                    )}
+                  </section>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </Panel>
+    </Layout>
+  )
+}

--- a/src/client/pages/ghostnet/engineering/[symbol].js
+++ b/src/client/pages/ghostnet/engineering/[symbol].js
@@ -10,7 +10,6 @@ import {
   formatNumber,
   getEngineerDistanceLy,
   getEngineerProgressState,
-  getEngineeringNavigation,
   normaliseBlueprintSymbol
 } from '../engineering-utils'
 import styles from '../../ghostnet.module.css'
@@ -38,7 +37,14 @@ function formatFeatureValue (feature) {
 export default function EngineeringBlueprintDetailPage () {
   const { connected, active, ready } = useSocket()
   const router = useRouter()
-  const navigationItems = useMemo(() => getEngineeringNavigation('engineering'), [])
+  const navigationItems = useMemo(() => ([
+    { name: 'Trade Routes', icon: 'route', onClick: () => router.push('/ghostnet') },
+    { name: 'Commodity Trade', icon: 'cargo', onClick: () => router.push('/ghostnet') },
+    { name: 'Missions', icon: 'asteroid-base', onClick: () => router.push('/ghostnet') },
+    { name: 'Pristine Mining Locations', icon: 'planet-ringed', onClick: () => router.push('/ghostnet') },
+    { name: 'Engineering Opportunities', icon: 'engineer', active: true, onClick: () => router.push('/ghostnet/engineering') },
+    { name: 'Search', icon: 'search', type: 'SEARCH', active: false }
+  ]), [router])
   const [componentReady, setComponentReady] = useState(false)
   const [currentSystem, setCurrentSystem] = useState(null)
   const [blueprintSummary, setBlueprintSummary] = useState(null)

--- a/src/service/lib/event-handlers/blueprints.js
+++ b/src/service/lib/event-handlers/blueprints.js
@@ -32,7 +32,8 @@ class Blueprints {
           system: engineer.system.name,
           location: engineer.system.position,
           rank: engineer.progress.rank,
-          progress: engineer.progress.status
+          progress: engineer.progress.status,
+          marketId: engineer.marketId
         }
       }
 


### PR DESCRIPTION
## Summary
- add a dedicated Ghost Net engineering opportunities page that assembles craftable blueprints with engineer destinations based on live materials
- extend the Ghost Net navigation with an engineering shortcut and supporting styles for the new table presentation

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: missing @next/swc binary in container)*
- npm run start *(fails: Next dev proxy cannot boot without SWC binary)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdbb523a08323b1fe897fe49caeab