### PR TITLE
Display GhostNet tokens beside header clock

### DIFF
--- a/CURRENCY.md
+++ b/CURRENCY.md
@@ -1,0 +1,117 @@
+# GhostNet Token Ledger Overview
+
+## Local ledger implementation
+
+The GhostNet/ICARUS service process now instantiates a `TokenLedger` singleton on boot. The ledger:
+
+- Persists balance snapshots at `~/.config/Icarus/tokens/ledger.json` and appends transactions to `transactions.jsonl` in the same directory.
+- Supports debits (`recordSpend`) and credits (`recordEarn`) while allowing negative balances. Each transaction entry contains `{ id, type, amount, delta, balance, timestamp, metadata, mode, remote }`.
+- Emits structured logs describing every mutation and broadcasts token updates via the `ghostnetTokensUpdated` WebSocket event.
+- Can mirror transactions to a remote service when the `ICARUS_TOKENS_REMOTE_MODE` feature flag enables it (see below). Remote sync failures do **not** block local writes; they simply mark the transaction as `remote.synced === false`.
+- Syncs the initial balance from disk (or the remote service if the mirror is active) and exposes `getSnapshot()` for API routes and socket handlers. The snapshot now includes `remote` metadata so the UI can surface mirror status.
+
+### Feature flags & environment variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `ICARUS_TOKENS_MODE` | `SIMULATION` or `LIVE`. Simulation mode awards/spends tokens locally without attempting real transmissions. | `SIMULATION` |
+| `ICARUS_TOKENS_INITIAL_BALANCE` | Optional starting balance for new ledgers. | `100000` |
+| `ICARUS_TOKENS_REMOTE_MODE` | `DISABLED` or `MIRROR`. When `MIRROR`, the ledger will attempt to call the remote API described below. | `DISABLED` |
+| `ICARUS_TOKENS_REMOTE_ENDPOINT` | Base URL for the external token service (e.g., `https://ledger.example.com/api`). | _empty_ |
+| `ICARUS_TOKENS_REMOTE_API_KEY` | Optional bearer token the service sends with every request. | _empty_ |
+| `ICARUS_TOKENS_REMOTE_TIMEOUT_MS` | Request timeout when calling the remote service. | `8000` |
+
+The remote mirror is only activated when `ICARUS_TOKENS_REMOTE_MODE=MIRROR` **and** a non-empty endpoint is provided. If Node’s global `fetch` is unavailable, the ledger silently disables remote sync to keep local bookkeeping working.
+
+## Client behaviour
+
+- The GhostNet console footer now renders the live token balance, a status badge describing whether the ledger is simulated or mirrored, and a grant button that awards `100000` tokens via the `awardTokens` socket event.
+- When the balance drops below zero, GhostNet injects “menacing” warnings into the console feed to remind the commander that tribute is overdue.
+- Balance updates arrive via the existing `ghostnetTokensUpdated` broadcast; the UI also polls `getTokenBalance` on page load.
+
+## Planned remote service API
+
+When the mirror flag is enabled, the Node service will call a dedicated token service. Another CODEX agent should stand up that service with the exact interface below so the current client code can drop in without modification.
+
+> **Base URL:** `ICARUS_TOKENS_REMOTE_ENDPOINT` (no trailing slash expected). All requests include `Authorization: Bearer <ICARUS_TOKENS_REMOTE_API_KEY>` when the key is present.
+
+### `GET /tokens/balance`
+
+Returns the canonical token snapshot.
+
+```json
+{
+  "balance": 123456,
+  "mode": "LIVE",
+  "simulation": false,
+  "remote": {
+    "enabled": true,
+    "mode": "MIRROR"
+  },
+  "updatedAt": "2024-03-20T18:42:51.123Z"
+}
+```
+
+- `mode` must be `LIVE` or `SIMULATION`.
+- `simulation` mirrors the boolean we expose locally for convenience.
+- `remote.enabled` and `remote.mode` are echoed back so the client can display mirror status.
+
+### `POST /tokens/earn`
+
+Credits the commander’s balance.
+
+**Request body**
+```json
+{
+  "amount": 750,
+  "metadata": {
+    "source": "ghostnet-console",
+    "reason": "manual-grant"
+  }
+}
+```
+
+**Response**
+```json
+{
+  "balance": 124206,
+  "transaction": {
+    "id": "txn_01HW9J3X8Z0V7",
+    "type": "earn",
+    "amount": 750,
+    "delta": 750,
+    "balance": 124206,
+    "timestamp": "2024-03-20T18:45:02.004Z",
+    "metadata": {
+      "source": "ghostnet-console",
+      "reason": "manual-grant"
+    }
+  }
+}
+```
+
+### `POST /tokens/spend`
+
+Debits the ledger by `amount`. Payload and response mirror `/tokens/earn` except `type` becomes `"spend"` and `delta` is negative.
+
+### `GET /tokens/transactions?limit=100`
+
+Returns the latest transactions in reverse chronological order. Each entry should match the `transaction` schema above. The ledger currently truncates to the last 100 entries when `limit` is omitted.
+
+### Error handling expectations
+
+- Non-2xx responses should include `{ "error": "STRING_CODE", "message": "Human readable" }`.
+- The client treats network failures as a soft warning: the local ledger still applies the change, but `remote.synced` remains `false`. The service should therefore never throw fatal errors; respond with HTTP 503 plus the error payload when the mirror cannot process a mutation so the client can log a warning.
+- Request timeouts longer than `ICARUS_TOKENS_REMOTE_TIMEOUT_MS` should be avoided.
+
+## Implementation guidance for the remote service agent
+
+1. Provide the four endpoints above. They must accept/return JSON exactly as documented.
+2. Authenticate requests using the optional bearer token header. If the header is missing but the service requires authentication, respond with HTTP 401.
+3. Persist balances and transactions so that the service remains authoritative even if ICARUS restarts. The schema must allow negative balances.
+4. Return the updated balance in the body of every mutation response so the Node service can mirror it back into the local ledger.
+5. Include `remote.enabled` and `remote.mode` in the balance response. Even if the remote service is the authority, echoing this data keeps the client’s status badge accurate.
+6. Ensure idempotency guards exist if you expect retried requests (e.g., supply an optional `idempotencyKey` header). The current caller does not send one yet, but accommodating it will keep us future-proof.
+7. Document any additional error codes in the service README so we can extend the client later if needed.
+
+With this API in place we can flip `ICARUS_TOKENS_REMOTE_MODE=MIRROR` and begin synchronising the on-device ledger with the central service without further code changes.

