### PR TITLE
Make GhostNet table layout full width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "yargs": "^17.2.1"
       },
       "devDependencies": {
+        "@next/swc-linux-x64-gnu": "^12.3.4",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^12.1.5",
         "babel-jest": "^29.7.0",
@@ -1795,7 +1796,6 @@
       ],
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "yargs": "^17.2.1"
       },
       "devDependencies": {
-        "@next/swc-linux-x64-gnu": "^12.3.4",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^12.1.5",
         "babel-jest": "^29.7.0",
@@ -56,6 +55,9 @@
       "engines": {
         "node": "18.17.1",
         "npm": "9.6.7"
+      },
+      "optionalDependencies": {
+        "@next/swc-linux-x64-gnu": "^12.3.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1794,8 +1796,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@next/swc-linux-x64-gnu": "^12.3.4",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^12.1.5",
     "babel-jest": "^29.7.0",
@@ -95,5 +94,8 @@
     "moduleNameMapper": {
       "\\.(css|less|scss|sass)$": "identity-obj-proxy"
     }
+  },
+  "optionalDependencies": {
+    "@next/swc-linux-x64-gnu": "^12.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@next/swc-linux-x64-gnu": "^12.3.4",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^12.1.5",
     "babel-jest": "^29.7.0",

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback, Fragment } from 'react'
 import Layout from '../components/layout'
-import Panel from '../components/panel'
+import PanelNavigation from '../components/panel-navigation'
 import Icons from '../lib/icons'
 import TransferContextSummary from '../components/ghostnet/transfer-context-summary'
 import StationSummary, { StationIcon, DemandIndicator } from '../components/ghostnet/station-summary'
@@ -2716,14 +2716,7 @@ function CargoHoldPanel () {
                     </div>
                   ) : (
                     <div className={styles.dataTableContainer}>
-                      <table className={`${styles.dataTable} ${styles.dataTableFixed}`}>
-                        <colgroup>
-                          <col style={{ width: '38%' }} />
-                          <col style={{ width: '18%' }} />
-                          <col style={{ width: '18%' }} />
-                          <col style={{ width: '12%' }} />
-                          <col style={{ width: '14%' }} />
-                        </colgroup>
+                      <table className={styles.dataTable}>
                         <thead>
                           <tr>
                             <th>Station</th>
@@ -2875,14 +2868,7 @@ function CargoHoldPanel () {
 
                 {status === 'ready' && hasCargo && hasDisplayableRows && (
                   <div className={styles.dataTableContainer} ref={tableContainerRef}>
-                    <table className={`${styles.dataTable} ${styles.dataTableFixed} ${styles.dataTableDense}`}>
-                      <colgroup>
-                        <col style={{ width: '32%' }} />
-                        <col style={{ width: '8%' }} />
-                        <col style={{ width: '20%' }} />
-                        <col style={{ width: '24%' }} />
-                        <col style={{ width: '16%' }} />
-                      </colgroup>
+                    <table className={`${styles.dataTable} ${styles.dataTableDense}`}>
                       <thead>
                         <tr>
                           <th>Commodity</th>
@@ -3712,28 +3698,7 @@ function TradeRoutesPanel () {
 
   const renderRoutesTable = () => (
     <div className={styles.dataTableContainer}>
-      <table className={`${styles.dataTable} ${styles.dataTableFixed} ${styles.dataTableDense}`}>
-      <colgroup>
-        <col style={{ width: '3%' }} />
-        <col style={{ width: '16%' }} />
-        <col style={{ width: '12%' }} />
-        <col style={{ width: '16%' }} />
-        <col style={{ width: '12%' }} />
-        <col style={{ width: '12%' }} />
-        <col style={{ width: '7%' }} />
-        <col style={{ width: '6%' }} />
-        <col style={{ width: '6%' }} />
-        <col style={{ width: '12%' }} />
-        <col style={{ width: '7%' }} />
-        <col style={{ width: '6%' }} />
-        <col style={{ width: '6%' }} />
-        <col style={{ width: '7%' }} />
-        <col style={{ width: '7%' }} />
-        <col style={{ width: '7%' }} />
-        <col style={{ width: '7%' }} />
-        <col style={{ width: '7%' }} />
-        <col style={{ width: '8%' }} />
-      </colgroup>
+      <table className={`${styles.dataTable} ${styles.dataTableDense}`}>
       <thead>
         <tr>
           <th aria-hidden='true' className={styles.tableCellCaret} />
@@ -5824,34 +5789,35 @@ export default function GhostnetPage() {
 
   const ghostnetClassName = [styles.ghostnet, arrivalMode ? styles.arrival : ''].filter(Boolean).join(' ')
   return (
-    <Layout connected={connected} active={socketActive} ready={ready} loader={false}>
-      <Panel
-        layout='full-width'
-        scrollable
-        navigation={navigationItems}
-        search={false}
-        className={styles.ghostnetPanel}
-      >
-        <div className={ghostnetClassName}>
-          <div className={styles.shell}>
-            <div className={styles.tabPanels}>
-              <div style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
-                <TradeRoutesPanel />
+    <Layout connected={connected} active={socketActive} ready={ready} loader={false} className={styles.ghostnetLayout}>
+      <div className={styles.ghostnetViewport}>
+        <div className={styles.ghostnetNavigation}>
+          <PanelNavigation items={navigationItems} search={false} />
+        </div>
+        <div className={styles.ghostnetContentArea}>
+          <div className={styles.ghostnetScrollRegion}>
+            <div className={ghostnetClassName}>
+              <div className={styles.shell}>
+                <div className={styles.tabPanels}>
+                  <div style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
+                    <TradeRoutesPanel />
+                  </div>
+                  <div style={{ display: activeTab === 'cargoHold' ? 'block' : 'none' }}>
+                    <CargoHoldPanel />
+                  </div>
+                  <div style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
+                    <MissionsPanel />
+                  </div>
+                  <div style={{ display: activeTab === 'pristineMining' ? 'block' : 'none' }}>
+                    <PristineMiningPanel />
+                  </div>
+                </div>
               </div>
-              <div style={{ display: activeTab === 'cargoHold' ? 'block' : 'none' }}>
-                <CargoHoldPanel />
-              </div>
-              <div style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
-                <MissionsPanel />
-              </div>
-              <div style={{ display: activeTab === 'pristineMining' ? 'block' : 'none' }}>
-                <PristineMiningPanel />
-              </div>
+              <GhostnetTerminalOverlay />
             </div>
           </div>
-          <GhostnetTerminalOverlay />
         </div>
-      </Panel>
+      </div>
     </Layout>
   )
 }

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1,3 +1,81 @@
+.ghostnetLayout {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0;
+}
+
+.ghostnetViewport {
+  position: relative;
+  display: grid;
+  grid-template-columns: 4.5rem minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+}
+
+.ghostnetNavigation {
+  position: relative;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-primary-dark) 70%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent) 100%);
+  box-shadow: inset -1px 0 0 color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
+  display: flex;
+  justify-content: center;
+}
+
+.ghostnetNavigation :global(.secondary-navigation) {
+  position: sticky;
+  top: 0;
+  left: 0;
+  bottom: auto;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: clamp(1.5rem, 4vw, 2.25rem) 0;
+  gap: 0.75rem;
+}
+
+.ghostnetNavigation :global(.secondary-navigation button.button--icon) {
+  margin: 0;
+}
+
+.ghostnetContentArea {
+  position: relative;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.ghostnetScrollRegion {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--ghostnet-color-background);
+  scrollbar-color: var(--ghostnet-color-scroll-thumb) var(--ghostnet-color-scroll-track);
+  scrollbar-width: thin;
+}
+
+.ghostnetScrollRegion::-webkit-scrollbar {
+  width: 14px;
+  background-color: var(--ghostnet-color-scroll-track);
+}
+
+.ghostnetScrollRegion::-webkit-scrollbar-track {
+  background: var(--ghostnet-color-scroll-track);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-scroll-thumb-border) 40%, transparent);
+}
+
+.ghostnetScrollRegion::-webkit-scrollbar-thumb {
+  background: var(--ghostnet-color-scroll-thumb);
+  border: 1px solid var(--ghostnet-color-scroll-thumb-border);
+  box-shadow: 0 0 1.5rem color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+}
+
+.ghostnetScrollRegion::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--ghostnet-color-scroll-thumb) 70%, var(--ghostnet-color-primary-light));
+}
+
 .ghostnet {
   position: relative;
   min-height: 100%;
@@ -24,7 +102,6 @@
   --ghostnet-scrollbar-track: var(--ghostnet-color-scroll-track);
   --ghostnet-scrollbar-thumb: var(--ghostnet-color-scroll-thumb);
   --ghostnet-scrollbar-thumb-border: var(--ghostnet-color-scroll-thumb-border);
-  /* Terminal glyph treatments for jackpots and debits */
   --ghostnet-terminal-jackpot-flood: color-mix(in srgb, var(--ghostnet-color-success) 88%, transparent);
   --ghostnet-terminal-jackpot-flood-shadow: color-mix(in srgb, var(--ghostnet-color-success) 58%, transparent);
   --ghostnet-terminal-jackpot-flood-accent: color-mix(in srgb, var(--ghostnet-color-primary-light) 28%, transparent);
@@ -39,7 +116,7 @@
   --ghostnet-gradient-top: color-mix(in srgb, var(--ghostnet-color-surface) 92%, transparent);
   --ghostnet-gradient-mid: color-mix(in srgb, var(--ghostnet-color-primary-dark) 60%, transparent);
   --ghostnet-gradient-bottom: color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent);
