### PR TITLE
Make GhostNet panels square

### DIFF
--- a/src/client/css/pages/ghostnet.css
+++ b/src/client/css/pages/ghostnet.css
@@ -117,7 +117,7 @@
   width: 100%;
   height: 100%;
   border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
-  border-radius: 1rem;
+  border-radius: 0;
   background: linear-gradient(
     180deg,
     color-mix(in srgb, var(--ghostnet-color-surface) 95%, transparent) 0%,
@@ -138,7 +138,7 @@
   background: color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
   color: var(--ghostnet-ink);
   border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
-  border-radius: 1rem 1rem 0 0;
+  border-radius: 0;
 }
 
 .pristine-mining__inspector .inspector__close-button {
@@ -164,7 +164,7 @@
   width: 100%;
   background: color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
-  border-radius: 1rem;
+  border-radius: 0;
   padding: 1rem 1.25rem;
   color: var(--ghostnet-muted);
   font-size: 0.95rem;

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -861,7 +861,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 }
 
 .sectionFrame {
-  border-radius: 1.25rem;
+  border-radius: 0;
   background: var(--ghostnet-panel);
   border: 1px solid var(--ghostnet-panel-border);
   box-shadow: 0 1.75rem 3.5rem var(--ghostnet-shadow);
@@ -895,7 +895,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 }
 
 .sectionFrameElevated {
-  border-radius: 1.5rem;
+  border-radius: 0;
   background: var(--ghostnet-panel);
   border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 32%, transparent);
   box-shadow: 0 1.75rem 4rem color-mix(in srgb, var(--ghostnet-color-background) 85%, transparent);
@@ -1025,7 +1025,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 .tradeFiltersForm {
   margin-top: 1.5rem;
   padding: 1.5rem 1.75rem;
-  border-radius: 1.25rem;
+  border-radius: 0;
   border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
   background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-background) 96%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-primary-dark) 16%, transparent) 100%);
   display: flex;
@@ -1523,7 +1523,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   gap: 0.35rem;
   min-width: 160px;
   padding: 0.9rem 1.25rem;
-  border-radius: 1rem;
+  border-radius: 0;
   background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 60%, transparent);
   border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
   color: color-mix(in srgb, var(--ghostnet-color-text-strong) 78%, transparent);
@@ -1551,7 +1551,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   flex-direction: column;
   gap: 0.4rem;
   padding: 1.15rem 1.35rem;
-  border-radius: 1.1rem;
+  border-radius: 0;
   background: color-mix(in srgb, var(--ghostnet-color-background) 92%, transparent);
   border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 32%, transparent);
   box-shadow: 0 1.2rem 2.4rem color-mix(in srgb, var(--ghostnet-color-background) 55%, transparent);
@@ -1583,7 +1583,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   padding: 1.75rem 1.9rem;
   background: color-mix(in srgb, var(--ghostnet-color-background) 92%, transparent);
   border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 32%, transparent);
-  border-radius: 1.25rem;
+  border-radius: 0;
   box-shadow: 0 1.45rem 2.8rem color-mix(in srgb, var(--ghostnet-color-background) 55%, transparent);
 }
 


### PR DESCRIPTION
## Summary
- remove rounded panel corners in the GhostNet layout so non-table surfaces retain padding with sharp edges
- align pristine mining inspector surfaces with the updated square panel style

## Testing
- npm test -- --runInBand --config jest.config.js
- CI=1 npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e1b82625e883238f971966b6bf57ed