--- a/docs/tokens/inara-api-brief.md
+++ b/docs/tokens/inara-api-brief.md
@@ -1,0 +1,44 @@
+# INARA API & GhostNet Token Economy Brief
+
+## API overview
+- **Authentication:** INARA requires an API key tied to a registered application plus the commander name. Requests include `header` metadata with `appName`, `appVersion`, `APIkey`, and `commanderName` values. The public API accepts HTTPS POST payloads at `https://inara.cz/inapi/v1/`.
+- **Payload shape:** Requests send an object with `header` and an `events` array. Each event contains an `eventName`, optional `eventTimestamp`, and `eventData` object. Responses mirror the array with `eventStatus`, `eventStatusText`, and `eventData`.
+- **Rate limiting:** INARA enforces 1 request per second baseline and may throttle bursts. Applications are also expected to avoid sending duplicate telemetry.
+- **Supported events:** The API includes telemetry submissions (`setCommanderInventoryMaterials`, `setCommanderMarket`, `setCommanderShip`, etc.) and lookup events (`getStarSystem`, `getStation`, `getMarket`, etc.). Some responses embed pagination tokens.
+- **Error handling:** Non-2xx HTTP responses indicate transport failures. Within 200 responses, failed events carry `eventStatus` values `300`+ and detailed text. Clients should log and optionally retry after the recommended delay.
+
+## GhostNet request comparison
+- Existing GhostNet scrapers (e.g., `/api/ghostnet-search`) currently post JSON objects with `appName`, `appVersion`, and `events` to INARA, omitting `APIkey` until credentials are supplied.
+- GhostNet queues heterogeneous events per request (market, outfitting, shipyard) matching the official schema but currently stubs authentication fields.
+- The payload structure aligns with INARA’s expectations, so the token system can treat each outbound request as a unit of cost without additional normalization.
+
+## Proposed token reward schedule
+| Telemetry source | Event mapping | Proposed tokens |
+| --- | --- | --- |
+| Market journal snapshot | `Market`, `CommodityPrices` -> `setCommanderMarket` | 750 |
+| Outfitting snapshot | `Outfitting` -> `setCommanderOutfitting` | 600 |
+| Shipyard snapshot | `Shipyard` -> `setCommanderShipyard` | 600 |
+| Mission completion | `MissionCompleted` -> `setCommanderMissionCompleted` | 400 |
+| Material inventory | `MaterialCollected` -> `setCommanderInventoryMaterials` | 250 |
+| Data material inventory | `DataScanned` -> `setCommanderInventoryMaterials` | 250 |
+| Engineer progress | `EngineerProgress` -> `setCommanderEngineer` | 500 |
+
+Values assume simulation mode; they can be tuned once real submission cadences are known.
+
+## Token spend guidance
+- Each INARA API request (scraper or future live submission) should deduct a baseline 250 tokens.
+- Expensive scrapers (trade routes, missions) may cost 400–600 tokens depending on complexity and rate limits.
+- General web searches can share a 200 token baseline to reflect lighter HTML scraping.
+
+## Outstanding questions
+1. **Authentication cadence:** Confirm whether GhostNet must rotate commander credentials per session or can reuse a shared app key.
+2. **Bulk submission size:** Validate INARA’s maximum `events` array length and payload size to size ledger granularity.
+3. **Rate limit feedback:** Determine if INARA includes headers for remaining quota to refine spend costs dynamically.
+4. **Error retries:** Decide whether failed submissions refund tokens automatically or require manual adjustment.
+5. **Cost tuning:** Monitor real usage to adjust reward/spend ratios and prevent runaway negative balances.
+
+## Next steps once API key is available
+- Implement secure storage for `APIkey` (likely service-side env var with optional commander override).
+- Exercise the submission events end-to-end, verifying response codes and refining error handling.
+- Adjust the reward table using empirical event frequency to maintain a healthy in-app economy.
+- Document operator playbooks for handling throttling or extended INARA outages.

--- a/docs/tokens/scraper-audit.md
+++ b/docs/tokens/scraper-audit.md
@@ -1,0 +1,45 @@
+# GhostNet Scraper & Search Audit
+
+## Service-side ingestion
+- `src/service/lib/events.js` boots the Elite Dangerous log readers and wires `loadFileCallback`, `logEventCallback`, and `eliteJsonCallback`.
+- Event handlers live under `src/service/lib/event-handlers/` with domain modules for cargo, missions, outfitting, trade routes, etc.
+- Broadcast helpers expose `global.BROADCAST_EVENT` so handlers can push updates to connected sockets.
+- Current ingestion does not award currency; events simply update caches (`marketCache`, `shipStatus`, mission queues).
+
+## Next.js API routes touching GhostNet/INARA
+| Route | Responsibilities | Shared behaviors |
+| --- | --- | --- |
+| `/api/ghostnet-commodity-values` | Combines journal market data with GhostNet market listings via INARA API | Uses `resolveLogDir`, local cache writes, cheerio parsing |
+| `/api/ghostnet-trade-routes` | Scrapes GhostNet trade route HTML, normalizes legs, calculates profits | Shares fetch wrapper, logging, and queue serialization |
+| `/api/ghostnet-missions` | Downloads GhostNet missions table, merges faction data | Similar error handling/logging, uses system selector helpers |
+| `/api/ghostnet-pristine-mining` | Fetches pristine mining listings, attaches metadata | Reuses caching helpers, minimal logging |
+| `/api/ghostnet-websearch` | Performs GhostNet search across commodities/ships/outfitting | Builds multi-event INARA payload, uses common fetch options |
+| `/api/ghostnet-search` | General INARA API bridge; constructs `events` array dynamically | Houses base request builder used by other routes |
+
+Shared concerns ripe for ScraperEngine extraction:
+- Log directory resolution (`resolveLogDir`, environment fallbacks).
+- HTTP agents with keep-alive and user-agent headers.
+- Retry/backoff policies for INARA and GhostNet HTML requests.
+- Unified logging (success, failure, cache hits) and metrics.
+- Token spend hooks (to be introduced) should reside alongside fetch helpers.
+
+## General search workflow
+- Client builds search payloads via `/api/ghostnet-search`, which proxies to INARA using the `events` array structure.
+- Route queues heterogeneous lookup events and returns combined results to the client for display.
+- Lacks per-request cost instrumentation; future ScraperEngine should wrap outbound fetch to apply uniform accounting and logging.
+
+## Extension requirements for ScraperEngine
+1. Provide a factory that accepts `requestType` metadata and returns fetch helpers preconfigured with logging, retries, and token spending.
+2. Expose shared utilities for caching paths and file IO to eliminate duplicated directory math.
+3. Surface instrumentation hooks (e.g., `onBeforeRequest`, `onAfterResponse`) so each scraper can register route-specific telemetry.
+4. Bundle schema normalizers (HTML -> structured data) where feasible to centralize transformation logic.
+5. Keep the engine agnostic to GhostNet vs. INARA endpoints so future integrations (other web APIs) can opt in with minimal code.
+
+## Observations
+- Several routes manually duplicate try/catch blocks for fetch + cheerio parsing; the engine should own this pattern.
+- The existing logging is inconsistent (`console.log`, `logger.info`, custom log files); centralize under one helper for clarity.
+- Rate limiting is ad hoc; a queue or token bucket inside the engine would simplify compliance if INARA tightens limits.
+
+## Recommended follow-ups
+- Inventory each scraper’s token cost once the ledger is in place and capture them in shared configuration.
+- Add integration tests for the engine once implemented to catch regressions when GhostNet or INARA markup changes.

