### PR TITLE
Add coverage for GhostNet API ledger metadata

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  roots: ['<rootDir>/src/client', '<rootDir>/src/service'],
+  roots: ['<rootDir>/src/client', '<rootDir>/src/service', '<rootDir>/test'],
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/test/setupTests.js'],
   moduleNameMapper: {
@@ -12,5 +12,6 @@ module.exports = {
   transform: {
     '^.+\\.(js|jsx)$': 'babel-jest'
   },
+  transformIgnorePatterns: ['/node_modules/(?!cheerio/)'],
   testMatch: ['**/__tests__/**/*.{test,spec}.[jt]s?(x)']
 }

--- a/test/api/__tests__/ghostnet-commodity-values.test.js
+++ b/test/api/__tests__/ghostnet-commodity-values.test.js
@@ -1,0 +1,135 @@
+const { createMockReq, createMockRes, createFetchResponse } = require('../helpers')
+
+const handlerPath = '../../../src/client/pages/api/ghostnet-commodity-values.js'
+const tokenCurrencyPath = '../../../src/client/pages/api/token-currency.js'
+
+describe('ghostnet-commodity-values API handler', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    delete global.LOG_DIR
+  })
+
+  async function loadModule() {
+    jest.doMock('node-fetch', () => jest.fn())
+    jest.doMock('fs', () => {
+      const actualFs = jest.requireActual('fs')
+      return {
+        ...actualFs,
+        existsSync: jest.fn(() => false),
+        readFileSync: jest.fn(() => ''),
+        writeFileSync: jest.fn(),
+        mkdirSync: jest.fn(),
+        readdirSync: jest.fn(() => []),
+        statSync: jest.fn(() => ({ mtimeMs: 0 }))
+      }
+    })
+
+    const tokenCurrency = require(tokenCurrencyPath)
+    tokenCurrency.spendTokensForInaraExchange = jest.fn().mockResolvedValue()
+
+    const handlerModule = require(handlerPath)
+    const handler = handlerModule.default || handlerModule
+    const fetchMock = require('node-fetch')
+
+    return { handler, fetchMock, spendTokensMock: tokenCurrency.spendTokensForInaraExchange }
+  }
+
+  it('records token spend metadata for commodity option and listing fetches', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    const optionsHtml = `
+      <select name="pa1[]">
+        <option value="101">Tritium</option>
+      </select>
+    `
+
+    const listingsHtml = `
+      <table class="tablesortercollapsed">
+        <tbody>
+          <tr>
+            <td>
+              <a href="/elite/station-market/128666762">
+                <span class="standardcase">Jameson Memorial</span>
+                <span class="uppercase">Shinrarta Dezhra</span>
+              </a>
+            </td>
+            <td>Large</td>
+            <td data-order="10"></td>
+            <td data-order="0"></td>
+            <td data-order="5"></td>
+            <td data-order="150000"></td>
+            <td data-order="${Math.floor(Date.now() / 1000)}"></td>
+          </tr>
+        </tbody>
+      </table>
+    `
+
+    fetchMock
+      .mockResolvedValueOnce(createFetchResponse({ status: 200, ok: true, body: optionsHtml }))
+      .mockResolvedValueOnce(createFetchResponse({ status: 200, ok: true, body: listingsHtml }))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: {
+        commodities: [
+          { name: 'Tritium', symbol: 'tritium', count: 12 }
+        ]
+      }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(spendTokensMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+
+    const optionsCall = spendTokensMock.mock.calls[0][0]
+    expect(optionsCall.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request',
+      status: 200,
+      phase: 'commodity-options',
+      error: undefined
+    })
+
+    const listingsCall = spendTokensMock.mock.calls[1][0]
+    expect(listingsCall.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request',
+      status: 200,
+      commodityId: '101',
+      system: null,
+      error: undefined
+    })
+  })
+
+  it('records token spend metadata when commodity options fail to load', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    fetchMock.mockRejectedValueOnce(new Error('options offline'))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: {
+        commodities: [
+          { name: 'Void Opals', symbol: 'void_opals', count: 2 }
+        ]
+      }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request-error',
+      status: null,
+      phase: 'commodity-options',
+      error: 'options offline'
+    })
+  })
+})

