### PR TITLE
Refactor GhostNet station and commodity summaries

### DIFF
--- a/src/client/components/ghostnet/commodity-summary.js
+++ b/src/client/components/ghostnet/commodity-summary.js
@@ -1,0 +1,232 @@
+import React, { useMemo } from 'react'
+import PropTypes from 'prop-types'
+import TransferContextSummary from './transfer-context-summary'
+import { StationIcon, DemandIndicator } from './station-summary'
+import Icons from '../../lib/icons'
+import { getCommodityIconConfig } from '../../lib/commodity-icons'
+import { sanitizeInaraText } from '../../lib/sanitize-inara-text'
+import {
+  formatCredits,
+  formatRelativeTime,
+  formatStationDistance,
+  formatSystemDistance
+} from '../../lib/ghostnet-formatters'
+import { stationIconFromType } from '../../lib/station-icons'
+
+export function CommodityIcon ({ category, size = 26 }) {
+  const config = getCommodityIconConfig(category)
+  const paths = Icons[config.icon]
+  if (!paths) return null
+  const viewBox = config.icon === 'asteroid-base' ? '0 0 2000 2000' : '0 0 1000 1000'
+  return (
+    <svg
+      viewBox={viewBox}
+      focusable='false'
+      aria-hidden='true'
+      style={{ width: size, height: size, fill: config.color, flexShrink: 0 }}
+    >
+      {paths}
+    </svg>
+  )
+}
+
+CommodityIcon.defaultProps = {
+  category: '',
+  size: 26
+}
+
+CommodityIcon.propTypes = {
+  category: PropTypes.string,
+  size: PropTypes.number
+}
+
+function buildMetrics (entries) {
+  if (!Array.isArray(entries)) return []
+  return entries
+    .map(entry => {
+      if (!entry || (!entry.label && !entry.value)) return null
+      return {
+        label: typeof entry.label === 'string' ? entry.label : entry.label,
+        value: entry.value,
+        priority: Boolean(entry.priority)
+      }
+    })
+    .filter(Boolean)
+}
+
+export default function CommoditySummary ({ summary, shipSourceSegment, className, valueIcon }) {
+  const memoized = useMemo(() => {
+    if (!summary) return null
+
+    const commodityName = sanitizeInaraText(summary.commodityName) || summary.commodityName || 'Unknown Commodity'
+    const commoditySymbol = sanitizeInaraText(summary.commoditySymbol) || summary.commoditySymbol || ''
+    const quantityDisplay = Number(summary.quantity || 0).toLocaleString()
+    const quantityText = quantityDisplay ? `${quantityDisplay} t` : ''
+    const summaryPriceDisplay = formatCredits(summary.price, summary.priceText || '--')
+    const commodityPriceDisplay = summaryPriceDisplay && summaryPriceDisplay !== '--'
+      ? `@ ${summaryPriceDisplay}`
+      : ''
+    const summaryValueDisplay = typeof summary.price === 'number'
+      ? formatCredits(summary.price * (summary.quantity || 0), '--')
+      : '--'
+
+    const summarySystemDistance = formatSystemDistance(summary.distanceLy, summary.distanceLyText)
+    const summaryStationDistance = formatStationDistance(summary.distanceLs, summary.distanceLsText)
+    const summaryUpdated = summary.updatedAt
+      ? formatRelativeTime(summary.updatedAt)
+      : (summary.updatedText || '')
+
+    const destinationDemandFallback = sanitizeInaraText(summary.demandText) || (typeof summary.demand === 'number'
+      ? summary.demand.toLocaleString()
+      : '')
+
+    const summaryDemandIndicator = (
+      <DemandIndicator
+        label={summary.demandText}
+        fallbackLabel={destinationDemandFallback}
+        isLow={Boolean(summary.demandIsLow)}
+        subtle
+      />
+    )
+
+    const stationName = sanitizeInaraText(summary.stationName) || summary.stationName || '--'
+    const systemName = sanitizeInaraText(summary.systemName) || summary.systemName || ''
+    const stationType = sanitizeInaraText(summary.stationType) || summary.stationType || ''
+
+    const originName = summary.originStationName || 'Local Market'
+    const originSystem = summary.originSystemName || ''
+    const originType = summary.originStationType || ''
+    const originUpdated = summary.originUpdatedAt
+      ? formatRelativeTime(summary.originUpdatedAt)
+      : (summary.originUpdatedText || '')
+
+    const localPriceDisplay = formatCredits(summary.localBestPrice, summary.localBestPriceText || '--')
+    const profitPerUnitDisplay = formatCredits(summary.profitPerUnit, summary.profitPerUnitText || '--')
+    const profitValueDisplay = formatCredits(summary.profitValue, summary.profitValueText || summaryValueDisplay)
+
+    const destinationIconName = stationName ? stationIconFromType(stationType || '') : null
+    const originIconName = summary.originStationName ? stationIconFromType(originType || '') : null
+
+    const originSubtexts = [originSystem, originType].filter(Boolean)
+    const destinationSubtexts = [systemName, stationType].filter(Boolean)
+    const commoditySubtexts = [
+      commoditySymbol && commoditySymbol !== commodityName ? commoditySymbol : null,
+      summaryPriceDisplay && summaryPriceDisplay !== '--' ? `@ ${summaryPriceDisplay}` : null
+    ].filter(Boolean)
+
+    const sourceMetrics = []
+    if (localPriceDisplay && localPriceDisplay !== '--') {
+      sourceMetrics.push({ label: 'Buy', value: localPriceDisplay, priority: true })
+    }
+    if (originUpdated) {
+      sourceMetrics.push({ label: 'Updated', value: originUpdated })
+    }
+
+    const destinationMetrics = []
+    if (summaryPriceDisplay && summaryPriceDisplay !== '--') {
+      destinationMetrics.push({ label: 'Sell', value: summaryPriceDisplay, priority: true })
+    }
+    if (summaryDemandIndicator) {
+      destinationMetrics.push({ label: 'Demand', value: summaryDemandIndicator, priority: true })
+    }
+    if (summaryUpdated) {
+      destinationMetrics.push({ label: 'Updated', value: summaryUpdated })
+    }
+
+    const valueSecondaryParts = []
+    if (profitPerUnitDisplay && profitPerUnitDisplay !== '--') valueSecondaryParts.push(`Per t ${profitPerUnitDisplay}`)
+    if (quantityText) valueSecondaryParts.push(`Payload ${quantityText}`)
+    const valueSecondary = valueSecondaryParts.join(' • ')
+
+    const distanceSegment = {
+      label: 'Distance',
+      value: summarySystemDistance || '',
+      secondary: summaryStationDistance || ''
+    }
+
+    const sourceSegment = shipSourceSegment
+      ? {
+          ...shipSourceSegment,
+          subtexts: [
+            ...(Array.isArray(shipSourceSegment.subtexts) ? shipSourceSegment.subtexts : []),
+            originName && originName !== shipSourceSegment.name ? `Docked: ${originName}` : null,
+            originSystem
+          ].filter(Boolean),
+          metrics: buildMetrics(sourceMetrics)
+        }
+      : {
+          icon: originIconName ? <StationIcon icon={originIconName} size={24} /> : null,
+          name: originName,
+          subtexts: originSubtexts,
+          metrics: buildMetrics(sourceMetrics),
+          ariaLabel: originName ? `Origin station ${originName}` : 'Local market origin'
+        }
+
+    const destinationSegment = {
+      icon: destinationIconName ? <StationIcon icon={destinationIconName} size={24} /> : null,
+      name: stationName,
+      subtexts: destinationSubtexts,
+      metrics: buildMetrics(destinationMetrics),
+      ariaLabel: `Destination station ${stationName}`
+    }
+
+    return {
+      item: {
+        icon: <CommodityIcon category={summary.commodityCategory} size={26} />,
+        name: commodityName,
+        subtexts: commoditySubtexts,
+        quantity: quantityText,
+        price: commodityPriceDisplay,
+        ariaLabel: `${commodityName} quantity ${quantityText || 'Unknown'}`
+      },
+      source: sourceSegment,
+      destination: destinationSegment,
+      distance: distanceSegment,
+      value: {
+        icon: valueIcon || null,
+        label: 'Profit',
+        value: profitValueDisplay && profitValueDisplay !== '--' ? profitValueDisplay : '',
+        secondary: valueSecondary
+      }
+    }
+  }, [summary, shipSourceSegment, valueIcon])
+
+  if (!memoized) return null
+
+  return (
+    <TransferContextSummary
+      className={className}
+      item={memoized.item}
+      source={memoized.source}
+      distance={memoized.distance}
+      target={memoized.destination}
+      value={memoized.value}
+    />
+  )
+}
+
+CommoditySummary.defaultProps = {
+  summary: null,
+  shipSourceSegment: null,
+  className: '',
+  valueIcon: null
+}
+
+CommoditySummary.propTypes = {
+  summary: PropTypes.object,
+  shipSourceSegment: PropTypes.shape({
+    icon: PropTypes.node,
+    name: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    subtexts: PropTypes.arrayOf(PropTypes.node),
+    metrics: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.node,
+        value: PropTypes.node,
+        priority: PropTypes.bool
+      })
+    ),
+    ariaLabel: PropTypes.string
+  }),
+  className: PropTypes.string,
+  valueIcon: PropTypes.node
+}