--- a/src/client/__tests__/ghostnet.test.js
+++ b/src/client/__tests__/ghostnet.test.js
@@ -26,6 +26,13 @@ describe('Ghost Net page', () => {
   beforeEach(() => {
     mockSendEvent.mockClear()
     mockEventListener.mockClear()
+    mockSendEvent.mockImplementation((eventName) => {
+      if (eventName === 'getTokenBalance') {
+        return Promise.resolve({ balance: 1337, mode: 'SIMULATION', simulation: true, remote: { enabled: false, mode: 'DISABLED' } })
+      }
+      return Promise.resolve(null)
+    })
+    mockEventListener.mockImplementation(() => () => {})
   })
 
   it('renders the Ghost Net status summary without the hero heading', async () => {
@@ -47,5 +54,13 @@ describe('Ghost Net page', () => {
     expect(screen.getByText(/cross-reference ghostnet freight whispers/i)).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /mining missions/i, hidden: true })).toBeInTheDocument()
     expect(screen.getByText(/ghost net decrypts volunteer ghostnet manifests/i)).toBeInTheDocument()
+  })
+
+  it('renders the token console meter with request control', async () => {
+    await act(async () => { render(<GhostnetPage />) })
+
+    expect(mockSendEvent).toHaveBeenCalledWith('getTokenBalance')
+    expect(await screen.findByText(/tokens/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /request 100000 tokens/i })).toBeInTheDocument()
   })
 })

--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -1,6 +1,6 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useRouter } from 'next/router'
-import { socketOptions } from 'lib/socket'
+import { socketOptions, sendEvent, eventListener } from 'lib/socket'
 import { isWindowFullScreen, isWindowPinned, toggleFullScreen, togglePinWindow } from 'lib/window'
 import { eliteDateTime } from 'lib/format'
 import { Settings } from 'components/settings'
