### PR TITLE
Realign GhostNet console controls

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -4499,6 +4499,17 @@ function PristineMiningPanel () {
 const GREEK_SYMBOLS = ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta', 'theta', 'iota', 'kappa', 'lambda', 'mu', 'nu', 'xi', 'omicron', 'pi', 'rho', 'sigma', 'tau', 'upsilon', 'phi', 'chi', 'psi', 'omega']
 const TERMINAL_BUFFER = 36
 const TERMINAL_WINDOW = 7
+const TERMINAL_WINDOW_EXPANDED = 14
+
+const TERMINAL_HEIGHT_NORMAL = 'clamp(180px, 18vh, 220px)'
+const TERMINAL_HEIGHT_COMPRESSED = '3rem'
+const TERMINAL_HEIGHT_EXPANDED = 'clamp(320px, 32vh, 420px)'
+
+const TERMINAL_VIEW = {
+  NORMAL: 'normal',
+  COMPRESSED: 'compressed',
+  EXPANDED: 'expanded'
+}
 
 function randomChoice (items) {
   return items[Math.floor(Math.random() * items.length)]
@@ -4944,12 +4955,13 @@ function createTerminalLineWithId (seed = '', baseLine) {
 }
 
 function GhostnetTerminalOverlay () {
-  const [collapsed, setCollapsed] = useState(false)
+  const [viewState, setViewState] = useState(TERMINAL_VIEW.NORMAL)
   const [terminalLines, setTerminalLines] = useState(() =>
     Array.from({ length: TERMINAL_BUFFER }).map((_, index) => createTerminalLineWithId(index))
   )
   const cadenceRef = useRef()
   const timeoutRef = useRef(null)
+  const terminalRef = useRef(null)
   const [creditCelebration, setCreditCelebration] = useState(null)
   const [tokenBalance, setTokenBalance] = useState(null)
   const [tokenBalanceAnimated, setTokenBalanceAnimated] = useState(null)
@@ -4977,6 +4989,27 @@ function GhostnetTerminalOverlay () {
       menaceCooldown: 0
     }
   }
+
+  useEffect(() => {
+    const host = terminalRef.current?.parentElement
+    if (!host) return
+    const nextHeight =
+      viewState === TERMINAL_VIEW.COMPRESSED
+        ? TERMINAL_HEIGHT_COMPRESSED
+        : viewState === TERMINAL_VIEW.EXPANDED
+          ? TERMINAL_HEIGHT_EXPANDED
+          : TERMINAL_HEIGHT_NORMAL
+    host.style.setProperty('--ghostnet-terminal-height', nextHeight)
+  }, [viewState])
+
+  useEffect(() => {
+    const host = terminalRef.current?.parentElement
+    return () => {
+      if (host) {
+        host.style.removeProperty('--ghostnet-terminal-height')
+      }
+    }
+  }, [])
 
   useEffect(() => {
     animatedBalanceRef.current = tokenBalanceAnimated
@@ -5533,17 +5566,73 @@ function GhostnetTerminalOverlay () {
     return `${ledgerLabel} · ${remoteLabel}`
   }, [tokenSimulation, tokenMode, tokenRemoteState.enabled, tokenRemoteState.mode])
 
+  const isCompressed = viewState === TERMINAL_VIEW.COMPRESSED
+  const isExpanded = viewState === TERMINAL_VIEW.EXPANDED
+
+  const terminalWindowSize = useMemo(() => {
+    if (isCompressed) return 1
+    if (isExpanded) return TERMINAL_WINDOW_EXPANDED
+    return TERMINAL_WINDOW
+  }, [isCompressed, isExpanded])
+
   const visibleLines = useMemo(() => {
-    return terminalLines.slice(-TERMINAL_WINDOW)
+    return terminalLines.slice(-terminalWindowSize)
+  }, [terminalLines, terminalWindowSize])
+
+  const latestLine = useMemo(() => {
+    return terminalLines[terminalLines.length - 1]
   }, [terminalLines])
 
-  const toggleCollapsed = useCallback(() => {
-    setCollapsed(previous => !previous)
+  const handleMinimize = useCallback(() => {
+    setViewState(TERMINAL_VIEW.COMPRESSED)
+  }, [])
+
+  const handleToggleExpand = useCallback(() => {
+    setViewState(previous => {
+      if (previous === TERMINAL_VIEW.COMPRESSED) return TERMINAL_VIEW.NORMAL
+      if (previous === TERMINAL_VIEW.EXPANDED) return TERMINAL_VIEW.NORMAL
+      return TERMINAL_VIEW.EXPANDED
+    })
+  }, [])
+
+  const handleClose = useCallback(() => {
+    setViewState(TERMINAL_VIEW.COMPRESSED)
+  }, [])
+
+  const terminalClassName = [
+    styles.terminal,
+    isCompressed ? styles.terminalCompressed : '',
+    isExpanded ? styles.terminalExpanded : ''
+  ].filter(Boolean).join(' ')
+
+  const shellClassName = [
+    styles.terminalShell,
+    isCompressed ? styles.terminalShellCompressed : ''
+  ].filter(Boolean).join(' ')
+
+  const headerClassName = [
+    styles.terminalHeader,
+    isCompressed ? styles.terminalHeaderCompressed : ''
+  ].filter(Boolean).join(' ')
+
+  const maximizeAriaLabel = isCompressed
+    ? 'Restore console'
+    : isExpanded
+      ? 'Restore console size'
+      : 'Expand console'
+
+  const maximizeIcon = isExpanded ? '▭' : '▢'
+
+  const statusPreviewLabel = latestLine?.label ?? 'ghostnet'
+  const statusPreviewText = latestLine?.text ?? 'Link stable'
+
+  const handleStatusPreviewActivate = useCallback(() => {
+    setViewState(TERMINAL_VIEW.NORMAL)
   }, [])
 
   return (
-    <div className={`${styles.terminal} ${collapsed ? styles.terminalCollapsed : ''}`}>
-      <div className={styles.terminalShell} role='region' aria-label='Ghost Net ship uplink activity log'>
+    <div className={terminalClassName} ref={terminalRef}>
+      <div className={shellClassName} role='region' aria-label='Ghost Net ship uplink activity log'>
         <div
           className={[styles.terminalCelebration, creditCelebration ? styles.terminalCelebrationActive : ''].filter(Boolean).join(' ')}
           aria-hidden='true'
@@ -5566,67 +5655,107 @@ function GhostnetTerminalOverlay () {
             </div>
           ) : null}
         </div>
-        <div className={styles.terminalHeader}>
-          <div className={styles.terminalHeaderContent}>
-            <span className={styles.terminalTitle}>Ship Uplink Console</span>
-            <span className={styles.terminalStatus}>Channel mesh://ghostnet</span>
-            <div className={styles.terminalTokenRow}>
-              <span className={styles.terminalTokenLabel}>Tokens</span>
-              <span
-                className={[
-                  styles.terminalTokenValue,
-                  isNegativeBalance ? styles.terminalTokenValueNegative : '',
-                  balanceFlash?.type === 'earn' ? styles.terminalTokenValueFlashCredit : '',
-                  balanceFlash?.type === 'spend' ? styles.terminalTokenValueFlashDebit : ''
-                ].filter(Boolean).join(' ')}
-              >
-                {tokenBalanceDisplay}
-              </span>
+        <div className={headerClassName}>
+          <div className={styles.terminalHeaderLeft}>
+            {!isCompressed ? (
+              <Fragment>
+                <div className={styles.terminalTokenRow}>
+                  <span className={styles.terminalTokenLabel}>Tokens</span>
+                  <span
+                    className={[
+                      styles.terminalTokenValue,
+                      isNegativeBalance ? styles.terminalTokenValueNegative : '',
+                      balanceFlash?.type === 'earn' ? styles.terminalTokenValueFlashCredit : '',
+                      balanceFlash?.type === 'spend' ? styles.terminalTokenValueFlashDebit : ''
+                    ].filter(Boolean).join(' ')}
+                  >
+                    {tokenBalanceDisplay}
+                  </span>
+                  <button
+                    type='button'
+                    className={styles.terminalTokenButton}
+                    onClick={handleAddTokens}
+                    disabled={tokenButtonDisabled}
+                    aria-label='Trigger a simulated jackpot payout'
+                  >
+                    {tokenActionPending ? '···' : '+'}
+                  </button>
+                </div>
+                <div className={styles.terminalTokenMeta} aria-live='polite'>
+                  {tokenStatusText}
+                </div>
+              </Fragment>
+            ) : null}
+          </div>
+          <div className={styles.terminalHeaderCenter}>
+            {isCompressed ? (
               <button
                 type='button'
-                className={styles.terminalTokenButton}
-                onClick={handleAddTokens}
-                disabled={tokenButtonDisabled}
-                aria-label='Trigger a simulated jackpot payout'
+                className={styles.terminalStatusPreview}
+                onClick={handleStatusPreviewActivate}
+                aria-label='Restore console'
               >
-                {tokenActionPending ? '···' : '+'}
+                <span className={styles.terminalStatusPreviewLabel} aria-hidden='true'>{statusPreviewLabel}</span>
+                <span className={styles.terminalStatusPreviewText}>{statusPreviewText}</span>
+              </button>
+            ) : (
+              <div className={styles.terminalHeaderContent}>
+                <span className={styles.terminalTitle}>Ship Uplink Console</span>
+                <span className={styles.terminalStatus}>Channel mesh://ghostnet</span>
+              </div>
+            )}
+          </div>
+          <div className={styles.terminalHeaderRight}>
+            <div className={styles.terminalWindowControls} role='group' aria-label='Console window controls'>
+              <button
+                type='button'
+                className={`${styles.terminalWindowControl} ${styles.terminalWindowControlMinimize}`}
+                onClick={handleMinimize}
+                aria-label='Minimize console'
+              >
+                <span aria-hidden='true'>─</span>
+              </button>
+              <button
+                type='button'
+                className={`${styles.terminalWindowControl} ${styles.terminalWindowControlMaximize}`}
+                onClick={handleToggleExpand}
+                aria-label={maximizeAriaLabel}
+              >
+                <span aria-hidden='true'>{maximizeIcon}</span>
+              </button>
+              <button
+                type='button'
+                className={`${styles.terminalWindowControl} ${styles.terminalWindowControlClose}`}
+                onClick={handleClose}
+                aria-label='Close console'
+              >
+                <span aria-hidden='true'>✕</span>
               </button>
             </div>
-            <div className={styles.terminalTokenMeta} aria-live='polite'>
-              {tokenStatusText}
-            </div>
           </div>
-          <button
-            type='button'
-            className={[styles.terminalToggle, collapsed ? styles.terminalToggleCollapsed : ''].filter(Boolean).join(' ')}
-            onClick={toggleCollapsed}
-            aria-expanded={!collapsed}
-            aria-label={collapsed ? 'Expand uplink console' : 'Collapse uplink console'}
-          >
-            <span aria-hidden='true' className={styles.terminalToggleIcon}>{collapsed ? '▵' : '▿'}</span>
-            <span className={styles.terminalToggleLabel}>{collapsed ? 'Expand' : 'Collapse'}</span>
-          </button>
         </div>
-        <div className={styles.terminalBody}>
-          <ul className={styles.terminalFeed}>
-            {visibleLines.map(line => {
-              const promptClassNames = [styles.terminalPrompt]
-              const promptTypeClass = line.type ? TERMINAL_PROMPT_TYPE_CLASS_MAP[line.type] : null
-              if (promptTypeClass) promptClassNames.push(promptTypeClass)
+        {!isCompressed ? (
+          <div className={styles.terminalBody}>
+            <ul className={styles.terminalFeed}>
+              {visibleLines.map(line => {
+                const promptClassNames = [styles.terminalPrompt]
+                const promptTypeClass = line.type ? TERMINAL_PROMPT_TYPE_CLASS_MAP[line.type] : null
+                if (promptTypeClass) promptClassNames.push(promptTypeClass)
 
-              const textClassNames = [styles.terminalText]
-              const textTypeClass = line.type ? TERMINAL_TEXT_TYPE_CLASS_MAP[line.type] : null
-              if (textTypeClass) textClassNames.push(textTypeClass)
+                const textClassNames = [styles.terminalText]
+                const textTypeClass = line.type ? TERMINAL_TEXT_TYPE_CLASS_MAP[line.type] : null
+                if (textTypeClass) textClassNames.push(textTypeClass)
 
-              return (
-                <li key={line.id} className={styles.terminalLine}>
-                  <span className={promptClassNames.join(' ')}>{line.label}</span>
-                  <span className={textClassNames.join(' ')}>{line.text}</span>
-                </li>
-              )
-            })}
-          </ul>
-        </div>
+                return (
+                  <li key={line.id} className={styles.terminalLine}>
+                    <span className={promptClassNames.join(' ')}>{line.label}</span>
+                    <span className={textClassNames.join(' ')}>{line.text}</span>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -227,11 +227,14 @@
   height: var(--ghostnet-terminal-height);
   pointer-events: none;
   z-index: 20;
-  transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.terminalCollapsed {
-  transform: translateY(calc(var(--ghostnet-terminal-height) - 3.25rem));
+.terminalCompressed {
+  align-items: stretch;
+}
+
+.terminalExpanded {
+  align-items: flex-end;
 }
 
 .terminalShell {
@@ -249,6 +252,14 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.terminalShellCompressed {
+  border-radius: 0;
+  border-left: none;
+  border-right: none;
+  box-shadow: 0 -0.75rem 1.5rem color-mix(in srgb, var(--ghostnet-color-background) 62%, transparent);
+  background: color-mix(in srgb, var(--ghostnet-color-surface) 82%, transparent);
 }
 
 .terminalCelebration {
@@ -312,6 +323,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1.5rem;
   padding: 1rem 1.5rem 0.75rem 1.5rem;
   background: color-mix(in srgb, var(--ghostnet-color-primary) 12%, transparent);
   border-bottom: 1px solid var(--ghostnet-border-soft);
@@ -323,10 +335,179 @@
   z-index: 1;
 }
 
+.terminalHeaderLeft,
+.terminalHeaderCenter,
+.terminalHeaderRight {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.terminalHeaderLeft {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.terminalHeaderCenter {
+  flex: 1.25;
+  justify-content: center;
+}
+
+.terminalHeaderRight {
+  justify-content: flex-end;
+}
+
+.terminalHeaderCompressed {
+  padding: 0.45rem 0.85rem;
+  background: color-mix(in srgb, var(--ghostnet-color-surface) 68%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-border-soft) 60%, transparent);
+  gap: 0.85rem;
+}
+
+.terminalHeaderCompressed .terminalHeaderLeft {
+  display: none;
+}
+
+.terminalHeaderCompressed .terminalHeaderCenter {
+  flex: 1;
+}
+
 .terminalHeaderContent {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  align-items: center;
+  text-align: center;
+}
+
+.terminalWindowControls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.15rem 0;
+}
+
+.terminalHeaderCompressed .terminalWindowControls {
+  gap: 0.35rem;
+}
+
+.terminalWindowControl {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--ghostnet-border-soft);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  line-height: 1;
+  color: var(--ghostnet-color-background);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 52%, transparent);
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+  box-shadow: 0 0 10px color-mix(in srgb, var(--ghostnet-color-primary) 24%, transparent);
+}
+
+.terminalWindowControl span {
+  pointer-events: none;
+}
+
+button.terminalWindowControl:hover,
+button.terminalWindowControl:focus-visible {
+  transform: translateY(-1px);
+}
+
+button.terminalWindowControl:focus-visible {
+  outline: 2px solid var(--ghostnet-border-focus);
+  outline-offset: 2px;
+}
+
+button.terminalWindowControl:active {
+  transform: translateY(1px);
+}
+
+.terminalWindowControlMinimize {
+  background: color-mix(in srgb, var(--ghostnet-color-warning) 60%, transparent);
+  border-color: color-mix(in srgb, var(--ghostnet-color-warning) 52%, transparent);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--ghostnet-color-warning) 28%, transparent);
+}
+
+button.terminalWindowControlMinimize:hover,
+button.terminalWindowControlMinimize:focus-visible {
+  background: color-mix(in srgb, var(--ghostnet-color-warning) 72%, transparent);
+}
+
+.terminalWindowControlMaximize {
+  background: color-mix(in srgb, var(--ghostnet-color-success) 68%, transparent);
+  border-color: color-mix(in srgb, var(--ghostnet-color-success) 58%, transparent);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--ghostnet-color-success) 30%, transparent);
+}
+
+button.terminalWindowControlMaximize:hover,
+button.terminalWindowControlMaximize:focus-visible {
+  background: color-mix(in srgb, var(--ghostnet-color-success) 80%, transparent);
+}
+
+.terminalWindowControlClose {
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 82%, transparent);
+  border-color: color-mix(in srgb, var(--ghostnet-color-primary) 68%, transparent);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--ghostnet-color-primary) 36%, transparent);
+}
+
+button.terminalWindowControlClose:hover,
+button.terminalWindowControlClose:focus-visible {
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 92%, transparent);
+}
+
+.terminalStatusPreview {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ghostnet-color-text-strong);
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: none;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+  flex: 1;
+  min-width: 0;
+  justify-content: flex-start;
+}
+
+button.terminalStatusPreview:hover {
+  border-color: color-mix(in srgb, var(--ghostnet-border-soft) 68%, transparent);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent);
+}
+
+button.terminalStatusPreview:focus-visible {
+  outline: 2px solid var(--ghostnet-border-focus);
+  outline-offset: 2px;
+}
+
+.terminalStatusPreviewLabel {
+  font-size: 0.68rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ghostnet-color-text-strong) 68%, transparent);
+  white-space: nowrap;
+}
+
+.terminalStatusPreviewText {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  color: var(--ghostnet-color-text-strong);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
 }
 
 .terminalTitle {
@@ -343,7 +524,6 @@
 }
 
 .terminalTokenRow {
-  margin-top: 0.35rem;
   display: flex;
   align-items: center;
   gap: 0.65rem;
@@ -420,76 +600,10 @@ button.terminalTokenButton:disabled {
 }
 
 .terminalTokenMeta {
-  margin-top: 0.35rem;
   font-size: 0.65rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: color-mix(in srgb, var(--ghostnet-color-text-strong) 54%, transparent);
-}
-
-.terminalToggle {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 1.1rem;
-  border-radius: 0;
-  border: 1px solid var(--ghostnet-border-strong);
-  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 72%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 48%, transparent));
-  color: var(--ghostnet-color-text-strong);
-  text-transform: uppercase;
-  letter-spacing: 0.24em;
-  font-size: 0.72rem;
-  cursor: pointer;
-  text-shadow: 0 0 12px color-mix(in srgb, var(--ghostnet-color-primary) 55%, transparent);
-  box-shadow: 0 0 0 transparent;
-  transition: background 200ms ease, transform 200ms ease, box-shadow 200ms ease;
-}
-
-button.terminalToggle:hover:not([disabled]):not(.button--active),
-button.terminalToggle:focus-visible:not([disabled]):not(.button--active) {
-  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary) 88%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 62%, transparent));
-  transform: translateY(-1px);
-  box-shadow: 0 0 18px color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent);
-}
-
-button.terminalToggle:focus-visible:not([disabled]):not(.button--active) {
-  outline: 2px solid color-mix(in srgb, var(--ghostnet-color-primary-light) 92%, transparent);
-  outline-offset: 3px;
-}
-
-button.terminalToggle:active:not([disabled]):not(.button--active) {
-  background: linear-gradient(135deg, color-mix(in srgb, var(--ghostnet-color-primary-dark) 78%, transparent), color-mix(in srgb, var(--ghostnet-color-primary) 52%, transparent));
-  transform: translateY(1px);
-  box-shadow: 0 0 10px color-mix(in srgb, var(--ghostnet-color-primary-dark) 48%, transparent);
-}
-
-.terminalToggleIcon {
-  font-size: 0.95rem;
-  line-height: 1;
-  color: var(--ghostnet-color-text-strong);
-  text-shadow: 0 0 14px color-mix(in srgb, var(--ghostnet-color-text-strong) 60%, transparent);
-  transition: transform 200ms ease, color 200ms ease;
-}
-
-.terminalToggleLabel {
-  font-size: 0.68rem;
-  letter-spacing: 0.3em;
-  display: inline-flex;
-  align-items: center;
-}
-
-.terminalToggleCollapsed {
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--ghostnet-color-primary-dark) 82%, transparent),
-    color-mix(in srgb, var(--ghostnet-color-primary) 48%, transparent)
-  );
-  box-shadow: 0 0 14px color-mix(in srgb, var(--ghostnet-color-primary-dark) 36%, transparent);
-}
-
-.terminalToggleCollapsed .terminalToggleIcon {
-  color: var(--ghostnet-color-success);
 }
 
 .terminalBody {


### PR DESCRIPTION
## Summary
- reposition the GhostNet console token meter to the left edge and move the window controls to the right for an OS-style header layout
- restructure the terminal header markup to keep the status/title centered between the new edge sections across normal and compressed states
- update the console header styling so compressed mode hides the token column, centers the status preview, and tidies token spacing

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js build aborts on legacy CommonJS exports in shared modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e2ea78dc83238d73d5102a23876f