--- a/src/client/components/ghostnet/station-summary.js
+++ b/src/client/components/ghostnet/station-summary.js
@@ -1,0 +1,187 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Icons from '../../lib/icons'
+import { sanitizeInaraText } from '../../lib/sanitize-inara-text'
+import styles from './station-summary.module.css'
+
+const DEMAND_ARROW_PATTERN = /[▲△▴▵▼▽▾▿↑↓]/g
+
+export function StationIcon ({ icon, size = 26, color = 'var(--ghostnet-accent)' }) {
+  if (!icon) return null
+  const paths = Icons[icon]
+  if (!paths) return null
+  const viewBox = icon === 'asteroid-base' ? '0 0 2000 2000' : '0 0 1000 1000'
+  return (
+    <svg
+      viewBox={viewBox}
+      focusable='false'
+      aria-hidden='true'
+      style={{ width: size, height: size, fill: color, flexShrink: 0 }}
+    >
+      {paths}
+    </svg>
+  )
+}
+
+StationIcon.defaultProps = {
+  icon: '',
+  size: 26,
+  color: 'var(--ghostnet-accent)'
+}
+
+StationIcon.propTypes = {
+  icon: PropTypes.string,
+  size: PropTypes.number,
+  color: PropTypes.string
+}
+
+export function DemandIndicator ({ label, fallbackLabel, isLow, subtle }) {
+  const rawLabel = typeof label === 'string' ? label : ''
+  const cleanedLabel = sanitizeInaraText(rawLabel)
+  const arrowMatches = rawLabel.match(DEMAND_ARROW_PATTERN) || []
+  const containsDownArrow = arrowMatches.some(char => /[▼▽▾▿↓]/.test(char))
+  const containsUpArrow = arrowMatches.some(char => /[▲△▴▵↑]/.test(char))
+  const direction = containsDownArrow && !containsUpArrow
+    ? 'down'
+    : (containsUpArrow && !containsDownArrow
+        ? 'up'
+        : (isLow ? 'down' : 'up'))
+  const arrowSymbol = direction === 'down' ? String.fromCharCode(0x25BC) : String.fromCharCode(0x25B2)
+  const arrowCount = Math.min(Math.max(arrowMatches.length || 1, 1), 4)
+  const displayLabel = cleanedLabel.replace(DEMAND_ARROW_PATTERN, '').trim()
+  const fallback = sanitizeInaraText(fallbackLabel)
+  const finalLabel = displayLabel || fallback
+  if (!finalLabel && arrowMatches.length === 0) return null
+
+  const containerClassNames = [styles.demandIndicator]
+  if (subtle) containerClassNames.push(styles.demandIndicatorSubtle)
+
+  const arrowClassNames = [styles.demandIndicatorArrow]
+  arrowClassNames.push(direction === 'down' ? styles.demandIndicatorArrowLow : styles.demandIndicatorArrowHigh)
+
+  return (
+    <span className={containerClassNames.join(' ')}>
+      <span className={arrowClassNames.join(' ')} aria-hidden='true'>{arrowSymbol.repeat(arrowCount)}</span>
+      {finalLabel ? <span>{finalLabel}</span> : null}
+    </span>
+  )
+}
+
+DemandIndicator.defaultProps = {
+  label: '',
+  fallbackLabel: '',
+  isLow: false,
+  subtle: false
+}
+
+DemandIndicator.propTypes = {
+  label: PropTypes.string,
+  fallbackLabel: PropTypes.string,
+  isLow: PropTypes.bool,
+  subtle: PropTypes.bool
+}
+
+export default function StationSummary ({
+  iconName,
+  icon,
+  name,
+  system,
+  stationType,
+  selectionLabel,
+  isSelected,
+  meta,
+  metrics,
+  demand,
+  demandLabel,
+  children
+}) {
+  const resolvedIcon = icon || (iconName ? <StationIcon icon={iconName} size={24} /> : null)
+  const normalizedName = sanitizeInaraText(name) || 'Unknown Station'
+  const normalizedSystem = sanitizeInaraText(system)
+  const normalizedType = sanitizeInaraText(stationType)
+  const normalizedMeta = Array.isArray(meta)
+    ? meta.map(entry => sanitizeInaraText(entry)).filter(Boolean)
+    : []
+
+  const hasMetaRow = normalizedMeta.length > 0 || normalizedType || (isSelected && selectionLabel)
+  const hasMetrics = Array.isArray(metrics) && metrics.length > 0
+  const hasDemand = Boolean(demand || demandLabel)
+
+  return (
+    <div className={styles.stationCell}>
+      {resolvedIcon}
+      <div className={styles.stationCellText}>
+        <div className={styles.stationName}>{normalizedName}</div>
+        {normalizedSystem ? <div className={styles.stationSystem}>{normalizedSystem}</div> : null}
+        {hasMetaRow ? (
+          <div className={styles.stationMetaRow}>
+            {normalizedType ? <div className={styles.stationMeta}>{normalizedType}</div> : null}
+            {normalizedMeta.map((entry, index) => (
+              <div key={`station-meta-${index}`} className={styles.stationMeta}>{entry}</div>
+            ))}
+            {isSelected && selectionLabel ? (
+              <span className={styles.stationSelectionTag}>{selectionLabel}</span>
+            ) : null}
+          </div>
+        ) : null}
+        {hasDemand ? (
+          <div className={styles.stationDemand}>
+            {demand || (demandLabel ? <span>{sanitizeInaraText(demandLabel)}</span> : null)}
+          </div>
+        ) : null}
+        {hasMetrics ? (
+          <div className={styles.stationMetrics}>
+            {metrics.map((metric, index) => {
+              if (!metric || (!metric.label && !metric.value)) return null
+              const label = sanitizeInaraText(metric.label)
+              const value = sanitizeInaraText(metric.value)
+              if (!label && !value) return null
+              return (
+                <div key={`station-metric-${index}`} className={styles.stationMetric}>
+                  {label ? <span className={styles.stationMetricLabel}>{label}</span> : null}
+                  {value ? <span>{value}</span> : null}
+                </div>
+              )
+            })}
+          </div>
+        ) : null}
+        {children}
+      </div>
+    </div>
+  )
+}
+
+StationSummary.defaultProps = {
+  iconName: '',
+  icon: null,
+  name: '',
+  system: '',
+  stationType: '',
+  selectionLabel: 'In Context',
+  isSelected: false,
+  meta: [],
+  metrics: [],
+  demand: null,
+  demandLabel: '',
+  children: null
+}
+
+StationSummary.propTypes = {
+  iconName: PropTypes.string,
+  icon: PropTypes.node,
+  name: PropTypes.string,
+  system: PropTypes.string,
+  stationType: PropTypes.string,
+  selectionLabel: PropTypes.string,
+  isSelected: PropTypes.bool,
+  meta: PropTypes.arrayOf(PropTypes.string),
+  metrics: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string
+    })
+  ),
+  demand: PropTypes.node,
+  demandLabel: PropTypes.string,
+  children: PropTypes.node
+}

