### PR TITLE
Make GhostNet buttons square

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -1100,7 +1100,7 @@ const FILTER_TOGGLE_BUTTON_STYLE = {
   background: 'rgba(127, 233, 255, 0.12)',
   border: '1px solid rgba(127, 233, 255, 0.4)',
   color: 'var(--ghostnet-accent)',
-  borderRadius: '.35rem',
+  borderRadius: '0',
   padding: '0 1rem',
   fontSize: '0.85rem',
   cursor: 'pointer',
@@ -1132,7 +1132,7 @@ const FILTER_SUMMARY_TEXT_STYLE = {
 const FILTER_SUMMARY_REFRESH_BUTTON_STYLE = {
   width: '2.1rem',
   height: '2.1rem',
-  borderRadius: '999px',
+  borderRadius: '0',
   border: '1px solid var(--color-info)',
   background: 'rgba(206, 237, 255, 0.18)',
   color: 'var(--color-info)',

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -302,7 +302,7 @@
   justify-content: center;
   width: 1.9rem;
   height: 1.9rem;
-  border-radius: 50%;
+  border-radius: 0;
   border: 1px solid var(--ghostnet-border-strong);
   background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 68%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 46%, transparent));
   color: var(--ghostnet-color-text-strong);
@@ -351,7 +351,7 @@ button.terminalTokenButton:disabled {
   align-items: center;
   gap: 0.5rem;
   padding: 0.4rem 1.1rem;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid var(--ghostnet-border-strong);
   background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 72%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 48%, transparent));
   color: var(--ghostnet-color-text-strong);
@@ -997,7 +997,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   background: color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent);
   color: var(--ghostnet-accent);
   padding: 0.6rem 1.15rem;
-  border-radius: 999px;
+  border-radius: 0;
   font-size: 0.85rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -1010,7 +1010,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 
 .tradeFiltersSubmit {
   border: none;
-  border-radius: 999px;
+  border-radius: 0;
   background: linear-gradient(90deg, var(--ghostnet-accent), color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent));
   color: #0c061f;
   padding: 0.6rem 1.4rem;
@@ -2047,6 +2047,11 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 
 .ghostnet :global(.ghostnet-panel-table .button--secondary:hover) {
   background: color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent);
+}
+
+.ghostnet :global(button),
+.ghostnet :global(.button) {
+  border-radius: 0;
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__inspector) {


### PR DESCRIPTION
## Summary
- remove rounded corners from GhostNet terminal and filter buttons so they render with square edges
- update GhostNet page inline button styles and add a page-scoped override to keep GhostNet button classes square

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client`


------
https://chatgpt.com/codex/tasks/task_e_68e16e4e421883239ff87f6907d54f68