### PR TITLE
Refine GhostNet jackpot animation

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -4691,12 +4691,9 @@ const TRANSACTION_REASON_SUFFIXES = ['protocol', 'whisper', 'script', 'manifest'
 const SIMULATION_BADGES = ['SIMULATION MODE', 'TRAINING SCENARIO', 'SANDBOX RELAY']
 const SIMULATION_TRAILS = ['ghostfire rehearsal', 'tribute drill active', 'mesh rehearsal running', 'no live traffic detected']
 const JACKPOT_ASCII_BANNER = [
-  '      ██████╗  █████╗  ██████╗██╗  ██╗██████╗  ██████╗ ████████╗',
-  '      ██╔══██╗██╔══██╗██╔════╝██║ ██╔╝██╔══██╗██╔═══██╗╚══██╔══╝',
-  '      ██████╔╝███████║██║     █████╔╝ ██████╔╝██║   ██║   ██║   ',
-  '      ██╔═══╝ ██╔══██║██║     ██╔═██╗ ██╔══██╗██║   ██║   ██║   ',
-  '      ██║     ██║  ██║╚██████╗██║  ██╗██║  ██║╚██████╔╝   ██║   ',
-  '      ╚═╝     ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝    ╚═╝   '
+  '══════════════════════════════════════════════════════════════════',
+  '   JACKPOT VECTOR LOCKED · CREDIT CASCADE INBOUND · TRIBUTE SURGE  ',
+  '══════════════════════════════════════════════════════════════════'
 ]
 const JACKPOT_SUMMARY_INTROS = [
   'Encrypted cache recovered from',
@@ -5560,7 +5557,7 @@ function GhostnetTerminalOverlay () {
                   style={{
                     animationDuration: `${glyph.duration}ms`,
                     animationDelay: `${glyph.delay}ms`,
-                    transform: `translateZ(0) skewY(${glyph.drift}deg)`
+                    '--terminal-celebration-skew': `${glyph.drift}deg`
                   }}
                 >
                   {glyph.symbol}

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -286,12 +286,18 @@
   font-size: 1.05rem;
   color: color-mix(in srgb, var(--ghostnet-color-success) 95%, transparent);
   text-shadow: 0 0 1.65rem color-mix(in srgb, var(--ghostnet-color-success) 60%, transparent);
+  --terminal-celebration-skew: 0deg;
+  display: inline-block;
   opacity: 0;
-  animation-name: terminalCreditGlyphFall;
+  transform: translate3d(-125%, 0, 0) skewY(var(--terminal-celebration-skew));
+  animation-name: terminalCreditGlyphStream;
   animation-timing-function: linear;
   animation-iteration-count: infinite;
+  animation-fill-mode: both;
   letter-spacing: 0.12em;
+  white-space: nowrap;
   transform-origin: center;
+  will-change: transform, opacity;
 }
 
 .terminalCelebrationGlyph:nth-child(odd) {
@@ -590,6 +596,7 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
     0 0 18px var(--ghostnet-terminal-jackpot-flood-shadow),
     0 0 28px var(--ghostnet-terminal-jackpot-flood-accent);
   animation: terminalJackpotFloodPulse 1.6s ease-in-out infinite;
+  white-space: nowrap;
 }
 
 .terminalPromptJackpotSummary {
@@ -675,6 +682,11 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
     0 0 18px var(--ghostnet-terminal-jackpot-flood-shadow),
     0 0 36px var(--ghostnet-terminal-jackpot-flood-accent);
   letter-spacing: 0.22em;
+  display: inline-block;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
   animation: terminalJackpotFloodGlyphDrift 2s linear infinite;
 }
 
@@ -705,19 +717,23 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
   }
 }
 
-@keyframes terminalCreditGlyphFall {
+@keyframes terminalCreditGlyphStream {
   0% {
-    transform: translate3d(0, -110%, 0);
+    transform: translate3d(-135%, 0, 0) skewY(var(--terminal-celebration-skew, 0deg));
     opacity: 0;
   }
-  12% {
+  15% {
     opacity: 1;
   }
-  55% {
+  50% {
+    transform: translate3d(0, 0, 0) skewY(var(--terminal-celebration-skew, 0deg));
+    opacity: 1;
+  }
+  85% {
     opacity: 1;
   }
   100% {
-    transform: translate3d(0, 120%, 0);
+    transform: translate3d(135%, 0, 0) skewY(var(--terminal-celebration-skew, 0deg));
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- replace the jackpot ASCII banner with a standard-height stream banner so the console layout stays steady
- redirect the GhostNet jackpot celebration glyphs into a horizontal stream animation driven by CSS variables
- clamp jackpot flood glyph output to single-line overflow to prevent the terminal from stretching mid-animation

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js cannot load the SWC binary in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d75d35ac832399eb7687fed73fa9