### PR TITLE
Improve GhostNet hero headings and whitespace

### DIFF
--- a/src/client/__tests__/ghostnet.test.js
+++ b/src/client/__tests__/ghostnet.test.js
@@ -35,16 +35,17 @@ describe('Ghost Net page', () => {
     mockEventListener.mockImplementation(() => () => {})
   })
 
-  it('renders the Ghost Net status summary without the hero heading', async () => {
+  it('renders the contextual hero heading and status summary', async () => {
     await act(async () => { render(<GhostnetPage />) })
 
-    expect(screen.queryByRole('heading', { level: 1, name: /ghost net/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { level: 1, name: /ghostnet operations/i })).not.toBeInTheDocument()
+    expect(await screen.findByRole('heading', { level: 1, name: /trade routes/i })).toBeInTheDocument()
 
-    const statusPanel = await screen.findByRole('complementary', { name: /signal brief/i })
-    expect(within(statusPanel).getByText(/uplink/i)).toBeInTheDocument()
-    expect(within(statusPanel).getByText(/linking/i)).toBeInTheDocument()
-    expect(within(statusPanel).getByText(/focus/i)).toBeInTheDocument()
-    expect(within(statusPanel).getByText(/idle/i)).toBeInTheDocument()
+    const statusPanel = await screen.findByRole('complementary', { name: /trade routes uplink status/i })
+    expect(within(statusPanel).getByText(/signal focus/i)).toBeInTheDocument()
+    expect(within(statusPanel).getByText(/trade routes/i)).toBeInTheDocument()
+    expect(within(statusPanel).getByText(/routing sync/i)).toBeInTheDocument()
+    expect(within(statusPanel).getByText(/live/i)).toBeInTheDocument()
   })
 
   it('exposes key Ghost Net panels for missions and mining', async () => {

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -59,6 +59,45 @@ const MISSIONS_CACHE_LIMIT = 8
 const TABLE_SCROLL_AREA_STYLE = { maxHeight: 'calc(100vh - 360px)', overflowY: 'auto' }
 const STATION_TABLE_SCROLL_AREA_STYLE = { maxHeight: 'calc(100vh - 340px)', overflowY: 'auto' }
 
+const HERO_CONTENT = {
+  tradeRoutes: {
+    title: 'Trade Routes',
+    subtitle: 'Plot the richest supply loops anchored to your current system and allied demand clusters.',
+    statusLabel: 'Trade routes uplink status',
+    status: [
+      { label: 'Signal Focus', value: 'Trade Routes' },
+      { label: 'Routing Sync', value: 'Live' }
+    ]
+  },
+  cargoHold: {
+    title: 'Cargo Hold',
+    subtitle: 'Audit your manifest in real time, highlighting tonnage, legality, and storage pressure.',
+    statusLabel: 'Cargo manifest telemetry',
+    status: [
+      { label: 'Signal Focus', value: 'Cargo Hold' },
+      { label: 'Manifest Sync', value: 'Live' }
+    ]
+  },
+  missions: {
+    title: 'Missions Board',
+    subtitle: 'Monitor active contracts and time-sensitive opportunities streamed straight from station logs.',
+    statusLabel: 'Mission board feed status',
+    status: [
+      { label: 'Signal Focus', value: 'Missions' },
+      { label: 'Board Feed', value: 'Streaming' }
+    ]
+  },
+  pristineMining: {
+    title: 'Pristine Mining Locations',
+    subtitle: 'Surface the highest-yield rings and surface deposits suited to your refinery and ship loadout.',
+    statusLabel: 'Prospecting intelligence status',
+    status: [
+      { label: 'Signal Focus', value: 'Pristine Mining' },
+      { label: 'Prospect Sync', value: 'Active' }
+    ]
+  }
+}
+
 function getMissionsCacheStorage () {
   if (typeof window === 'undefined') {
     return { entries: {} }
@@ -4459,6 +4498,7 @@ export default function GhostnetPage() {
   ]), [activeTab])
 
   const ghostnetClassName = [styles.ghostnet, arrivalMode ? styles.arrival : ''].filter(Boolean).join(' ')
+  const heroContent = HERO_CONTENT[activeTab] || HERO_CONTENT.tradeRoutes
 
   return (
     <Layout connected={connected} active={socketActive} ready={ready} loader={false}>
@@ -4472,23 +4512,27 @@ export default function GhostnetPage() {
         <div className={ghostnetClassName}>
           <div className={styles.hero}>
             <div className={styles.heroHeader}>
-              <h1 className={styles.heroTitle}>GhostNet Operations</h1>
-              <p className={styles.heroSubtitle}>
-                Synthesise trade intelligence, mission alerts, and refinery telemetry in one continuous sweep.
-              </p>
+              <h1 className={styles.heroTitle}>{heroContent.title}</h1>
+              {heroContent.subtitle && (
+                <p className={styles.heroSubtitle}>{heroContent.subtitle}</p>
+              )}
             </div>
-            <aside className={styles.heroStatus} role='complementary' aria-label='Signal Brief'>
-              <dl className={styles.heroStatusList}>
-                <div className={styles.heroStatusItem}>
-                  <dt className={styles.heroStatusLabel}>Uplink</dt>
-                  <dd className={styles.heroStatusValue}>Linking</dd>
-                </div>
-                <div className={styles.heroStatusItem}>
-                  <dt className={styles.heroStatusLabel}>Focus</dt>
-                  <dd className={styles.heroStatusValue}>Idle</dd>
-                </div>
-              </dl>
-            </aside>
+            {heroContent.status?.length > 0 && (
+              <aside
+                className={styles.heroStatus}
+                role='complementary'
+                aria-label={heroContent.statusLabel || 'Panel status'}
+              >
+                <dl className={styles.heroStatusList}>
+                  {heroContent.status.map(item => (
+                    <div key={item.label} className={styles.heroStatusItem}>
+                      <dt className={styles.heroStatusLabel}>{item.label}</dt>
+                      <dd className={styles.heroStatusValue}>{item.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </aside>
+            )}
           </div>
           <div className={styles.shell}>
             <div className={styles.tabPanels}>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -32,7 +32,7 @@
   --ghostnet-gradient-top: color-mix(in srgb, var(--ghostnet-color-surface) 92%, transparent);
   --ghostnet-gradient-mid: color-mix(in srgb, var(--ghostnet-color-primary-dark) 60%, transparent);
   --ghostnet-gradient-bottom: color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent);
-  padding: 2.5rem 3rem calc(3.5rem + var(--ghostnet-terminal-height));
+  padding: clamp(3rem, 5vw, 4.25rem) clamp(1.75rem, 5vw, 3.75rem) calc(4.25rem + var(--ghostnet-terminal-height));
   background: linear-gradient(165deg, var(--ghostnet-gradient-top) 0%, var(--ghostnet-gradient-mid) 55%, var(--ghostnet-gradient-bottom) 100%),
     var(--ghostnet-bg);
   color: var(--ghostnet-ink);
@@ -125,7 +125,7 @@
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 2.75rem;
+  gap: clamp(2.5rem, 4.5vw, 3.5rem);
 }
 
 .hero {
@@ -133,7 +133,10 @@
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: clamp(1.5rem, 3.5vw, 2.5rem);
+  padding-bottom: clamp(1.75rem, 4vw, 2.75rem);
+  margin-bottom: clamp(2.25rem, 5vw, 3.5rem);
+  border-bottom: 1px solid var(--ghostnet-divider);
 }
 
 @media (min-width: 768px) {
@@ -148,7 +151,7 @@
   max-width: 40rem;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: clamp(0.85rem, 2vw, 1.2rem);
 }
 
 .heroTitle {
@@ -170,14 +173,16 @@
 .heroStatus {
   border: 1px solid var(--ghostnet-border-soft);
   border-radius: 1.1rem;
-  padding: 1.25rem 1.75rem;
+  padding: clamp(1.5rem, 3vw, 2rem) clamp(1.5rem, 3.2vw, 2.5rem);
   background: color-mix(in srgb, var(--ghostnet-color-surface) 80%, transparent);
   box-shadow: 0 0.75rem 2.4rem color-mix(in srgb, var(--ghostnet-shadow) 55%, transparent);
 }
 
 .heroStatusList {
   display: flex;
-  gap: 1.75rem;
+  flex-wrap: wrap;
+  gap: clamp(1.25rem, 3vw, 1.9rem);
+  row-gap: clamp(1.1rem, 3vw, 1.6rem);
   margin: 0;
   padding: 0;
 }
@@ -555,19 +560,19 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 .sectionGroup {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(1.75rem, 4vw, 2.75rem);
 }
 
 .tableSection {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(1.75rem, 3.5vw, 2.5rem);
 }
 
 .tableSectionHeader {
   display: grid;
-  gap: 1rem;
-  padding-bottom: 0.5rem;
+  gap: clamp(1.1rem, 3vw, 1.5rem);
+  padding-bottom: clamp(1rem, 3vw, 1.5rem);
   align-items: start;
 }
 


### PR DESCRIPTION
## Summary
- swap the GhostNet overview hero for tab-specific titles and status copy
- expand GhostNet layout spacing to give headings, tables, and sections more breathing room
- update the GhostNet test suite to cover the new contextual heading and status labels

## Testing
- npm test -- --runInBand --config jest.config.js
- CI=1 npm run build:client


------
https://chatgpt.com/codex/tasks/task_e_68e09ace78c483238f3f19c56ca7badb