### PR TITLE
Fix trade routes system selector wiring

### DIFF
--- a/src/client/pages/api/ghostnet-trade-routes.js
+++ b/src/client/pages/api/ghostnet-trade-routes.js
@@ -317,7 +317,7 @@ const allowedPriceAges = new Set(['8', '16', '24', '48', '72'])
 const allowedPadSizes = new Set(['1', '2', '3'])
 const allowedStationDistances = new Set(['0', '100', '500', '1000', '2000', '5000', '10000', '15000', '20000', '25000', '50000', '100000'])
 const allowedSurfaceOptions = new Set(['0', '1', '2'])
-const allowedPowers = new Set(['', '1', '2', '3', '4', '5', '7', '8', '9', '10', '11', '12', '13'])
+const allowedPowers = new Set(['', '0', '-1', '1', '2', '3', '4', '5', '7', '8', '9', '10', '11', '12', '13'])
 const allowedSupplyDemand = new Set(['0', '100', '500', '1000', '2500', '5000', '10000', '50000'])
 const allowedOrder = new Set(['0', '1', '2', '3', '4'])
 

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -779,6 +779,184 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   overflow: hidden;
 }
 
+.tradeFiltersForm {
+  margin-top: 1.5rem;
+  padding: 1.5rem 1.75rem;
+  border-radius: 1.25rem;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-background) 96%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-primary-dark) 16%, transparent) 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.tradeFiltersHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
+.tradeFiltersSystemGroup {
+  flex: 1 1 320px;
+}
+
+.tradeFiltersLabel {
+  display: block;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 74%, transparent);
+}
+
+.tradeFiltersSystemControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.6rem;
+}
+
+.tradeFiltersSelect,
+.tradeFiltersTextInput,
+.tradeFiltersNumberInput {
+  appearance: none;
+  border-radius: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 40%, transparent);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 90%, transparent);
+  color: var(--ghostnet-ink);
+  padding: 0.65rem 0.9rem;
+  font-size: 0.95rem;
+  min-width: 0;
+}
+
+.tradeFiltersSelect:focus,
+.tradeFiltersTextInput:focus,
+.tradeFiltersNumberInput:focus {
+  outline: 2px solid var(--ghostnet-color-success);
+  outline-offset: 2px;
+}
+
+.tradeFiltersActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.tradeFiltersToggle {
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent);
+  color: var(--ghostnet-accent);
+  padding: 0.6rem 1.15rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.tradeFiltersToggle:hover {
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 26%, transparent);
+}
+
+.tradeFiltersSubmit {
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--ghostnet-accent), color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent));
+  color: #0c061f;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tradeFiltersSubmit:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.tradeFiltersCollapsedSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: var(--ghostnet-muted);
+}
+
+.tradeFiltersSummaryText {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 80%, transparent);
+}
+
+.tradeFiltersQueryRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--ghostnet-muted);
+}
+
+.tradeFiltersQueryLabel {
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tradeFiltersGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.tradeFilterField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: var(--ghostnet-muted);
+}
+
+.tradeFilterField label {
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
+}
+
+.tradeFiltersNumberInput::-webkit-outer-spin-button,
+.tradeFiltersNumberInput::-webkit-inner-spin-button {
+  margin: 0;
+}
+
+.tradeFilterHint {
+  font-size: 0.75rem;
+  color: var(--ghostnet-muted);
+}
+
+.tradeFilterFieldToggle {
+  justify-content: flex-end;
+}
+
+.tradeFilterToggleRow {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 78%, transparent);
+}
+
+.tradeFilterToggleRow input[type='checkbox'] {
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: var(--ghostnet-accent);
+}
+
+.tradeFiltersFooter {
+  border-top: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+  padding-top: 1rem;
+}
+
 .dataTable {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- add a dedicated TradeRouteFilterPanel component with comprehensive filter controls and query preview
- render trade route rows through a reusable TradeRouteTableRow with expanded metrics and sorting support
- update TradeRoutesPanel to orchestrate the new filter state, sorting helpers, and system selector wiring

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js cannot load the SWC binary in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bc5337b88323b15a13edd3b7a12c