--- a/test/api/__tests__/ghostnet-missions.test.js
+++ b/test/api/__tests__/ghostnet-missions.test.js
@@ -1,0 +1,90 @@
+const { createMockReq, createMockRes, createFetchResponse } = require('../helpers')
+
+const handlerPath = '../../../src/client/pages/api/ghostnet-missions.js'
+const tokenCurrencyPath = '../../../src/client/pages/api/token-currency.js'
+
+describe('ghostnet-missions API handler', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  async function loadModule() {
+    jest.doMock('node-fetch', () => jest.fn())
+
+    const tokenCurrency = require(tokenCurrencyPath)
+    tokenCurrency.spendTokensForInaraExchange = jest.fn().mockResolvedValue()
+
+    const handlerModule = require(handlerPath)
+    const handler = handlerModule.default || handlerModule
+    const fetchMock = require('node-fetch')
+
+    return { handler, fetchMock, spendTokensMock: tokenCurrency.spendTokensForInaraExchange }
+  }
+
+  it('records token spend metadata when missions are fetched successfully', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    const html = `
+      <table class="tablesortercollapsed">
+        <tbody>
+          <tr>
+            <td><a href="/elite/system/1">Sol</a></td>
+            <td><a href="/elite/minorfaction/2">Federation</a></td>
+            <td data-order="12">12 Ly</td>
+            <td data-order="${Math.floor(Date.now() / 1000)}">just now</td>
+          </tr>
+        </tbody>
+      </table>
+    `
+
+    fetchMock.mockResolvedValue(createFetchResponse({ status: 200, ok: true, body: html }))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: { system: 'Sol' }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body?.missions).toBeDefined()
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.endpoint).toContain('nearest-misc')
+    expect(call.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request',
+      status: 200,
+      system: 'Sol',
+      error: undefined
+    })
+  })
+
+  it('records token spend metadata when the mission fetch fails', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    fetchMock.mockResolvedValue(createFetchResponse({ status: 503, ok: false, body: 'error' }))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: { system: 'Lave' }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request-error',
+      status: 503,
+      system: 'Lave',
+      error: 'GHOSTNET request failed with status 503'
+    })
+  })
+})

--- a/test/api/__tests__/ghostnet-pristine-mining.test.js
+++ b/test/api/__tests__/ghostnet-pristine-mining.test.js
@@ -1,0 +1,91 @@
+const { createMockReq, createMockRes, createFetchResponse } = require('../helpers')
+
+const handlerPath = '../../../src/client/pages/api/ghostnet-pristine-mining.js'
+const tokenCurrencyPath = '../../../src/client/pages/api/token-currency.js'
+
+describe('ghostnet-pristine-mining API handler', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  async function loadModule() {
+    jest.doMock('node-fetch', () => jest.fn())
+
+    const tokenCurrency = require(tokenCurrencyPath)
+    tokenCurrency.spendTokensForInaraExchange = jest.fn().mockResolvedValue()
+
+    const handlerModule = require(handlerPath)
+    const handler = handlerModule.default || handlerModule
+    const fetchMock = require('node-fetch')
+
+    return { handler, fetchMock, spendTokensMock: tokenCurrency.spendTokensForInaraExchange }
+  }
+
+  it('records token spend metadata when pristine mining locations are returned', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    const html = `
+      <table class="tablesortercollapsed">
+        <tbody>
+          <tr>
+            <td><a href="/elite/system/1">Sol</a></td>
+            <td><a href="/elite/body/2">Sol A Ring</a></td>
+            <td>Metallic Ring</td>
+            <td data-order="1200">1,200 Ls</td>
+            <td data-order="15">15 Ly</td>
+          </tr>
+        </tbody>
+      </table>
+    `
+
+    fetchMock.mockResolvedValue(createFetchResponse({ status: 200, ok: true, body: html }))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: { system: 'Sol' }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body?.locations).toBeDefined()
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.endpoint).toContain('nearest-bodies')
+    expect(call.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request',
+      status: 200,
+      system: 'Sol',
+      error: undefined
+    })
+  })
+
+  it('records token spend metadata when pristine mining fetch fails', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    fetchMock.mockResolvedValue(createFetchResponse({ status: 500, ok: false, body: 'error' }))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: { system: 'Achenar' }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request-error',
+      status: 500,
+      system: 'Achenar',
+      error: 'GHOSTNET request failed with status 500'
+    })
+  })
+})

