### PR TITLE
Add GhostNet initialization trigger and nav animation

### DIFF
--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -16,6 +16,7 @@ const TITLE_MIN_WIDTH = `${ORIGINAL_TITLE.length}ch`
 const TITLE_GLYPHS = ['Λ', 'Ξ', 'Ψ', 'Ø', 'Σ', '✦', '✧', '☍', '⌁', '⌖', '◬', '◈', '★', '✶', '⋆']
 const createEmptyGlitchStyles = () => Array.from({ length: ORIGINAL_TITLE.length }, () => null)
 import { initiateGhostnetExitTransition, isGhostnetExitTransitionActive } from 'lib/ghostnet-exit-transition'
+import { getGhostnetInitSetting, setGhostnetInitSetting } from 'lib/ghostnet-settings'
 
 const NAV_BUTTONS = [
   {
@@ -45,6 +46,8 @@ const NAV_BUTTONS = [
   }
 ]
 
+const GHOSTNET_INIT_ANIMATION_DURATION = 900
+
 let IS_WINDOWS_APP = false
 
 export default function Header ({ connected, active }) {
@@ -64,6 +67,12 @@ export default function Header ({ connected, active }) {
   const activeTitleGlitchIndices = useRef(new Set())
   const currentPath = `/${(router.pathname.split('/')[1] || '').toLowerCase()}`
   const isGhostnetRouteActive = currentPath === '/ghostnet'
+  const [ghostnetInitState, setGhostnetInitState] = useState(() => {
+    if (typeof window === 'undefined') return 'complete'
+    return getGhostnetInitSetting() ? 'complete' : 'pending'
+  })
+  const [ghostnetInitAnimating, setGhostnetInitAnimating] = useState(false)
+  const ghostnetInitAnimationTimeout = useRef(null)
 
   const clearTitleAnimationTimeouts = useCallback(() => {
     const clearTimeoutFn = typeof window !== 'undefined' ? window.clearTimeout : clearTimeout
@@ -323,6 +332,25 @@ export default function Header ({ connected, active }) {
     }
   }, [startTitleMorph])
 
+  useEffect(() => () => {
+    if (ghostnetInitAnimationTimeout.current && typeof window !== 'undefined') {
+      window.clearTimeout(ghostnetInitAnimationTimeout.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (ghostnetInitState !== 'complete') return
+
+    setGhostnetInitSetting(true)
+    if (ghostnetInitAnimationTimeout.current && typeof window !== 'undefined') {
+      window.clearTimeout(ghostnetInitAnimationTimeout.current)
+      ghostnetInitAnimationTimeout.current = null
+    }
+    if (ghostnetInitAnimating) {
+      setGhostnetInitAnimating(false)
+    }
+  }, [ghostnetInitAnimating, ghostnetInitState])
+
   useEffect(() => {
     if (!titleAssimilated) return undefined
 
@@ -336,6 +364,24 @@ export default function Header ({ connected, active }) {
     stopTitleGlitching(true)
     return undefined
   }, [isGhostnetRouteActive, startTitleGlitching, stopTitleGlitching, titleAssimilated])
+
+  const ghostnetInitPending = ghostnetInitState !== 'complete'
+  const ghostnetNavCollapsed = ghostnetInitPending && !ghostnetInitAnimating
+  const ghostnetNavAnimating = ghostnetInitPending && ghostnetInitAnimating
+
+  const handleGhostnetInitTrigger = useCallback(() => {
+    if (!ghostnetInitPending || ghostnetInitAnimating) return
+    if (typeof window === 'undefined') return
+
+    setGhostnetInitAnimating(true)
+    if (ghostnetInitAnimationTimeout.current) {
+      window.clearTimeout(ghostnetInitAnimationTimeout.current)
+      ghostnetInitAnimationTimeout.current = null
+    }
+    ghostnetInitAnimationTimeout.current = window.setTimeout(() => {
+      setGhostnetInitState('complete')
+    }, GHOSTNET_INIT_ANIMATION_DURATION)
+  }, [ghostnetInitAnimating, ghostnetInitPending])
 
   let signalClassName = 'icon icarus-terminal-signal '
   if (!connected) {
@@ -409,6 +455,22 @@ export default function Header ({ connected, active }) {
           </span>
         </p>
 
+        <button
+          type='button'
+          tabIndex='1'
+          className={['button--icon', 'ghostnet-init-trigger', ghostnetInitPending ? 'ghostnet-init-trigger--armed' : ''].filter(Boolean).join(' ')}
+          style={{ marginRight: '.5rem' }}
+          onClick={handleGhostnetInitTrigger}
+          disabled={ghostnetNavAnimating}
+          aria-disabled={!ghostnetInitPending && !ghostnetNavAnimating}
+          aria-pressed={!ghostnetInitPending}
+          aria-label={ghostnetInitPending ? 'Initialize GhostNet navigation controls' : 'GhostNet navigation initialized'}
+          title={ghostnetInitPending ? 'Initialize GhostNet navigation controls' : 'GhostNet navigation initialized'}
+          data-ghostnet-init-trigger='true'
+        >
+          <i className='icon icarus-terminal-shield' aria-hidden='true' />
+        </button>
+
         <button disabled className='button--icon button--transparent' style={{ marginRight: '.5rem', opacity: active ? 1 : .25, transition: 'all .25s ease-out' }}>
           <i className={signalClassName} style={{ position: 'relative', transition: 'all .25s ease', fontSize: '3rem', lineHeight: '1.8rem', top: '.5rem', right: '.25rem' }} />
         </button>
@@ -442,12 +504,19 @@ export default function Header ({ connected, active }) {
             <button
               key={button.name}
               data-primary-navigation={i + 1}
-              tabIndex='1'
-              disabled={isActive || (isGhostNet && isGhostnetAssimilationActive()) || exitActive}
+              tabIndex={isGhostNet && ghostnetNavCollapsed ? -1 : 1}
+              disabled={
+                isActive ||
+                exitActive ||
+                (isGhostNet && (isGhostnetAssimilationActive() || ghostnetNavCollapsed || ghostnetNavAnimating))
+              }
+              aria-hidden={isGhostNet && ghostnetNavCollapsed ? 'true' : undefined}
               aria-current={isActive ? 'page' : undefined}
               className={[
                 isActive ? 'button--active' : '',
-                isGhostNet ? 'ghostnet-nav-button' : ''
+                isGhostNet ? 'ghostnet-nav-button' : '',
+                isGhostNet && ghostnetNavCollapsed ? 'ghostnet-nav-button--collapsed' : '',
+                isGhostNet && ghostnetNavAnimating ? 'ghostnet-nav-button--expanding' : ''
               ].filter(Boolean).join(' ')}
               onClick={() => handleNavigate(button.path)}
               style={{ fontSize: '1.5rem' }}

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -506,6 +506,10 @@ body.ghostnet-theme #secondaryNavigation .button--icon.button--secondary {
   border-right: 0;
 }
 
+#primaryNavigation button {
+  transition: flex-basis 0.55s ease, max-width 0.55s ease, width 0.55s ease, padding 0.45s ease, margin 0.45s ease, opacity 0.35s ease;
+}
+
 #primaryNavigation .ghostnet-nav-button {
   --ghostnet-nav-accent: rgb(216, 180, 254);
   --ghostnet-nav-depth: rgba(73, 27, 115, 0.35);
@@ -515,12 +519,34 @@ body.ghostnet-theme #secondaryNavigation .button--icon.button--secondary {
   color: var(--ghostnet-nav-accent);
   text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
   filter: none;
-  transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  flex: 1 1 11rem;
+  flex-basis: 11rem;
+  max-width: 11.5rem;
+  overflow: hidden;
+  transition: flex-basis 0.55s ease, max-width 0.55s ease, width 0.55s ease, padding 0.45s ease, margin 0.45s ease, opacity 0.35s ease, background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
 #primaryNavigation .ghostnet-nav-button .visible-small,
 #primaryNavigation .ghostnet-nav-button .hidden-small {
   text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
+}
+
+#primaryNavigation .ghostnet-nav-button.ghostnet-nav-button--collapsed {
+  flex: 0 0 0 !important;
+  flex-basis: 0 !important;
+  max-width: 0 !important;
+  width: 0 !important;
+  padding-left: 0;
+  padding-right: 0;
+  margin-left: 0;
+  margin-right: 0;
+  opacity: 0;
+  border-width: 0;
+  pointer-events: none;
+}
+
+#primaryNavigation .ghostnet-nav-button.ghostnet-nav-button--expanding {
+  pointer-events: none;
 }
 
 #primaryNavigation .ghostnet-nav-button.button--active {
@@ -538,6 +564,51 @@ body.ghostnet-theme #secondaryNavigation .button--icon.button--secondary {
   box-shadow: 0 0 1.35rem rgba(216, 180, 254, 0.45), inset 0 0 0.45rem rgba(216, 180, 254, 0.65);
   color: var(--ghostnet-nav-accent);
   transform: translateY(-1px);
+}
+
+.ghostnet-init-trigger {
+  --ghostnet-init-accent: rgb(216, 180, 254);
+  --ghostnet-init-depth: rgba(73, 27, 115, 0.35);
+  align-items: center;
+  background: linear-gradient(180deg, rgba(44, 18, 68, 0.95), rgba(81, 27, 128, 0.85));
+  border: 1px solid rgba(216, 180, 254, 0.3);
+  border-radius: 0.55rem;
+  box-shadow: inset 0 0 1.35rem var(--ghostnet-init-depth);
+  color: var(--ghostnet-init-accent);
+  display: inline-flex;
+  filter: none;
+  height: 4.25rem;
+  justify-content: center;
+  padding: 0;
+  text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
+  transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
+  width: 4.25rem;
+}
+
+.ghostnet-init-trigger .icon {
+  font-size: 2.1rem;
+}
+
+.ghostnet-init-trigger--armed {
+  box-shadow: 0 0 1.65rem rgba(216, 180, 254, 0.55), inset 0 0 1.5rem var(--ghostnet-init-depth);
+}
+
+.ghostnet-init-trigger:hover:not([disabled]),
+.ghostnet-init-trigger:focus:not([disabled]) {
+  background: linear-gradient(180deg, rgba(54, 21, 84, 0.95), rgba(88, 31, 139, 0.9));
+  box-shadow: 0 0 1.35rem rgba(216, 180, 254, 0.45), inset 0 0 0.45rem rgba(216, 180, 254, 0.65);
+  color: var(--ghostnet-init-accent);
+  transform: translateY(-1px);
+}
+
+.ghostnet-init-trigger[disabled] {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.ghostnet-init-trigger[aria-disabled='true'] {
+  opacity: 0.8;
+  cursor: default;
 }
 
 body.ghostnet-assimilation-mode {

--- a/src/client/lib/ghostnet-settings.js
+++ b/src/client/lib/ghostnet-settings.js
@@ -2,6 +2,7 @@ export const ASSIMILATION_DURATION_STORAGE_KEY = 'ghostnetAssimilationDuration'
 export const ASSIMILATION_DURATION_DEFAULT = 5
 export const ASSIMILATION_DURATION_MIN = 2
 export const ASSIMILATION_DURATION_MAX = 8
+export const GHOSTNET_INIT_STORAGE_KEY = 'ghostnetInit'
 
 function clampDuration (value) {
   if (!Number.isFinite(value)) return ASSIMILATION_DURATION_DEFAULT
@@ -34,4 +35,29 @@ export function saveAssimilationDurationSeconds (value) {
     }
   }
   return sanitized
+}
+
+export function getGhostnetInitSetting () {
+  if (typeof window === 'undefined' || !window.localStorage) return false
+
+  try {
+    return window.localStorage.getItem(GHOSTNET_INIT_STORAGE_KEY) === '1'
+  } catch (error) {
+    return false
+  }
+}
+
+export function setGhostnetInitSetting (value) {
+  if (typeof window === 'undefined' || !window.localStorage) return false
+
+  try {
+    if (value) {
+      window.localStorage.setItem(GHOSTNET_INIT_STORAGE_KEY, '1')
+    } else {
+      window.localStorage.removeItem(GHOSTNET_INIT_STORAGE_KEY)
+    }
+    return true
+  } catch (error) {
+    return false
+  }
 }


### PR DESCRIPTION
## Summary
- add a GhostNet INIT trigger button next to the signal indicator that expands the navigation entry
- animate the GhostNet navigation button from a collapsed state and track completion with a persisted setting

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e16e808ec083239e80607382a1b6e6