--- a/src/client/components/ghostnet/station-summary.module.css
+++ b/src/client/components/ghostnet/station-summary.module.css
@@ -1,0 +1,98 @@
+.stationCell {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.stationCellText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.stationMetaRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.stationName {
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+}
+
+.stationSystem {
+  font-size: 0.78rem;
+  color: var(--ghostnet-muted);
+}
+
+.stationMeta {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 58%, transparent);
+}
+
+.stationSelectionTag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ghostnet-color-success);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-success) 60%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ghostnet-color-success) 18%, transparent);
+}
+
+.stationMetrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.stationMetric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  color: var(--ghostnet-muted);
+}
+
+.stationMetricLabel {
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.66rem;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 58%, transparent);
+}
+
+.stationDemand {
+  margin-top: 0.25rem;
+}
+
+.demandIndicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.demandIndicatorSubtle {
+  font-size: 0.88em;
+}
+
+.demandIndicatorArrow {
+  font-size: 0.85em;
+  line-height: 1;
+}
+
+.demandIndicatorArrowHigh {
+  color: var(--ghostnet-color-success);
+}
+
+.demandIndicatorArrowLow {
+  color: var(--ghostnet-color-warning);
+}

--- a/src/client/lib/commodity-icons.js
+++ b/src/client/lib/commodity-icons.js
@@ -1,0 +1,26 @@
+const COMMODITY_CATEGORY_ICON_MAP = {
+  chemicals: { icon: 'barrel', color: 'var(--ghostnet-color-warning)' },
+  'consumer items': { icon: 'cargo', color: 'var(--ghostnet-accent)' },
+  foods: { icon: 'plant', color: 'var(--ghostnet-color-success)' },
+  'industrial materials': { icon: 'materials-manufactured', color: 'var(--ghostnet-accent)' },
+  'legal drugs': { icon: 'warning', color: 'var(--ghostnet-color-warning)' },
+  machinery: { icon: 'cogs', color: 'var(--ghostnet-accent)' },
+  medicines: { icon: 'help', color: 'var(--ghostnet-color-success)' },
+  metals: { icon: 'materials-raw', color: 'var(--ghostnet-accent)' },
+  minerals: { icon: 'materials', color: 'var(--ghostnet-accent)' },
+  nonmarketable: { icon: 'inventory', color: 'var(--ghostnet-subdued)' },
+  salvage: { icon: 'cargo-export', color: 'var(--ghostnet-accent)' },
+  slavery: { icon: 'system-authority', color: 'var(--ghostnet-color-warning)' },
+  technology: { icon: 'power', color: 'var(--ghostnet-accent)' },
+  textiles: { icon: 'materials-grade-1', color: 'var(--ghostnet-accent)' },
+  waste: { icon: 'warning', color: 'var(--ghostnet-color-warning)' },
+  weapons: { icon: 'shield', color: 'var(--ghostnet-color-warning)' },
+  default: { icon: 'cargo', color: 'var(--ghostnet-accent)' }
+}
+
+export function getCommodityIconConfig (category) {
+  const key = typeof category === 'string' ? category.trim().toLowerCase() : ''
+  return COMMODITY_CATEGORY_ICON_MAP[key] || COMMODITY_CATEGORY_ICON_MAP.default
+}
+
+export { COMMODITY_CATEGORY_ICON_MAP }