--- a/test/api/__tests__/ghostnet-search.test.js
+++ b/test/api/__tests__/ghostnet-search.test.js
@@ -1,0 +1,90 @@
+const { createMockReq, createMockRes, createFetchResponse } = require('../helpers')
+
+const handlerPath = '../../../src/client/pages/api/ghostnet-search.js'
+const tokenCurrencyPath = '../../../src/client/pages/api/token-currency.js'
+
+describe('ghostnet-search API handler', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  async function loadModule() {
+    jest.doMock('node-fetch', () => jest.fn())
+
+    const tokenCurrency = require(tokenCurrencyPath)
+    tokenCurrency.spendTokensForInaraExchange = jest.fn().mockResolvedValue()
+
+    const handlerModule = require(handlerPath)
+    const handler = handlerModule.default || handlerModule
+    const fetchMock = require('node-fetch')
+
+    return { handler, fetchMock, spendTokensMock: tokenCurrency.spendTokensForInaraExchange }
+  }
+
+  it('records token spend metadata for successful searches', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    fetchMock.mockResolvedValue(createFetchResponse({
+      status: 200,
+      ok: true,
+      body: JSON.stringify({ data: [{ id: 1 }] })
+    }))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: {
+        searchType: 'commodity',
+        searchTerm: 'Tritium',
+        appName: 'GhostNet Tests',
+        appVersion: '1.0.0'
+      }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.endpoint).toBe('https://inara.cz/inapi/v1/')
+    expect(call.metadata).toMatchObject({
+      method: 'POST',
+      reason: 'inara-request',
+      status: 200,
+      searchType: 'commodity',
+      error: undefined
+    })
+  })
+
+  it('records token spend metadata when the INARA request fails', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    fetchMock.mockRejectedValue(new Error('network down'))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: {
+        searchType: 'module',
+        searchTerm: 'Shield Generator',
+        appName: 'GhostNet Tests',
+        appVersion: '1.0.0'
+      }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.metadata).toMatchObject({
+      method: 'POST',
+      reason: 'inara-request-error',
+      status: null,
+      searchType: 'module',
+      error: 'network down'
+    })
+  })
+})

--- a/test/api/__tests__/ghostnet-trade-routes.test.js
+++ b/test/api/__tests__/ghostnet-trade-routes.test.js
@@ -1,0 +1,87 @@
+const { createMockReq, createMockRes, createFetchResponse } = require('../helpers')
+
+const handlerPath = '../../../src/client/pages/api/ghostnet-trade-routes.js'
+const tokenCurrencyPath = '../../../src/client/pages/api/token-currency.js'
+
+describe('ghostnet-trade-routes API handler', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  async function loadModule() {
+    jest.doMock('node-fetch', () => jest.fn())
+    jest.doMock('../../../src/client/pages/api/ghostnet-log-utils.js', () => ({
+      appendGhostnetLogEntry: jest.fn()
+    }))
+    jest.doMock('../../../src/service/lib/elite-log.js', () => jest.fn().mockImplementation(() => ({
+      load: jest.fn().mockResolvedValue(),
+      watch: jest.fn()
+    })))
+    jest.doMock('../../../src/service/lib/event-handlers/system.js', () => jest.fn().mockImplementation(() => ({
+      getSystem: jest.fn().mockResolvedValue(null)
+    })))
+    jest.doMock('../../../src/shared/distance.js', () => jest.fn(() => 0))
+
+    const tokenCurrency = require(tokenCurrencyPath)
+    tokenCurrency.spendTokensForInaraExchange = jest.fn().mockResolvedValue()
+
+    const handlerModule = require(handlerPath)
+    const handler = handlerModule.default || handlerModule
+    const fetchMock = require('node-fetch')
+
+    return { handler, fetchMock, spendTokensMock: tokenCurrency.spendTokensForInaraExchange }
+  }
+
+  it('records token spend metadata when no trade routes are returned', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    fetchMock.mockResolvedValue(createFetchResponse({ status: 200, ok: true, body: '<html></html>' }))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: { system: 'Shinrarta Dezhra' }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.endpoint).toContain('market-traderoutes')
+    expect(call.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request',
+      status: 200,
+      system: 'Shinrarta Dezhra',
+      error: undefined
+    })
+  })
+
+  it('records token spend metadata when the trade routes fetch fails', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    fetchMock.mockResolvedValue(createFetchResponse({ status: 502, ok: false, body: 'error' }))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: { system: 'Cubeo' }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request-error',
+      status: 502,
+      system: 'Cubeo',
+      error: 'GHOSTNET request failed'
+    })
+  })
+})

