### PR TITLE
Add modular station and commodity displays

### DIFF
--- a/src/client/components/ghostnet/entity-display.js
+++ b/src/client/components/ghostnet/entity-display.js
@@ -1,0 +1,198 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { sanitizeInaraText } from '../../lib/sanitize-inara-text'
+import { StationIcon } from './station-summary'
+import styles from './entity-display.module.css'
+
+function normalizeMetaEntries (entries) {
+  if (!Array.isArray(entries)) return []
+  return entries
+    .map(entry => {
+      if (entry === null || entry === undefined) return null
+      if (typeof entry === 'string') {
+        const sanitized = sanitizeInaraText(entry)
+        return sanitized || null
+      }
+      return entry
+    })
+    .filter(Boolean)
+}
+
+export function StationDisplay ({
+  iconName,
+  icon,
+  name,
+  system,
+  badge,
+  meta,
+  className,
+  nameClassName,
+  nameStyle,
+  nameTitle,
+  systemClassName,
+  children
+}) {
+  const resolvedIcon = icon || (iconName ? <StationIcon icon={iconName} size={24} /> : null)
+  const stationName = sanitizeInaraText(name) || name || 'Unknown Station'
+  const stationSystem = sanitizeInaraText(system) || system || ''
+  const metaEntries = normalizeMetaEntries(meta)
+  const resolvedTitle = typeof nameTitle === 'string' && nameTitle.trim() ? nameTitle : undefined
+
+  const containerClassNames = [styles.stationDisplay]
+  if (className) containerClassNames.push(className)
+  const nameClassNames = [styles.stationDisplayName]
+  if (nameClassName) nameClassNames.push(nameClassName)
+  const systemClassNames = [styles.stationDisplaySystem]
+  if (systemClassName) systemClassNames.push(systemClassName)
+
+  return (
+    <div className={containerClassNames.join(' ')}>
+      {resolvedIcon ? <div className={styles.stationDisplayIcon}>{resolvedIcon}</div> : null}
+      <div className={styles.stationDisplayContent}>
+        <div className={styles.stationDisplayHeader}>
+          <span className={nameClassNames.join(' ')} style={nameStyle} title={resolvedTitle}>{stationName}</span>
+          {badge ? <span className={styles.stationDisplayBadge}>{badge}</span> : null}
+        </div>
+        {stationSystem ? <div className={systemClassNames.join(' ')}>{stationSystem}</div> : null}
+        {metaEntries.length > 0 ? (
+          <div className={styles.stationDisplayMeta}>
+            {metaEntries.map((entry, index) => (
+              <span key={`station-meta-${index}`}>{entry}</span>
+            ))}
+          </div>
+        ) : null}
+        {children ? <div className={styles.stationDisplayChildren}>{children}</div> : null}
+      </div>
+    </div>
+  )
+}
+
+StationDisplay.defaultProps = {
+  iconName: '',
+  icon: null,
+  name: '',
+  system: '',
+  badge: null,
+  meta: [],
+  className: '',
+  nameClassName: '',
+  nameStyle: null,
+  nameTitle: '',
+  systemClassName: '',
+  children: null
+}
+
+StationDisplay.propTypes = {
+  iconName: PropTypes.string,
+  icon: PropTypes.node,
+  name: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  system: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  badge: PropTypes.node,
+  meta: PropTypes.arrayOf(PropTypes.node),
+  className: PropTypes.string,
+  nameClassName: PropTypes.string,
+  nameStyle: PropTypes.object,
+  nameTitle: PropTypes.string,
+  systemClassName: PropTypes.string,
+  children: PropTypes.node
+}
+
+export function CommodityDisplay ({
+  icon,
+  name,
+  demandIn,
+  meta,
+  station,
+  className,
+  nameClassName,
+  demandClassName,
+  children
+}) {
+  const resolvedName = sanitizeInaraText(name) || name || 'Unknown Commodity'
+  const metaEntries = normalizeMetaEntries(meta)
+  const containerClassNames = [styles.commodityDisplay]
+  if (className) containerClassNames.push(className)
+  const nameClassNames = [styles.commodityDisplayName]
+  if (nameClassName) nameClassNames.push(nameClassName)
+  const demandClassNames = [styles.commodityDisplayDemandIn]
+  if (demandClassName) demandClassNames.push(demandClassName)
+
+  const stationInfo = station && typeof station === 'object' ? station : null
+  const stationName = stationInfo?.name ? sanitizeInaraText(stationInfo.name) || stationInfo.name : ''
+  const stationSystem = stationInfo?.system ? sanitizeInaraText(stationInfo.system) || stationInfo.system : ''
+  const stationPrice = stationInfo?.price
+  const stationDemandOut = stationInfo?.demandOut
+
+  return (
+    <div className={containerClassNames.join(' ')}>
+      <div className={styles.commodityDisplayPrimary}>
+        {icon ? <div className={styles.commodityDisplayIcon}>{icon}</div> : null}
+        <div className={styles.commodityDisplayText}>
+          <div className={styles.commodityDisplayNameRow}>
+            <span className={nameClassNames.join(' ')}>{resolvedName}</span>
+            {demandIn ? <span className={demandClassNames.join(' ')}>{demandIn}</span> : null}
+          </div>
+          {metaEntries.length > 0 ? (
+            <div className={styles.commodityDisplayMeta}>
+              {metaEntries.map((entry, index) => (
+                <span key={`commodity-meta-${index}`}>{entry}</span>
+              ))}
+            </div>
+          ) : null}
+          {children ? <div className={styles.commodityDisplayChildren}>{children}</div> : null}
+        </div>
+      </div>
+      {stationInfo && (stationName || stationSystem || stationPrice || stationDemandOut) ? (
+        <div className={styles.commodityDisplayStation}>
+          {(stationName || stationSystem) ? (
+            <div className={styles.commodityDisplayStationHeader}>
+              {stationName ? <span>{stationName}</span> : null}
+              {stationSystem ? <span>· {stationSystem}</span> : null}
+            </div>
+          ) : null}
+          {(stationPrice || stationDemandOut) ? (
+            <div className={styles.commodityDisplayStationMetrics}>
+              {stationPrice ? (
+                <span className={styles.commodityDisplayStationPrice}>{stationPrice}</span>
+              ) : null}
+              {stationDemandOut ? (
+                <span className={styles.commodityDisplayStationDemand}>{stationDemandOut}</span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+CommodityDisplay.defaultProps = {
+  icon: null,
+  name: '',
+  demandIn: null,
+  meta: [],
+  station: null,
+  className: '',
+  nameClassName: '',
+  demandClassName: '',
+  children: null
+}
+
+CommodityDisplay.propTypes = {
+  icon: PropTypes.node,
+  name: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  demandIn: PropTypes.node,
+  meta: PropTypes.arrayOf(PropTypes.node),
+  station: PropTypes.shape({
+    name: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    system: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    price: PropTypes.node,
+    demandOut: PropTypes.node
+  }),
+  className: PropTypes.string,
+  nameClassName: PropTypes.string,
+  demandClassName: PropTypes.string,
+  children: PropTypes.node
+}
+
+export { StationIcon }

--- a/src/client/components/ghostnet/entity-display.module.css
+++ b/src/client/components/ghostnet/entity-display.module.css
@@ -1,0 +1,192 @@
+.stationDisplay {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.stationDisplayIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent);
+  box-shadow: 0 0.8rem 1.8rem color-mix(in srgb, var(--ghostnet-color-background) 80%, transparent);
+  flex-shrink: 0;
+}
+
+.stationDisplayIcon :global(svg) {
+  width: 1.4rem !important;
+  height: 1.4rem !important;
+}
+
+.stationDisplayContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.stationDisplayHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.stationDisplayName {
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+}
+
+.stationDisplaySystem {
+  font-size: 0.78rem;
+  color: var(--ghostnet-subdued);
+}
+
+.stationDisplayMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.7rem;
+  font-size: 0.78rem;
+  color: var(--ghostnet-subdued);
+}
+
+.stationDisplayChildren {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--ghostnet-text-soft);
+}
+
+.stationDisplayBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+  color: var(--ghostnet-ink);
+  font-size: 0.65rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.commodityDisplay {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.commodityDisplayPrimary {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.commodityDisplayIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent);
+  box-shadow: 0 0.8rem 1.8rem color-mix(in srgb, var(--ghostnet-color-background) 80%, transparent);
+  flex-shrink: 0;
+}
+
+.commodityDisplayIcon :global(svg) {
+  width: 1.4rem !important;
+  height: 1.4rem !important;
+}
+
+.commodityDisplayText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.commodityDisplayNameRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.commodityDisplayName {
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+}
+
+.commodityDisplayDemandIn {
+  font-size: 0.8rem;
+  color: var(--ghostnet-text-soft);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.commodityDisplayMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.65rem;
+  font-size: 0.78rem;
+  color: var(--ghostnet-subdued);
+}
+
+.commodityDisplayStation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-left: calc(2.95rem);
+}
+
+.commodityDisplayStationHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: var(--ghostnet-subdued);
+}
+
+.commodityDisplayStationMetrics {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.8rem;
+  font-size: 0.82rem;
+  color: var(--ghostnet-text-soft);
+}
+
+.commodityDisplayStationPrice {
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+}
+
+.commodityDisplayStationDemand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.commodityDisplayChildren {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--ghostnet-text-soft);
+}
+
+@media (max-width: 768px) {
+  .stationDisplayIcon,
+  .commodityDisplayIcon {
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .commodityDisplayStation {
+    margin-left: calc(2.6rem);
+  }
+}


### PR DESCRIPTION
## Summary
- create reusable `StationDisplay` and `CommodityDisplay` components so station and commodity rows share icon, name, and metadata formatting
- update GhostNet trade routes, station listings, and cargo hold tables to render the new displays with consistent demand and price context
- add shared styling to support the aligned layouts for station and commodity details

## Testing
- npm test -- --runInBand --config jest.config.js
- CI=1 npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e133d2aa188323a147bb3cc11c60fe