--- a/src/client/lib/ghostnet-formatters.js
+++ b/src/client/lib/ghostnet-formatters.js
@@ -1,0 +1,45 @@
+export function formatSystemDistance (value, fallback) {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return `${value.toFixed(2)} Ly`
+  }
+  return fallback || ''
+}
+
+export function formatStationDistance (value, fallback) {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return `${Math.round(value).toLocaleString()} Ls`
+  }
+  return fallback || ''
+}
+
+export function formatCredits (value, fallback) {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return `${Math.round(value).toLocaleString()} Cr`
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed)) {
+      return `${Math.round(parsed).toLocaleString()} Cr`
+    }
+    return value
+  }
+  return fallback || '--'
+}
+
+export function formatRelativeTime (value) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return typeof value === 'string' ? value : ''
+  }
+  const diffMs = Date.now() - date.getTime()
+  if (diffMs < 0) return 'Just now'
+  const minutes = Math.floor(diffMs / 60000)
+  if (minutes < 1) return 'Just now'
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`
+  return date.toLocaleDateString()
+}

--- a/src/client/lib/sanitize-inara-text.js
+++ b/src/client/lib/sanitize-inara-text.js
@@ -1,0 +1,8 @@
+const INARA_ARTIFACT_PATTERN = /[\u25A0-\u25AF\u25FB-\u25FE\uFFFD]/gu
+
+export function sanitizeInaraText (value) {
+  if (typeof value !== 'string') return ''
+  return value.replace(INARA_ARTIFACT_PATTERN, '').replace(/\s+/g, ' ').trim()
+}
+
+export { INARA_ARTIFACT_PATTERN }

--- a/src/client/lib/station-icons.js
+++ b/src/client/lib/station-icons.js
@@ -1,0 +1,26 @@
+import { sanitizeInaraText } from './sanitize-inara-text'
+
+export function stationIconFromType (type = '') {
+  const lower = type.toLowerCase()
+  if (lower.includes('asteroid')) return 'asteroid-base'
+  if (lower.includes('outpost')) return 'outpost'
+  if (lower.includes('ocellus')) return 'ocellus-starport'
+  if (lower.includes('orbis')) return 'orbis-starport'
+  if (lower.includes('planetary port') || lower.includes('planetary outpost') || lower.includes('workshop')) return 'planetary-port'
+  if (lower.includes('settlement')) return 'settlement'
+  if (lower.includes('installation') || lower.includes('mega ship') || lower.includes('megaship') || lower.includes('fleet carrier')) return 'megaship'
+  return 'coriolis-starport'
+}
+
+export function getStationIconName (localInfo = {}, remoteInfo = {}) {
+  if (localInfo?.icon) return localInfo.icon
+  const candidates = [
+    sanitizeInaraText(localInfo?.stationType),
+    sanitizeInaraText(localInfo?.type),
+    sanitizeInaraText(remoteInfo?.stationType),
+    sanitizeInaraText(remoteInfo?.type),
+    sanitizeInaraText(remoteInfo?.subType)
+  ].filter(entry => typeof entry === 'string' && entry.trim())
+  if (candidates.length === 0) return null
+  return stationIconFromType(candidates[0])
+}

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1704,29 +1704,6 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   color: var(--ghostnet-muted);
 }
 
-.demandIndicator {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.demandIndicatorSubtle {
-  font-size: 0.88em;
-}
-
-.demandIndicatorArrow {
-  font-size: 0.85em;
-  line-height: 1;
-}
-
-.demandIndicatorArrowHigh {
-  color: var(--ghostnet-color-success);
-}
-
-.demandIndicatorArrowLow {
-  color: var(--ghostnet-color-warning);
-}
-
 
 .commodityDetailContainer {
   display: flex;
@@ -1770,55 +1747,6 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   font-size: 0.95rem;
 }
 
-.stationCell {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
-}
-
-.stationCellText {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.stationMetaRow {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.stationName {
-  font-weight: 600;
-  color: var(--ghostnet-ink);
-}
-
-.stationSystem {
-  font-size: 0.78rem;
-  color: var(--ghostnet-muted);
-}
-
-.stationMeta {
-  font-size: 0.7rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 58%, transparent);
-}
-
-.stationSelectionTag {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.2rem 0.6rem;
-  font-size: 0.68rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--ghostnet-color-success);
-  border: 1px solid color-mix(in srgb, var(--ghostnet-color-success) 60%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--ghostnet-color-success) 18%, transparent);
-}
 
 .stationRowSelected {
   background: color-mix(in srgb, var(--ghostnet-color-primary) 20%, transparent);


### PR DESCRIPTION
## Summary
- extract reusable station and commodity summary components for GhostNet UI
- centralize formatting, sanitization, and icon helpers for reuse across panels
- update GhostNet page to consume new primitives and clean up redundant styles

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e01d7a16c08323aca26906d2a09357