--- a/test/api/__tests__/ghostnet-websearch.test.js
+++ b/test/api/__tests__/ghostnet-websearch.test.js
@@ -1,0 +1,107 @@
+const { createMockReq, createMockRes, createFetchResponse } = require('../helpers')
+
+const handlerPath = '../../../src/client/pages/api/ghostnet-websearch.js'
+const tokenCurrencyPath = '../../../src/client/pages/api/token-currency.js'
+
+describe('ghostnet-websearch API handler', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    delete global.ICARUS_SYSTEM_INSTANCE
+    delete global.ICARUS_ELITE_LOG
+    delete global.CACHE
+  })
+
+  async function loadModule(systemMockImpl = () => ({ getSystem: jest.fn().mockResolvedValue(null) })) {
+    jest.doMock('node-fetch', () => jest.fn())
+    jest.doMock('fs', () => {
+      const actualFs = jest.requireActual('fs')
+      return {
+        ...actualFs,
+        existsSync: jest.fn(() => false),
+        readFileSync: jest.fn((filePath) => {
+          if (typeof filePath === 'string' && filePath.includes('shipyard.json')) {
+            return JSON.stringify([{ id: 123, name: 'Anaconda', symbol: 'anaconda' }])
+          }
+          return ''
+        }),
+        writeFileSync: jest.fn(),
+        mkdirSync: jest.fn(),
+        readdirSync: jest.fn(() => []),
+        statSync: jest.fn(() => ({ mtimeMs: 0 }))
+      }
+    })
+    jest.doMock('../../../src/service/lib/elite-log.js', () => jest.fn().mockImplementation(() => ({
+      load: jest.fn().mockResolvedValue(),
+      watch: jest.fn()
+    })))
+    jest.doMock('../../../src/service/lib/event-handlers/system.js', () => jest.fn().mockImplementation(systemMockImpl))
+    jest.doMock('../../../src/shared/distance.js', () => jest.fn(() => 0))
+    jest.doMock('../../../src/client/pages/api/ghostnet-log-utils.js', () => ({
+      appendGhostnetLogEntry: jest.fn()
+    }))
+
+    const tokenCurrency = require(tokenCurrencyPath)
+    tokenCurrency.spendTokensForInaraExchange = jest.fn().mockResolvedValue()
+
+    const handlerModule = require(handlerPath)
+    const handler = handlerModule.default || handlerModule
+    const fetchMock = require('node-fetch')
+
+    return { handler, fetchMock, spendTokensMock: tokenCurrency.spendTokensForInaraExchange }
+  }
+
+  it('records token spend metadata when no outfitting stations are found', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    fetchMock.mockResolvedValue(createFetchResponse({ status: 200, ok: true, body: '<html></html>' }))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: { shipId: 123, system: 'Sol' }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.endpoint).toContain('nearest-outfitting')
+    expect(call.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request',
+      status: 200,
+      shipId: 123,
+      system: 'Sol',
+      error: undefined
+    })
+  })
+
+  it('records token spend metadata when the outfitting fetch fails', async () => {
+    const { handler, fetchMock, spendTokensMock } = await loadModule()
+
+    fetchMock.mockResolvedValue(createFetchResponse({ status: 504, ok: false, body: 'error' }))
+
+    const req = createMockReq({
+      method: 'POST',
+      body: { shipId: 123, system: 'Achenar' }
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(spendTokensMock).toHaveBeenCalledTimes(1)
+
+    const call = spendTokensMock.mock.calls[0][0]
+    expect(call.metadata).toMatchObject({
+      method: 'GET',
+      reason: 'inara-request-error',
+      status: 504,
+      shipId: 123,
+      system: 'Achenar',
+      error: 'GHOSTNET request failed'
+    })
+  })
+})

--- a/test/api/helpers.js
+++ b/test/api/helpers.js
@@ -1,0 +1,43 @@
+function createMockRes() {
+  const res = {
+    statusCode: 200,
+    body: null,
+    headers: {},
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(payload) {
+      this.body = payload
+      return this
+    },
+    setHeader: jest.fn((key, value) => {
+      this.headers[key] = value
+    })
+  }
+  return res
+}
+
+function createMockReq({ method = 'POST', body = null, url = '/api/test' } = {}) {
+  return {
+    method,
+    body,
+    url,
+    headers: {}
+  }
+}
+
+function createFetchResponse({ status = 200, ok = true, body = '', headers = {} } = {}) {
+  return {
+    status,
+    ok,
+    headers,
+    text: jest.fn().mockResolvedValue(body)
+  }
+}
+
+module.exports = {
+  createMockRes,
+  createMockReq,
+  createFetchResponse
+}


### PR DESCRIPTION
## Summary
- add API handler Jest suites covering GhostNet commodity, mission, pristine mining, trade routes, search, and websearch endpoints with ledger metadata assertions
- share request/response helpers for API handler testing and mock external dependencies to exercise success and failure paths
- update Jest config to include the test directory and transform cheerio so the new suites execute

## Testing
- npm test -- --runInBand --config jest.config.js

------
https://chatgpt.com/codex/tasks/task_e_68e164c52ce0832393d056e61eab229a