-  padding: clamp(3rem, 5vw, 4.25rem) clamp(1.75rem, 5vw, 3.75rem) calc(4.25rem + var(--ghostnet-terminal-height));
+  padding: clamp(3rem, 5vw, 4.25rem) 0 calc(4.25rem + var(--ghostnet-terminal-height));
   background: linear-gradient(165deg, var(--ghostnet-gradient-top) 0%, var(--ghostnet-gradient-mid) 55%, var(--ghostnet-gradient-bottom) 100%),
     var(--ghostnet-bg);
   color: var(--ghostnet-ink);
@@ -75,7 +152,6 @@
   width: 14px;
   background-color: var(--ghostnet-scrollbar-track);
 }
-
 
 .ghostnetPanel :global(.layout__panel-scroll::-webkit-scrollbar-track) {
   background: var(--ghostnet-scrollbar-track);
@@ -915,17 +991,35 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 
 .dataTableContainer {
   position: relative;
-  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
-  border-radius: 1.25rem;
-  background: linear-gradient(
-      175deg,
-      color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent) 0%,
-      color-mix(in srgb, var(--ghostnet-color-primary-dark) 12%, transparent) 45%,
-      transparent 100%
-    ),
-    linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-background) 95%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-background) 94%, transparent) 100%);
-  box-shadow: 0 1.65rem 3.75rem color-mix(in srgb, var(--ghostnet-color-background) 78%, transparent);
-  overflow: hidden;
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  scrollbar-width: thin;
+  scrollbar-color: var(--ghostnet-color-scroll-thumb) transparent;
+}
+
+.dataTableContainer::-webkit-scrollbar {
+  height: 12px;
+  background: transparent;
+}
+
+.dataTableContainer::-webkit-scrollbar-track {
+  background: color-mix(in srgb, var(--ghostnet-color-scroll-track) 80%, transparent);
+  border-radius: 999px;
+}
+
+.dataTableContainer::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--ghostnet-color-scroll-thumb) 88%, transparent);
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-scroll-thumb-border) 60%, transparent);
+}
+
+.dataTableContainer::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--ghostnet-color-scroll-thumb) 95%, transparent);
 }
 
 .tradeFiltersForm {
@@ -1108,15 +1202,13 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 
 .dataTable {
   width: 100%;
+  min-width: 1100px;
   border-collapse: collapse;
+  border-spacing: 0;
   table-layout: auto;
   color: var(--ghostnet-ink);
   line-height: 1.45;
   background: transparent;
-}
-
-.dataTableFixed {
-  table-layout: fixed;
 }
 
 .dataTableDense td {
@@ -1168,6 +1260,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   color: var(--ghostnet-ink);
   text-transform: none !important;
   vertical-align: middle;
+  white-space: nowrap;
 }
 
 .nonCommodityRow {
@@ -1362,24 +1455,28 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   color: var(--ghostnet-muted);
   font-size: 0.82rem;
   margin-top: 0.35rem;
+  white-space: normal;
 }
 
 .tableMetaMuted {
   color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   font-size: 0.75rem;
   margin-top: 0.25rem;
+  white-space: normal;
 }
 
 .tableWarning {
   color: var(--ghostnet-color-warning);
   font-size: 0.78rem;
   margin-top: 0.35rem;
+  white-space: normal;
 }
 
 .tableMutedNote {
   color: color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
   font-size: 0.75rem;
   margin-top: 0.45rem;
+  white-space: normal;
 }
 
 .routeDetailLabel {
@@ -1729,6 +1826,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   display: inline-flex;
   flex-direction: column;
   gap: 0.25rem;
+  white-space: normal;
 }
 
 .tableContextLabel {
@@ -1741,11 +1839,13 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 .tableContextValue {
   font-weight: 600;
   color: var(--ghostnet-ink);
+  white-space: normal;
 }
 
 .tableContextFootnote {
   font-size: 0.72rem;
   color: var(--ghostnet-muted);
+  white-space: normal;
 }
 
 
@@ -1830,6 +1930,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
+  white-space: normal;
 }
 
 .commodityCellTitle {
@@ -1923,36 +2024,39 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 }
 
 .ghostnet :global(.ghostnet-panel-table) {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-background) 94%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-background) 92%, transparent) 100%);