@@ -64,6 +64,11 @@ export default function Header ({ connected, active }) {
   const activeTitleGlitchIndices = useRef(new Set())
   const currentPath = `/${(router.pathname.split('/')[1] || '').toLowerCase()}`
   const isGhostnetRouteActive = currentPath === '/ghostnet'
+  const [tokenBalance, setTokenBalance] = useState(null)
+  const [tokenMode, setTokenMode] = useState(null)
+  const [tokenSimulation, setTokenSimulation] = useState(false)
+  const [tokenLoading, setTokenLoading] = useState(false)
+  const [tokenActionPending, setTokenActionPending] = useState(false)
 
   const clearTitleAnimationTimeouts = useCallback(() => {
     const clearTimeoutFn = typeof window !== 'undefined' ? window.clearTimeout : clearTimeout
@@ -337,6 +342,95 @@ export default function Header ({ connected, active }) {
     return undefined
   }, [isGhostnetRouteActive, startTitleGlitching, stopTitleGlitching, titleAssimilated])
 
+  useEffect(() => {
+    let unsubscribe = null
+    let active = true
+
+    const applySnapshot = (snapshot = {}) => {
+      if (!active) return
+      const nextBalance = typeof snapshot.balance === 'number' ? snapshot.balance : null
+      const nextMode = typeof snapshot.mode === 'string' ? snapshot.mode : null
+      const nextSimulation = Boolean(snapshot.simulation)
+      setTokenBalance(nextBalance)
+      setTokenMode(nextMode)
+      setTokenSimulation(nextSimulation)
+    }
+
+    if (!isGhostnetRouteActive) {
+      setTokenBalance(null)
+      setTokenMode(null)
+      setTokenSimulation(false)
+      setTokenLoading(false)
+      return () => {}
+    }
+
+    setTokenLoading(true)
+
+    sendEvent('getTokenBalance')
+      .then((response) => {
+        if (!active) return
+        applySnapshot(response || {})
+      })
+      .catch((error) => {
+        console.warn('Failed to load token balance', error)
+        if (!active) return
+        setTokenBalance(null)
+        setTokenMode(null)
+        setTokenSimulation(false)
+      })
+      .finally(() => {
+        if (active) setTokenLoading(false)
+      })
+
+    unsubscribe = eventListener('ghostnetTokensUpdated', (payload = {}) => {
+      const snapshot = payload?.snapshot || payload || {}
+      applySnapshot(snapshot)
+    })
+
+    return () => {
+      active = false
+      if (typeof unsubscribe === 'function') unsubscribe()
+    }
+  }, [isGhostnetRouteActive])
+
+  const handleAddTokens = useCallback(async () => {
+    if (!isGhostnetRouteActive || tokenActionPending) return
+    setTokenActionPending(true)
+    try {
+      await sendEvent('awardTokens', {
+        amount: 100000,
+        metadata: { source: 'ghostnet-header', reason: 'manual-token-boost' }
+      })
+    } catch (error) {
+      console.warn('Failed to award tokens', error)
+    } finally {
+      setTokenActionPending(false)
+    }
+  }, [isGhostnetRouteActive, tokenActionPending])
+
+  const tokenDisplayValue = useMemo(() => {
+    if (!isGhostnetRouteActive) return null
+    if (tokenLoading) return '…'
+    if (typeof tokenBalance === 'number') {
+      try {
+        return tokenBalance.toLocaleString('en-US')
+      } catch (error) {
+        console.warn('Failed to format token balance', error)
+        return String(tokenBalance)
+      }
+    }
+    if (tokenMode === 'UNAVAILABLE') return 'N/A'
+    return '—'
+  }, [isGhostnetRouteActive, tokenLoading, tokenBalance, tokenMode])
+
+  const tokenStatusLabel = useMemo(() => {
+    if (!isGhostnetRouteActive) return null
+    if (tokenMode === 'UNAVAILABLE') return 'Offline'
+    if (tokenSimulation) return 'Sim'
+    if (tokenMode) return tokenMode
+    return null
+  }, [isGhostnetRouteActive, tokenMode, tokenSimulation])
+
   let signalClassName = 'icon icarus-terminal-signal '
   if (!connected) {
     signalClassName += 'text-primary'
@@ -395,7 +489,72 @@ export default function Header ({ connected, active }) {
           </span>
         </span>
       </h1>
-      <div style={{ position: 'absolute', top: '1rem', right: '.5rem' }}>
+      <div
+        style={{
+          position: 'absolute',
+          top: '1rem',
+          right: '.5rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '1rem'
+        }}
+      >
+        {isGhostnetRouteActive && (
+          <div
+            className='text-primary text-uppercase'
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '.5rem',
+              marginRight: '.5rem',
+              padding: '.25rem .5rem',
+              border: '1px solid rgba(140, 92, 255, 0.35)',
+              borderRadius: '.5rem',
+              background: 'rgba(28, 22, 51, 0.72)',
+              boxShadow: '0 0 12px rgba(93, 46, 255, 0.45)'
+            }}
+          >
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', lineHeight: '1.1rem' }}>
+              <span style={{ fontSize: '.9rem', letterSpacing: '.12em' }}>Tokens</span>
+              <span
+                style={{
+                  fontSize: '1.5rem',
+                  fontWeight: 600,
+                  minWidth: '7ch',
+                  textAlign: 'right',
+                  color: 'rgba(245, 241, 255, 0.92)'
+                }}
+              >
+                {tokenDisplayValue}
+              </span>
+            </div>
+            {tokenStatusLabel && (
+              <span
+                className='text-muted'
+                style={{ fontSize: '.75rem', letterSpacing: '.16em', textTransform: 'uppercase' }}
+              >
+                {tokenStatusLabel}
+              </span>
+            )}
+            <button
+              type='button'
+              className='button--icon button--transparent'
+              onClick={handleAddTokens}
+              disabled={tokenActionPending}
+              aria-label='Add 100000 GhostNet tokens'
+              style={{
+                marginLeft: '.25rem',
+                fontSize: '1.6rem',
+                fontWeight: 600,
+                lineHeight: '1.2rem',
+                opacity: tokenActionPending ? 0.5 : 1,
+                transition: 'opacity .2s ease'
+              }}
+            >
+              +
+            </button>
+          </div>
+        )}
         <p
           className='text-primary text-center text-uppercase'
           style={{ display: 'inline-block', padding: 0, margin: 0, lineHeight: '1rem', minWidth: '7.5rem' }}

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -237,6 +237,83 @@
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
 }
 
+.terminalTokenRow {
+  margin-top: 0.35rem;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+}
+
+.terminalTokenLabel {
+  font-size: 0.72rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
+}
+
+.terminalTokenValue {
+  font-size: 0.96rem;
+  letter-spacing: 0.08em;
+  color: var(--ghostnet-color-text-strong);
+  min-width: 5rem;
+  text-align: right;
+}
+
+.terminalTokenValueNegative {
+  color: var(--ghostnet-color-warning);
+  text-shadow: 0 0 0.8rem color-mix(in srgb, var(--ghostnet-color-warning) 55%, transparent);
+}
+
+.terminalTokenButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 50%;
+  border: 1px solid var(--ghostnet-border-strong);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 68%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 46%, transparent));
+  color: var(--ghostnet-color-text-strong);
+  font-size: 1.1rem;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  transition: background 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+  box-shadow: 0 0 0 transparent;
+}
+
+button.terminalTokenButton:hover:not([disabled]),
+button.terminalTokenButton:focus-visible:not([disabled]) {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 84%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 58%, transparent));
+  transform: translateY(-1px);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
+}
+
+button.terminalTokenButton:focus-visible:not([disabled]) {
+  outline: 2px solid color-mix(in srgb, var(--ghostnet-color-primary-light) 90%, transparent);
+  outline-offset: 3px;
+}
+
+button.terminalTokenButton:active:not([disabled]) {
+  transform: translateY(1px);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary-dark) 72%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 48%, transparent));
+  box-shadow: 0 0 10px color-mix(in srgb, var(--ghostnet-color-primary-dark) 40%, transparent);
+}
+
+button.terminalTokenButton:disabled {
+  opacity: 0.62;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.terminalTokenMeta {
+  margin-top: 0.35rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 54%, transparent);
+}
+
 .terminalToggle {
   position: relative;
   display: inline-flex;

--- a/src/service/lib/__tests__/token-ledger.test.js
+++ b/src/service/lib/__tests__/token-ledger.test.js
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ */
+
+const path = require('path')
+const os = require('os')
+const fs = require('fs-extra')
+
+const TokenLedger = require('../token-ledger')
+
+function createTempDir () {
+  const dir = path.join(os.tmpdir(), `token-ledger-test-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`)
+  fs.ensureDirSync(dir)
+  return dir
+}
+
+describe('TokenLedger', () => {
+  let tempDir
+
+  beforeEach(() => {
+    tempDir = createTempDir()
+  })
+
+  afterEach(async () => {
+    await fs.remove(tempDir)
+  })
+
+  it('bootstraps with initial balance when no files exist', async () => {
+    const ledger = new TokenLedger({ storageDir: tempDir, initialBalance: 1234, mode: TokenLedger.TOKEN_MODES.SIMULATION })
+    const snapshot = await ledger.bootstrap()
+    expect(snapshot.balance).toBe(1234)
+    expect(snapshot.simulation).toBe(true)
+  })
+
+  it('records earn and spend transactions sequentially', async () => {
+    const ledger = new TokenLedger({ storageDir: tempDir, initialBalance: 0 })
+    await ledger.bootstrap()
+
+    await ledger.recordEarn(500, { reason: 'test-earn' })
+    await ledger.recordSpend(150, { reason: 'test-spend' })
+
+    const balance = await ledger.getBalance()
+    expect(balance).toBe(350)
+
+    const transactions = await ledger.listTransactions()
+    expect(transactions).toHaveLength(2)
+    expect(transactions[0].type).toBe('earn')
+    expect(transactions[1].type).toBe('spend')
+  })
+
+  it('allows negative balances', async () => {
+    const ledger = new TokenLedger({ storageDir: tempDir, initialBalance: 10 })
+    await ledger.bootstrap()
+
+    await ledger.recordSpend(25)
+    expect(await ledger.getBalance()).toBe(-15)
+  })
+
+  it('serializes concurrent writes', async () => {
+    const ledger = new TokenLedger({ storageDir: tempDir, initialBalance: 0 })
+    await ledger.bootstrap()
+
+    await Promise.all([
+      ledger.recordEarn(100),
+      ledger.recordEarn(50),
+      ledger.recordSpend(25)
+    ])
+
+    const balance = await ledger.getBalance()
+    expect(balance).toBe(125)
+
+    const ledgerFile = await fs.readJson(path.join(tempDir, 'ledger.json'))
+    expect(ledgerFile.balance).toBe(125)
+  })
+})

--- a/src/service/lib/token-ledger.js
+++ b/src/service/lib/token-ledger.js
@@ -6,14 +6,108 @@ const {
   getInitialTokenBalance,
   getTokenMode,
   shouldSimulateTokenTransfers,
-  TOKEN_MODES
+  TOKEN_MODES,
+  getRemoteLedgerConfig,
+  TOKEN_REMOTE_MODES
 } = require('../../shared/token-config')
+
+const DEFAULT_REMOTE_TIMEOUT = 8000
 
 const LEDGER_FILENAME = 'ledger.json'
 const TRANSACTIONS_FILENAME = 'transactions.jsonl'
 
 function createEntryId () {
   return `${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 10)}`
+}
+
+class RemoteLedgerClient {
+  constructor (config = {}) {
+    this.mode = config.mode || TOKEN_REMOTE_MODES.DISABLED
+    this.baseUrl = (config.endpoint || '').replace(/\/+$/, '')
+    this.apiKey = config.apiKey || null
+    this.timeout = Number.isFinite(config.timeout) && config.timeout > 0 ? config.timeout : DEFAULT_REMOTE_TIMEOUT
+    this.fetchImpl = config.fetchImpl || (typeof fetch === 'function' ? fetch : null)
+    this.enabled = config.enabled !== undefined ? Boolean(config.enabled) : null
+  }
+
+  isEnabled () {
+    if (this.enabled !== null) {
+      return this.enabled && this.baseUrl && typeof this.fetchImpl === 'function'
+    }
+    return this.mode !== TOKEN_REMOTE_MODES.DISABLED && this.baseUrl && typeof this.fetchImpl === 'function'
+  }
+
+  async fetchSnapshot () {
+    return this._request('/tokens/balance', { method: 'GET' })
+  }
+
+  async recordTransaction (type, amount, metadata = {}) {
+    const path = type === 'earn' ? '/tokens/earn' : '/tokens/spend'
+    return this._request(path, {
+      method: 'POST',
+      body: JSON.stringify({ amount, metadata })
+    })
+  }
+
+  async _request (path, options = {}) {
+    if (!this.isEnabled()) return null
+    const target = `${this.baseUrl}${path}`
+    const controller = typeof AbortController !== 'undefined' ? new AbortController() : null
+    const timeoutId = controller ? setTimeout(() => controller.abort(), this.timeout) : null
+
+    const headers = { ...(options.headers || {}) }
+    if (options.method && options.method.toUpperCase() !== 'GET') {
+      if (!headers['Content-Type'] && !headers['content-type']) {
+        headers['Content-Type'] = 'application/json'
+      }
+    }
+    if (this.apiKey && !headers.Authorization) {
+      headers.Authorization = `Bearer ${this.apiKey}`
+    }
+
+    const requestOptions = {
+      method: options.method || 'GET',
+      headers,
+      signal: controller ? controller.signal : undefined
+    }
+
+    if (options.body) {
+      requestOptions.body = options.body
+    }
+
+    try {
+      const response = await this.fetchImpl(target, requestOptions)
+      if (timeoutId) clearTimeout(timeoutId)
+      if (!response.ok) {
+        throw new Error(`Remote ledger responded with status ${response.status}`)
+      }
+      const contentType = response.headers?.get ? response.headers.get('content-type') : null
+      if (contentType && !contentType.includes('json')) {
+        return null
+      }
+      const text = await response.text()
+      if (!text) return null
+      try {
+        return JSON.parse(text)
+      } catch (error) {
+        console.warn('[TokenLedger] Remote ledger returned non-JSON payload')
+        return null
+      }
+    } catch (error) {
+      if (timeoutId) clearTimeout(timeoutId)
+      console.warn('[TokenLedger] Remote ledger request failed', error)
+      return null
+    }
+  }
+}
+
+function createRemoteLedgerClient (config = {}) {
+  const fetchImpl = config.fetchImpl || (typeof fetch === 'function' ? fetch : null)
+  if (config.enabled === false) return null
+  if (!fetchImpl) return null
+  if (config.mode === TOKEN_REMOTE_MODES.DISABLED && !config.enabled) return null
+  if (!(config.endpoint || '').trim()) return null
+  return new RemoteLedgerClient({ ...config, fetchImpl })
 }
 
 class TokenLedger {
@@ -23,6 +117,11 @@ class TokenLedger {
     this.storageDir = options.storageDir || path.join(Preferences.preferencesDir(), 'tokens')
     this.ledgerPath = path.join(this.storageDir, LEDGER_FILENAME)
     this.transactionsPath = path.join(this.storageDir, TRANSACTIONS_FILENAME)
+    this.remoteConfig = options.remote ? { ...getRemoteLedgerConfig(), ...options.remote } : getRemoteLedgerConfig()
+    if (options.remoteFetch) {
+      this.remoteConfig = { ...this.remoteConfig, fetchImpl: options.remoteFetch }
+    }
+    this.remoteClient = options.remoteClient || createRemoteLedgerClient(this.remoteConfig)
 
     this._writeQueue = Promise.resolve()
     this._state = { balance: this.initialBalance }
@@ -60,6 +159,8 @@ class TokenLedger {
         this._transactions = []
       }
     }
+
+    await this._syncRemoteSnapshot()
 
     this._initialized = true
   }
@@ -101,7 +202,8 @@ class TokenLedger {
     return {
       balance: this._state.balance,
       mode: this.mode,
-      simulation: this.isSimulation()
+      simulation: this.isSimulation(),
+      remote: this._describeRemoteState()
     }
   }
 
@@ -139,12 +241,55 @@ class TokenLedger {
         metadata: metadata || {},
         mode: this.mode
       }
+
+      if (this.remoteClient && this.remoteClient.isEnabled()) {
+        const remoteResult = await this.remoteClient.recordTransaction(type, normalizedAmount, metadata).catch(() => null)
+        if (remoteResult && Number.isFinite(remoteResult.balance)) {
+          this._state.balance = remoteResult.balance
+          entry.balance = remoteResult.balance
+          entry.remote = this._describeRemoteState({ synced: true })
+        } else {
+          entry.remote = this._describeRemoteState({ synced: false })
+        }
+      } else if (this.remoteClient) {
+        entry.remote = this._describeRemoteState({ synced: false })
+      } else {
+        entry.remote = this._describeRemoteState()
+      }
+
       this._transactions.push(entry)
       await this._persistState()
       await fs.appendFile(this.transactionsPath, `${JSON.stringify(entry)}\n`)
-      console.log(`[TokenLedger] ${type} ${normalizedAmount} (delta ${delta}) -> balance ${this._state.balance} [${this.mode}]`, metadata)
+      const remoteStatus = entry.remote?.enabled ? (entry.remote.synced ? 'remote:synced' : 'remote:pending') : 'remote:disabled'
+      console.log(`[TokenLedger] ${type} ${normalizedAmount} (delta ${delta}) -> balance ${this._state.balance} [${this.mode}] [${remoteStatus}]`, metadata)
       return entry
     })
