### PR TITLE
Add deterministic sandbox token balance mocks

### DIFF
--- a/src/client/__tests__/ghostnet.test.js
+++ b/src/client/__tests__/ghostnet.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render, screen, act } from '@testing-library/react'
+import { getMockTokenBalanceSnapshot } from '../lib/ghostnet-mock-data'
 import GhostnetPage, {
   createTransactionSequence,
   createJackpotFloodConfig,
@@ -34,7 +35,7 @@ describe('Ghost Net page', () => {
     mockEventListener.mockClear()
     mockSendEvent.mockImplementation((eventName) => {
       if (eventName === 'getTokenBalance') {
-        return Promise.resolve({ balance: 1337, mode: 'SIMULATION', simulation: true, remote: { enabled: false, mode: 'DISABLED' } })
+        return Promise.resolve(getMockTokenBalanceSnapshot())
       }
       return Promise.resolve(null)
     })

--- a/src/client/lib/ghostnet-mock-data.js
+++ b/src/client/lib/ghostnet-mock-data.js
@@ -1,5 +1,121 @@
 import { formatCredits, formatRelativeTime, formatStationDistance, formatSystemDistance } from './ghostnet-formatters'
 
+const MOCK_TOKEN_REMOTE_STATE_TEMPLATE = Object.freeze({
+  enabled: true,
+  mode: 'MIRROR',
+  synced: true,
+  userId: 'layout-sandbox',
+  pending: 0,
+  attempts: 1,
+  lastSyncedAt: '2024-02-18T09:30:00.000Z',
+  lastError: null
+})
+
+const MOCK_TOKEN_BALANCE_SNAPSHOT_TEMPLATE = Object.freeze({
+  balance: 128500,
+  mode: 'SIMULATION',
+  simulation: true,
+  remote: MOCK_TOKEN_REMOTE_STATE_TEMPLATE
+})
+
+const MOCK_TOKEN_LEDGER_TRANSACTION_TEMPLATES = Object.freeze([
+  Object.freeze({
+    id: 'sandbox-entry-0001',
+    type: 'earn',
+    amount: 750,
+    delta: 750,
+    balance: 126250,
+    timestamp: '2024-02-18T09:08:00.000Z',
+    metadata: Object.freeze({
+      reason: 'earn:layout-sandbox',
+      source: 'ghostnet-console',
+      simulation: true
+    }),
+    mode: 'SIMULATION',
+    remoteOverrides: Object.freeze({
+      lastSyncedAt: '2024-02-18T09:08:06.000Z'
+    })
+  }),
+  Object.freeze({
+    id: 'sandbox-entry-0002',
+    type: 'spend',
+    amount: 250,
+    delta: -250,
+    balance: 126000,
+    timestamp: '2024-02-18T09:18:00.000Z',
+    metadata: Object.freeze({
+      reason: 'spend:layout-sandbox',
+      source: 'ghostnet-console',
+      simulation: true
+    }),
+    mode: 'SIMULATION',
+    remoteOverrides: Object.freeze({
+      lastSyncedAt: '2024-02-18T09:18:07.000Z'
+    })
+  }),
+  Object.freeze({
+    id: 'sandbox-entry-0003',
+    type: 'earn',
+    amount: 2500,
+    delta: 2500,
+    balance: 128500,
+    timestamp: '2024-02-18T09:29:00.000Z',
+    metadata: Object.freeze({
+      reason: 'earn:layout-sandbox',
+      source: 'ghostnet-console',
+      simulation: true,
+      celebrationId: 'layout-sandbox-streak'
+    }),
+    mode: 'SIMULATION',
+    remoteOverrides: Object.freeze({
+      lastSyncedAt: '2024-02-18T09:29:05.000Z'
+    })
+  })
+])
+
+export function getMockTokenRemoteState (overrides = {}) {
+  return {
+    ...MOCK_TOKEN_REMOTE_STATE_TEMPLATE,
+    ...(overrides || {})
+  }
+}
+
+export function getMockTokenBalanceSnapshot (overrides = {}) {
+  const { remote: remoteOverrides, ...rest } = overrides || {}
+  return {
+    ...MOCK_TOKEN_BALANCE_SNAPSHOT_TEMPLATE,
+    ...rest,
+    remote: getMockTokenRemoteState(remoteOverrides)
+  }
+}
+
+export function getMockTokenLedgerTransactions () {
+  return MOCK_TOKEN_LEDGER_TRANSACTION_TEMPLATES.map(entry => ({
+    id: entry.id,
+    type: entry.type,
+    amount: entry.amount,
+    delta: entry.delta,
+    balance: entry.balance,
+    timestamp: entry.timestamp,
+    metadata: { ...(entry.metadata || {}) },
+    mode: entry.mode,
+    remote: getMockTokenRemoteState(entry.remoteOverrides)
+  }))
+}
+
+export function getMockTokenLedger ({ limit } = {}) {
+  const normalizedLimit = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : null
+  const transactions = getMockTokenLedgerTransactions()
+  const limitedTransactions = normalizedLimit === null
+    ? transactions
+    : transactions.slice(normalizedLimit === 0 ? 0 : -normalizedLimit)
+
+  return {
+    snapshot: getMockTokenBalanceSnapshot(),
+    transactions: limitedTransactions
+  }
+}
+
 export function normaliseCommodityKey (value) {
   return typeof value === 'string' ? value.trim().toLowerCase() : ''
 }

--- a/src/client/lib/ghostnet-mock-data.js
+++ b/src/client/lib/ghostnet-mock-data.js
@@ -103,7 +103,8 @@ export function getMockTokenLedgerTransactions () {
   }))
 }
 
-export function getMockTokenLedger ({ limit } = {}) {
+export function getMockTokenLedger (options) {
+  const { limit } = options || {}
   const normalizedLimit = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : null
   const transactions = getMockTokenLedgerTransactions()
   const limitedTransactions = normalizedLimit === null

--- a/src/client/lib/socket.js
+++ b/src/client/lib/socket.js
@@ -1,7 +1,7 @@
 /* global WebSocket, CustomEvent */
 import { createContext, useState, useContext, useEffect } from 'react'
 import notification from 'lib/notification'
-import { getMockShipStatus, getMockSystemData } from './ghostnet-mock-data'
+import { getMockShipStatus, getMockSystemData, getMockTokenBalanceSnapshot, getMockTokenLedger } from './ghostnet-mock-data'
 
 let socket = null // Store socket connection (defaults to null)
 let callbackHandlers = {} // Store callbacks waiting to be executed (pending response from server)
@@ -170,6 +170,10 @@ function handleSandboxEvent (name, message) {
       return getMockSystemData(message?.name)
     case 'getLoadingStatus':
       return { loadingComplete: true }
+    case 'getTokenBalance':
+      return getMockTokenBalanceSnapshot()
+    case 'getTokenLedger':
+      return getMockTokenLedger(message)
     default:
       return null
   }


### PR DESCRIPTION
## Summary
- add deterministic token balance and ledger mock helpers for the layout sandbox
- update the sandbox socket handler to return token balances and ledgers immediately
- align the GhostNet tests with the shared token snapshot helper

## Testing
- npm test -- --runInBand --config jest.config.js --testPathPattern ghostnet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1dba4f4e48323a636dfdbaa0b43ea