-  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
-  border-radius: 1.25rem;
-  overflow: hidden;
-  box-shadow: 0 1.75rem 3.5rem color-mix(in srgb, var(--ghostnet-color-background) 75%, transparent);
-  backdrop-filter: blur(10px);
+  width: 100%;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable) {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-primary-dark) 78%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-background) 90%, transparent) 100%);
-  scrollbar-color: color-mix(in srgb, var(--ghostnet-color-primary) 60%, transparent) color-mix(in srgb, var(--ghostnet-color-background) 85%, transparent);
+  background: transparent;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-color: var(--ghostnet-color-scroll-thumb) transparent;
+  scrollbar-width: thin;
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar) {
-  width: 0.65rem;
+  height: 12px;
+  background: transparent;
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-track) {
-  background: color-mix(in srgb, var(--ghostnet-color-background) 75%, transparent);
-  border-radius: 0.65rem;
+  background: color-mix(in srgb, var(--ghostnet-color-scroll-track) 80%, transparent);
+  border-radius: 999px;
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-thumb) {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-primary) 75%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-primary-dark) 85%, transparent) 100%);
-  border-radius: 0.65rem;
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ghostnet-color-background) 55%, transparent) inset;
+  background: color-mix(in srgb, var(--ghostnet-color-scroll-thumb) 88%, transparent);
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-scroll-thumb-border) 60%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table > .scrollable::-webkit-scrollbar-thumb:hover) {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-primary) 85%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-primary-dark) 90%, transparent) 100%);
+  background: color-mix(in srgb, var(--ghostnet-color-scroll-thumb) 95%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table table thead) {
@@ -1979,11 +2083,11 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr:nth-child(even):not(.ghostnet-table-detail-row)) {
-  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 45%, transparent);
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 22%, transparent);
 }
 
 .ghostnet :global(.ghostnet-panel-table tbody tr:hover) {
-  background: color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent) !important;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 24%, var(--ghostnet-color-surface) 76%) !important;
 }
 
 .ghostnet :global(.ghostnet-panel-table .pristine-mining__detail) {
@@ -2055,7 +2159,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 
 @media (max-width: 640px) {
   .ghostnet {
-    padding: 2rem 1.5rem 2.75rem;
+    padding: 2rem 0 2.75rem;
   }
 
   .sectionPadding {


### PR DESCRIPTION
## Summary
- replace the GhostNet panel shell with a full-width viewport and inline navigation rail so content spans the layout edges
- restyle GhostNet data tables to auto-size across the viewport with horizontal scroll support on narrow screens
- add the prebuilt Linux SWC package so production builds succeed without optional dependency skips

## Testing
- npm test -- --runInBand --config jest.config.js
- CI=1 npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e16f624d4c8323a608c912b96ffea6