+  }
+
+  async _syncRemoteSnapshot () {
+    if (!this.remoteClient || !this.remoteClient.isEnabled()) return null
+    try {
+      const snapshot = await this.remoteClient.fetchSnapshot()
+      if (snapshot && Number.isFinite(snapshot.balance)) {
+        this._state.balance = snapshot.balance
+        await this._persistState()
+      }
+      return snapshot
+    } catch (error) {
+      console.warn('[TokenLedger] Failed to synchronise remote snapshot', error)
+      return null
+    }
+  }
+
+  _describeRemoteState (overrides = {}) {
+    if (!this.remoteClient) {
+      return { enabled: false, mode: TOKEN_REMOTE_MODES.DISABLED, ...overrides }
+    }
+    return {
+      enabled: this.remoteClient.isEnabled(),
+      mode: this.remoteClient.mode || TOKEN_REMOTE_MODES.DISABLED,
+      ...overrides
+    }
   }
 
   async _persistState () {
@@ -161,5 +306,6 @@ class TokenLedger {
 }
 
 TokenLedger.TOKEN_MODES = TOKEN_MODES
+TokenLedger.REMOTE_MODES = TOKEN_REMOTE_MODES
 
 module.exports = TokenLedger

--- a/src/service/lib/token-ledger.js
+++ b/src/service/lib/token-ledger.js
@@ -1,0 +1,165 @@
+const path = require('path')
+const fs = require('fs-extra')
+
+const Preferences = require('./preferences')
+const {
+  getInitialTokenBalance,
+  getTokenMode,
+  shouldSimulateTokenTransfers,
+  TOKEN_MODES
+} = require('../../shared/token-config')
+
+const LEDGER_FILENAME = 'ledger.json'
+const TRANSACTIONS_FILENAME = 'transactions.jsonl'
+
+function createEntryId () {
+  return `${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 10)}`
+}
+
+class TokenLedger {
+  constructor (options = {}) {
+    this.mode = options.mode || getTokenMode()
+    this.initialBalance = options.initialBalance ?? getInitialTokenBalance()
+    this.storageDir = options.storageDir || path.join(Preferences.preferencesDir(), 'tokens')
+    this.ledgerPath = path.join(this.storageDir, LEDGER_FILENAME)
+    this.transactionsPath = path.join(this.storageDir, TRANSACTIONS_FILENAME)
+
+    this._writeQueue = Promise.resolve()
+    this._state = { balance: this.initialBalance }
+    this._transactions = []
+    this._initialized = false
+  }
+
+  async init () {
+    if (this._initialized) return
+
+    await fs.ensureDir(this.storageDir)
+    const ledgerExists = await fs.pathExists(this.ledgerPath)
+    if (ledgerExists) {
+      try {
+        const raw = await fs.readFile(this.ledgerPath, 'utf8')
+        const parsed = JSON.parse(raw)
+        if (Number.isFinite(parsed.balance)) {
+          this._state.balance = parsed.balance
+        }
+      } catch (error) {
+        console.warn('[TokenLedger] Failed to read ledger file, rebuilding.', error)
+        this._state.balance = this.initialBalance
+      }
+    } else {
+      await this._persistState()
+    }
+
+    const txExists = await fs.pathExists(this.transactionsPath)
+    if (txExists) {
+      try {
+        const raw = await fs.readFile(this.transactionsPath, 'utf8')
+        this._transactions = raw.split('\n').filter(Boolean).map(line => JSON.parse(line))
+      } catch (error) {
+        console.warn('[TokenLedger] Failed to read transactions log, resetting.', error)
+        this._transactions = []
+      }
+    }
+
+    this._initialized = true
+  }
+
+  async bootstrap (options = {}) {
+    if (options.mode) {
+      this.mode = options.mode
+    }
+    if (typeof options.initialBalance === 'number' && Number.isFinite(options.initialBalance)) {
+      this.initialBalance = options.initialBalance
+      if (!this._initialized) {
+        this._state.balance = options.initialBalance
+      }
+    }
+    await this.init()
+
+    if (!await fs.pathExists(this.ledgerPath)) {
+      await this._persistState()
+    }
+
+    return this.getSnapshot()
+  }
+
+  getMode () {
+    return this.mode
+  }
+
+  isSimulation () {
+    return shouldSimulateTokenTransfers({ ICARUS_TOKENS_MODE: this.mode })
+  }
+
+  async getBalance () {
+    await this.init()
+    return this._state.balance
+  }
+
+  async getSnapshot () {
+    await this.init()
+    return {
+      balance: this._state.balance,
+      mode: this.mode,
+      simulation: this.isSimulation()
+    }
+  }
+
+  async listTransactions ({ limit } = {}) {
+    await this.init()
+    if (typeof limit === 'number' && limit >= 0) {
+      return this._transactions.slice(-limit)
+    }
+    return [...this._transactions]
+  }
+
+  async recordEarn (amount, metadata = {}) {
+    return this._recordTransaction('earn', Math.abs(amount), metadata)
+  }
+
+  async recordSpend (amount, metadata = {}) {
+    return this._recordTransaction('spend', Math.abs(amount), metadata)
+  }
+
+  async _recordTransaction (type, amount, metadata) {
+    const normalizedAmount = Number.isFinite(amount) ? amount : 0
+    const delta = type === 'earn' ? normalizedAmount : -normalizedAmount
+
+    return this._enqueue(async () => {
+      await this.init()
+      const timestamp = new Date().toISOString()
+      this._state.balance = (this._state.balance ?? this.initialBalance) + delta
+      const entry = {
+        id: createEntryId(),
+        type,
+        amount: normalizedAmount,
+        delta,
+        balance: this._state.balance,
+        timestamp,
+        metadata: metadata || {},
+        mode: this.mode
+      }
+      this._transactions.push(entry)
+      await this._persistState()
+      await fs.appendFile(this.transactionsPath, `${JSON.stringify(entry)}\n`)
+      console.log(`[TokenLedger] ${type} ${normalizedAmount} (delta ${delta}) -> balance ${this._state.balance} [${this.mode}]`, metadata)
+      return entry
+    })
+  }
+
+  async _persistState () {
+    await fs.writeJson(this.ledgerPath, { balance: this._state.balance, updatedAt: new Date().toISOString() }, { spaces: 2 })
+  }
+
+  _enqueue (fn) {
+    this._writeQueue = this._writeQueue.then(() => fn()).catch(error => {
+      console.error('[TokenLedger] transaction failure', error)
+      throw error
+    })
+    return this._writeQueue
+  }
+}
+
+TokenLedger.TOKEN_MODES = TOKEN_MODES
+
+module.exports = TokenLedger

--- a/src/shared/__tests__/token-config.test.js
+++ b/src/shared/__tests__/token-config.test.js
@@ -3,7 +3,11 @@ const {
   getTokenMode,
   isTokenLedgerLive,
   shouldSimulateTokenTransfers,
-  getInitialTokenBalance
+  getInitialTokenBalance,
+  TOKEN_REMOTE_MODES,
+  getRemoteLedgerMode,
+  getRemoteLedgerConfig,
+  isRemoteLedgerEnabled
 } = require('../token-config')
 
 describe('token-config', () => {
@@ -49,6 +53,65 @@ describe('token-config', () => {
 
     it('ignores invalid numbers', () => {
       expect(getInitialTokenBalance({ ICARUS_TOKENS_INITIAL_BALANCE: 'abc' })).toBe(100000)
+    })
+  })
+
+  describe('getRemoteLedgerMode', () => {
+    it('defaults to disabled', () => {
+      expect(getRemoteLedgerMode({})).toBe(TOKEN_REMOTE_MODES.DISABLED)
+    })
+
+    it('normalizes mirror mode', () => {
+      expect(getRemoteLedgerMode({ ICARUS_TOKENS_REMOTE_MODE: 'mirror' })).toBe(TOKEN_REMOTE_MODES.MIRROR)
+    })
+
+    it('falls back to disabled on unexpected values', () => {
+      expect(getRemoteLedgerMode({ ICARUS_TOKENS_REMOTE_MODE: 'primary' })).toBe(TOKEN_REMOTE_MODES.DISABLED)
+    })
+  })
+
+  describe('getRemoteLedgerConfig', () => {
+    it('disables remote usage without endpoint', () => {
+      const config = getRemoteLedgerConfig({ ICARUS_TOKENS_REMOTE_MODE: 'mirror' })
+      expect(config.enabled).toBe(false)
+      expect(config.mode).toBe(TOKEN_REMOTE_MODES.MIRROR)
+    })
+
+    it('parses endpoint, api key and timeout when provided', () => {
+      const config = getRemoteLedgerConfig({
+        ICARUS_TOKENS_REMOTE_MODE: 'mirror',
+        ICARUS_TOKENS_REMOTE_ENDPOINT: 'https://tokens.example.com/api',
+        ICARUS_TOKENS_REMOTE_API_KEY: '  secret  ',
+        ICARUS_TOKENS_REMOTE_TIMEOUT_MS: '12000'
+      })
+
+      expect(config.enabled).toBe(true)
+      expect(config.endpoint).toBe('https://tokens.example.com/api')
+      expect(config.apiKey).toBe('secret')
+      expect(config.timeout).toBe(12000)
+    })
+
+    it('uses default timeout when invalid', () => {
+      const config = getRemoteLedgerConfig({
+        ICARUS_TOKENS_REMOTE_MODE: 'mirror',
+        ICARUS_TOKENS_REMOTE_ENDPOINT: 'https://tokens.example.com/api',
+        ICARUS_TOKENS_REMOTE_TIMEOUT_MS: '-1'
+      })
+
+      expect(config.timeout).toBe(8000)
+    })
+  })
+
+  describe('isRemoteLedgerEnabled', () => {
+    it('returns false by default', () => {
+      expect(isRemoteLedgerEnabled({})).toBe(false)
+    })
+
+    it('returns true when mirror mode and endpoint provided', () => {
+      expect(isRemoteLedgerEnabled({
+        ICARUS_TOKENS_REMOTE_MODE: 'mirror',
+        ICARUS_TOKENS_REMOTE_ENDPOINT: 'https://tokens.example.com/api'
+      })).toBe(true)
     })
   })
 })

--- a/src/shared/__tests__/token-config.test.js
+++ b/src/shared/__tests__/token-config.test.js
@@ -1,0 +1,54 @@
+const {
+  TOKEN_MODES,
+  getTokenMode,
+  isTokenLedgerLive,
+  shouldSimulateTokenTransfers,
+  getInitialTokenBalance
+} = require('../token-config')
+
+describe('token-config', () => {
+  describe('getTokenMode', () => {
+    it('defaults to simulation when env var missing', () => {
+      expect(getTokenMode({})).toBe(TOKEN_MODES.SIMULATION)
+    })
+
+    it('treats lowercase live as live', () => {
+      expect(getTokenMode({ ICARUS_TOKENS_MODE: 'live' })).toBe(TOKEN_MODES.LIVE)
+    })
+
+    it('treats unexpected value as simulation', () => {
+      expect(getTokenMode({ ICARUS_TOKENS_MODE: 'banana' })).toBe(TOKEN_MODES.SIMULATION)
+    })
+  })
+
+  describe('isTokenLedgerLive', () => {
+    it('is true when mode is live', () => {
+      expect(isTokenLedgerLive({ ICARUS_TOKENS_MODE: 'LIVE' })).toBe(true)
+    })
+
+    it('is false otherwise', () => {
+      expect(isTokenLedgerLive({ ICARUS_TOKENS_MODE: 'SIMULATION' })).toBe(false)
+    })
+  })
+
+  describe('shouldSimulateTokenTransfers', () => {
+    it('is inverse of live detection', () => {
+      expect(shouldSimulateTokenTransfers({ ICARUS_TOKENS_MODE: 'LIVE' })).toBe(false)
+      expect(shouldSimulateTokenTransfers({ ICARUS_TOKENS_MODE: 'SIMULATION' })).toBe(true)
+    })
+  })
+
+  describe('getInitialTokenBalance', () => {
+    it('defaults to 100000 when unset', () => {
+      expect(getInitialTokenBalance({})).toBe(100000)
+    })
+
+    it('parses integers when provided', () => {
+      expect(getInitialTokenBalance({ ICARUS_TOKENS_INITIAL_BALANCE: '1500' })).toBe(1500)
+    })
+
+    it('ignores invalid numbers', () => {
+      expect(getInitialTokenBalance({ ICARUS_TOKENS_INITIAL_BALANCE: 'abc' })).toBe(100000)
+    })
+  })
+})

--- a/src/shared/token-config.js
+++ b/src/shared/token-config.js
@@ -1,0 +1,56 @@
+const TOKEN_MODES = {
+  SIMULATION: 'SIMULATION',
+  LIVE: 'LIVE'
+}
+
+function getTokenMode (env = process.env) {
+  const raw = (env.ICARUS_TOKENS_MODE || '').trim().toUpperCase()
+  return raw === TOKEN_MODES.LIVE ? TOKEN_MODES.LIVE : TOKEN_MODES.SIMULATION
+}
+
+function isTokenLedgerLive (env) {
+  return getTokenMode(env) === TOKEN_MODES.LIVE
+}
+
+function shouldSimulateTokenTransfers (env) {
+  return !isTokenLedgerLive(env)
+}
+
+function getInitialTokenBalance (env = process.env) {
+  const raw = env.ICARUS_TOKENS_INITIAL_BALANCE
+  const parsed = Number.parseInt(raw, 10)
+  if (Number.isFinite(parsed)) {
+    return parsed
+  }
+  return 100000
+}
+
+const TOKEN_SPEND_COSTS = Object.freeze({
+  DEFAULT_REQUEST: 250,
+  TRADE_ROUTES: 500,
+  MISSIONS: 450,
+  PRISTINE_MINING: 400,
+  COMMODITY_VALUES: 350,
+  GENERAL_SEARCH: 200,
+  WEB_SCRAPE: 200
+})
+
+const TOKEN_REWARD_VALUES = Object.freeze({
+  MARKET_SNAPSHOT: 750,
+  OUTFITTING_SNAPSHOT: 600,
+  SHIPYARD_SNAPSHOT: 600,
+  MISSION_COMPLETED: 400,
+  MATERIAL_COLLECTED: 250,
+  DATA_COLLECTED: 250,
+  ENGINEER_PROGRESS: 500
+})
+
+module.exports = {
+  TOKEN_MODES,
+  TOKEN_SPEND_COSTS,
+  TOKEN_REWARD_VALUES,
+  getTokenMode,
+  isTokenLedgerLive,
+  shouldSimulateTokenTransfers,
+  getInitialTokenBalance
+}

--- a/src/shared/token-config.js
+++ b/src/shared/token-config.js
@@ -3,6 +3,11 @@ const TOKEN_MODES = {
   LIVE: 'LIVE'
 }
 
+const TOKEN_REMOTE_MODES = {
+  DISABLED: 'DISABLED',
+  MIRROR: 'MIRROR'
+}
+
 function getTokenMode (env = process.env) {
   const raw = (env.ICARUS_TOKENS_MODE || '').trim().toUpperCase()
   return raw === TOKEN_MODES.LIVE ? TOKEN_MODES.LIVE : TOKEN_MODES.SIMULATION
@@ -45,12 +50,57 @@ const TOKEN_REWARD_VALUES = Object.freeze({
   ENGINEER_PROGRESS: 500
 })
 
+function getRemoteLedgerMode (env = process.env) {
+  const raw = (env.ICARUS_TOKENS_REMOTE_MODE || '').trim().toUpperCase()
+  if (raw === TOKEN_REMOTE_MODES.MIRROR) return TOKEN_REMOTE_MODES.MIRROR
+  return TOKEN_REMOTE_MODES.DISABLED
+}
+
+function getRemoteLedgerEndpoint (env = process.env) {
+  return (env.ICARUS_TOKENS_REMOTE_ENDPOINT || '').trim()
+}
+
+function getRemoteLedgerApiKey (env = process.env) {
+  const raw = (env.ICARUS_TOKENS_REMOTE_API_KEY || '').trim()
+  return raw.length > 0 ? raw : null
+}
+
+function getRemoteLedgerTimeout (env = process.env) {
+  const raw = Number.parseInt((env.ICARUS_TOKENS_REMOTE_TIMEOUT_MS || '').trim(), 10)
+  if (Number.isFinite(raw) && raw > 0) return raw
+  return 8000
+}
+
+function getRemoteLedgerConfig (env = process.env) {
+  const mode = getRemoteLedgerMode(env)
+  const endpoint = getRemoteLedgerEndpoint(env)
+  const apiKey = getRemoteLedgerApiKey(env)
+  const timeout = getRemoteLedgerTimeout(env)
+  const enabled = mode !== TOKEN_REMOTE_MODES.DISABLED && endpoint.length > 0
+
+  return {
+    mode,
+    endpoint,
+    apiKey,
+    timeout,
+    enabled
+  }
+}
+
+function isRemoteLedgerEnabled (env = process.env) {
+  return getRemoteLedgerConfig(env).enabled
+}
+
 module.exports = {
   TOKEN_MODES,
+  TOKEN_REMOTE_MODES,
   TOKEN_SPEND_COSTS,
   TOKEN_REWARD_VALUES,
   getTokenMode,
   isTokenLedgerLive,
   shouldSimulateTokenTransfers,
-  getInitialTokenBalance
+  getInitialTokenBalance,
+  getRemoteLedgerMode,
+  getRemoteLedgerConfig,
+  isRemoteLedgerEnabled
 }


### PR DESCRIPTION
## Summary
- load token ledger snapshots when the GhostNet tab is active and refresh from broadcast updates
- render the token balance to the left of the header clock with a simulation status badge and grant button
- wire the add-tokens control to award 100000 credits via the existing socket event

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e03b0330bc83238d0093e5c34a6fd2