### PR TITLE
Refine trade routes table layout

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -435,8 +435,10 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   const originIconName = getStationIconName(originLocal, route?.origin)
   const destinationIconName = getStationIconName(destinationLocal, route?.destination)
 
-  const originStationDistanceDisplay = resolveStationDistanceDisplay(route?.origin)
-  const destinationStationDistanceDisplay = resolveStationDistanceDisplay(route?.destination)
+  const originStationDistance = resolveStationDistance(route?.origin)
+  const destinationStationDistance = resolveStationDistance(route?.destination)
+  const originStationDistanceDisplay = originStationDistance.display
+  const destinationStationDistanceDisplay = destinationStationDistance.display
   const originSystemDistance = resolveStationSystemDistance(route, 'origin')
   const destinationSystemDistance = resolveStationSystemDistance(route, 'destination')
   const originSystemDistanceDisplay = originSystemDistance.display || ''
@@ -464,7 +466,44 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   const profitPerHour = formatCredits(route?.summary?.profitPerHour, route?.summary?.profitPerHourText)
   const averageProfitText = sanitizeInaraText(route?.summary?.averageProfitText)
 
+  const routeDistance = resolveRouteDistance(route)
+  const updatedDisplay = formatRelativeTime(route?.summary?.updated || route?.updatedAt || route?.lastUpdated || route?.timestamp)
+
   const renderValue = value => (value ? value : <span className={styles.tradeRoutePlaceholder}>--</span>)
+
+  const metricVariantClasses = {
+    neutral: styles.metricChipNeutral,
+    success: styles.metricChipSuccess,
+    caution: styles.metricChipCaution,
+    warning: styles.metricChipWarning
+  }
+
+  const renderMetricChip = ({ value, variant = 'neutral', title, color }) => {
+    const classes = [styles.metricChip]
+    if (value) {
+      if (metricVariantClasses[variant]) {
+        classes.push(metricVariantClasses[variant])
+      }
+    } else {
+      classes.push(styles.metricChipPlaceholder)
+    }
+
+    return (
+      <span
+        className={classes.join(' ')}
+        title={title}
+        style={value && color ? { '--chip-color': color } : undefined}
+      >
+        {value || '--'}
+      </span>
+    )
+  }
+
+  const originStationDistanceVariant = getStationDistanceVariant(originStationDistance.value)
+  const destinationStationDistanceVariant = getStationDistanceVariant(destinationStationDistance.value)
+  const originSystemDistanceVariant = getSystemDistanceVariant(originSystemDistance.value)
+  const destinationSystemDistanceVariant = getSystemDistanceVariant(destinationSystemDistance.value)
+  const routeDistanceVariant = getSystemDistanceVariant(routeDistance.value)
 
   const handleClick = () => onSelect(route, index)
   const handleKeyDown = event => onKeyDown(event, route, index)
@@ -492,23 +531,31 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                 ? <StationIcon icon={originIconName} color={originStandingDisplay.color} size={28} />
                 : null}
             </span>
-            <span className={styles.tradeRouteStationName} title={originStationDisplay || undefined}>{renderValue(originStationDisplay)}</span>
-            <span className={`${styles.tradeRouteStationMetric} ${styles.tradeRouteHideCompact}`} title='Distance to station'>
-              {renderValue(originStationDistanceDisplay)}
-            </span>
+            <div className={styles.tradeRouteStationContent}>
+              <span className={styles.tradeRouteStationName} title={originStationDisplay || undefined}>{renderValue(originStationDisplay)}</span>
+              <div className={styles.tradeRouteStationChips}>
+                {renderMetricChip({
+                  value: originStationDistanceDisplay,
+                  variant: originStationDistanceVariant,
+                  title: 'Distance to station'
+                })}
+                {renderMetricChip({
+                  value: originSystemDistanceDisplay,
+                  variant: originSystemDistanceVariant,
+                  title: 'Distance to system'
+                })}
+              </div>
+            </div>
           </div>
           <div className={`${styles.tradeRouteStationRow} ${styles.tradeRouteStationRowSecondary}`}>
             <span className={styles.tradeRouteStationSystem} title={originSystemName || undefined}>{renderValue(originSystemName)}</span>
-            <span
-              className={`${styles.tradeRouteStationReputation} ${styles.tradeRouteHideMedium}`}
-              style={originStandingDisplay.color ? { color: originStandingDisplay.color } : undefined}
-              title={originStandingDisplay.title || undefined}
-            >
-              {renderValue(originReputationDisplay)}
-            </span>
-            <span className={`${styles.tradeRouteStationMetric} ${styles.tradeRouteHideNarrow}`} title='Distance to system'>
-              {renderValue(originSystemDistanceDisplay)}
-            </span>
+            <div className={styles.tradeRouteStationChips}>
+              {renderMetricChip({
+                value: originReputationDisplay,
+                title: originStandingDisplay.title || 'Faction standing',
+                color: originStandingDisplay.color
+              })}
+            </div>
           </div>
         </div>
       </td>
@@ -556,23 +603,31 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                 ? <StationIcon icon={destinationIconName} color={destinationStandingDisplay.color} size={28} />
                 : null}
             </span>
-            <span className={styles.tradeRouteStationName} title={destinationStationDisplay || undefined}>{renderValue(destinationStationDisplay)}</span>
-            <span className={`${styles.tradeRouteStationMetric} ${styles.tradeRouteHideCompact}`} title='Distance to station'>
-              {renderValue(destinationStationDistanceDisplay)}
-            </span>
+            <div className={styles.tradeRouteStationContent}>
+              <span className={styles.tradeRouteStationName} title={destinationStationDisplay || undefined}>{renderValue(destinationStationDisplay)}</span>
+              <div className={styles.tradeRouteStationChips}>
+                {renderMetricChip({
+                  value: destinationStationDistanceDisplay,
+                  variant: destinationStationDistanceVariant,
+                  title: 'Distance to station'
+                })}
+                {renderMetricChip({
+                  value: destinationSystemDistanceDisplay,
+                  variant: destinationSystemDistanceVariant,
+                  title: 'Distance to system'
+                })}
+              </div>
+            </div>
           </div>
           <div className={`${styles.tradeRouteStationRow} ${styles.tradeRouteStationRowSecondary}`}>
             <span className={styles.tradeRouteStationSystem} title={destinationSystemName || undefined}>{renderValue(destinationSystemName)}</span>
-            <span
-              className={`${styles.tradeRouteStationReputation} ${styles.tradeRouteHideMedium}`}
-              style={destinationStandingDisplay.color ? { color: destinationStandingDisplay.color } : undefined}
-              title={destinationStandingDisplay.title || undefined}
-            >
-              {renderValue(destinationReputationDisplay)}
-            </span>
-            <span className={`${styles.tradeRouteStationMetric} ${styles.tradeRouteHideNarrow}`} title='Distance to system'>
-              {renderValue(destinationSystemDistanceDisplay)}
-            </span>
+            <div className={styles.tradeRouteStationChips}>
+              {renderMetricChip({
+                value: destinationReputationDisplay,
+                title: destinationStandingDisplay.title || 'Faction standing',
+                color: destinationStandingDisplay.color
+              })}
+            </div>
           </div>
         </div>
       </td>
@@ -597,6 +652,18 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
               <span className={styles.tradeRouteProfitLabel}>Per hour</span>
               <span className={styles.tradeRouteProfitValue}>{renderValue(profitPerHour && profitPerHour !== '--' ? profitPerHour : '')}</span>
             </div>
+          </div>
+          <div className={styles.tradeRouteProfitMeta}>
+            {renderMetricChip({
+              value: routeDistance.display,
+              variant: routeDistanceVariant,
+              title: 'Total route distance'
+            })}
+            {renderMetricChip({
+              value: updatedDisplay,
+              variant: 'neutral',
+              title: 'Last updated'
+            })}
           </div>
         </div>
       </td>
@@ -1328,7 +1395,7 @@ function extractSystemDistance (route) {
   return null
 }
 
-function resolveStationDistanceDisplay (station = {}) {
+function resolveStationDistance (station = {}) {
   const numericCandidates = [
     station?.stationDistance?.value,
     station?.stationDistance,
@@ -1356,8 +1423,66 @@ function resolveStationDistanceDisplay (station = {}) {
   }
 
   const display = formatStationDistance(numericValue, textValue)
-  if (display && display !== '--') return display
-  return textValue && textValue !== '--' ? textValue : ''
+  const normalizedDisplay = display && display !== '--' ? display : (textValue && textValue !== '--' ? textValue : '')
+
+  return {
+    display: normalizedDisplay,
+    value: numericValue !== null ? numericValue : parseNumberFromText(textValue)
+  }
+}
+
+function resolveRouteDistance (route = {}) {
+  const summary = route?.summary || {}
+  const numericCandidates = [
+    summary?.routeDistanceLy,
+    summary?.distanceLy,
+    route?.distanceLy,
+    route?.distance
+  ]
+
+  let numericValue = null
+  for (const value of numericCandidates) {
+    if (typeof value === 'number' && !Number.isNaN(value)) {
+      numericValue = value
+      break
+    }
+  }
+
+  const textCandidates = [
+    summary?.routeDistanceText,
+    summary?.distanceText,
+    route?.distanceDisplay
+  ]
+
+  let textValue = ''
+  for (const text of textCandidates) {
+    if (typeof text === 'string' && text.trim()) {
+      textValue = sanitizeInaraText(text)
+      break
+    }
+  }
+
+  const display = formatSystemDistance(numericValue, textValue)
+  const normalizedDisplay = display && display !== '--' ? display : (textValue && textValue !== '--' ? textValue : '')
+
+  return {
+    display: normalizedDisplay,
+    value: numericValue !== null ? numericValue : parseNumberFromText(textValue)
+  }
+}
+
+function getStationDistanceVariant (value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 'neutral'
+  if (value <= 500) return 'success'
+  if (value <= 1500) return 'caution'
+  return 'warning'
+}
+
+function getSystemDistanceVariant (value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 'neutral'
+  if (value <= 15) return 'success'
+  if (value <= 35) return 'caution'
+  return 'warning'
 }
 
 function resolveStationSystemDistance (route, type) {

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1457,12 +1457,36 @@ button.terminalTokenButton:disabled {
 
 .tradeRoutesTable {
   min-width: 980px;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
+.tradeRoutesTable th,
 .tradeRoutesTable td {
   white-space: nowrap;
-  padding: 1.35rem 1.15rem;
+  padding: 0.95rem 1rem;
   overflow: hidden;
+}
+
+.tradeRoutesTable thead th {
+  position: sticky;
+  top: 0;
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 24%, transparent);
+  border-bottom: 1px solid var(--ghostnet-border-regular);
+  text-align: left;
+  font-size: 0.92rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ghostnet-muted);
+  z-index: 1;
+}
+
+.tradeRoutesTable thead th:first-child {
+  border-top-left-radius: 0.75rem;
+}
+
+.tradeRoutesTable thead th:last-child {
+  border-top-right-radius: 0.75rem;
 }
 
 .tradeRoutesStationCell,
@@ -1473,20 +1497,21 @@ button.terminalTokenButton:disabled {
 
 .tradeRouteStationGrid {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.4rem;
   min-width: 0;
 }
 
 .tradeRouteStationRow {
   display: grid;
-  grid-template-columns: minmax(2.2rem, auto) minmax(0, 1fr) minmax(0, 1.1fr);
-  align-items: center;
-  gap: 0.6rem;
+  grid-template-columns: minmax(2.4rem, auto) minmax(0, 1fr);
+  align-items: start;
+  gap: 0.75rem;
   min-width: 0;
 }
 
 .tradeRouteStationRowSecondary {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr) minmax(0, 1.1fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: center;
 }
 
 .tradeRouteStationIcon {
@@ -1498,8 +1523,15 @@ button.terminalTokenButton:disabled {
   color: var(--ghostnet-accent);
 }
 
+.tradeRouteStationContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
 .tradeRouteStationName {
-  font-size: 1.05rem;
+  font-size: 1.02rem;
   font-weight: 600;
   color: var(--ghostnet-ink);
   white-space: nowrap;
@@ -1513,18 +1545,14 @@ button.terminalTokenButton:disabled {
   overflow: hidden;
 }
 
-.tradeRouteStationMetric {
-  font-size: 0.82rem;
-  color: var(--ghostnet-text-soft);
-  white-space: nowrap;
-  justify-self: end;
+.tradeRouteStationChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
 }
 
-.tradeRouteStationReputation {
-  font-size: 0.85rem;
-  font-weight: 600;
-  justify-self: center;
-  white-space: nowrap;
+.tradeRouteStationRowSecondary .tradeRouteStationChips {
+  justify-content: flex-end;
 }
 
 .tradeRouteCommodityGrid {
@@ -1535,9 +1563,9 @@ button.terminalTokenButton:disabled {
 
 .tradeRouteCommodityRow {
   display: grid;
-  grid-template-columns: minmax(1.6rem, auto) minmax(2.2rem, auto) minmax(0, 1.35fr) minmax(0, 1fr) minmax(0, 1.15fr) minmax(1.6rem, auto);
+  grid-template-columns: minmax(1.6rem, auto) minmax(2.1rem, auto) minmax(0, 1.3fr) minmax(0, 0.95fr) minmax(0, 1.05fr) minmax(1.6rem, auto);
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.45rem;
   min-width: 0;
   position: relative;
 }
@@ -1616,9 +1644,11 @@ button.terminalTokenButton:disabled {
   opacity: 0.65;
 }
 
+
 .tradeRouteProfitGrid {
   display: grid;
-  gap: 0.6rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
   min-width: 0;
 }
 
@@ -1647,6 +1677,13 @@ button.terminalTokenButton:disabled {
   font-weight: 600;
   color: var(--ghostnet-ink);
   white-space: nowrap;
+}
+
+.tradeRouteProfitMeta {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
 }
 
 @media (max-width: 1440px) {
@@ -1682,20 +1719,30 @@ button.terminalTokenButton:disabled {
 .tradeRoutesHeader {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.35rem;
 }
 
 .tradeRoutesHeaderTitle {
   display: flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ghostnet-ink);
+  text-transform: none;
 }
 
 .tradeRoutesHeaderSubtitle {
-  font-size: 0.64rem;
-  letter-spacing: 0.18em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--ghostnet-text-soft);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 24%, transparent);
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
 }
 
 .tradeRoutesQuantityBadge {
@@ -1731,6 +1778,46 @@ button.terminalTokenButton:disabled {
   color: var(--ghostnet-text-soft);
   background: color-mix(in srgb, var(--ghostnet-color-primary) 10%, transparent);
   box-shadow: none;
+}
+
+.metricChip {
+  --chip-color: var(--ghostnet-accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--chip-color);
+  background: color-mix(in srgb, var(--chip-color) 22%, transparent);
+  border: 1px solid color-mix(in srgb, var(--chip-color) 35%, transparent);
+  box-shadow: 0 0 0.65rem color-mix(in srgb, var(--chip-color) 25%, transparent);
+  white-space: nowrap;
+}
+
+.metricChipPlaceholder {
+  color: var(--ghostnet-text-soft);
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 10%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+  box-shadow: none;
+}
+
+.metricChipNeutral {
+  --chip-color: var(--ghostnet-accent);
+}
+
+.metricChipSuccess {
+  --chip-color: var(--ghostnet-color-success);
+}
+
+.metricChipCaution {
+  --chip-color: color-mix(in srgb, var(--ghostnet-color-warning) 55%, var(--ghostnet-color-primary-light) 45%);
+}
+
+.metricChipWarning {
+  --chip-color: var(--ghostnet-color-warning);
 }
 
 .tableCellTop {


### PR DESCRIPTION
## Summary
- compress the Trade Route Data row layout with reusable metric chips so station, system, and route stats stay visible
- add helpers to normalize station and route distances and drive severity-based coloring for the new chips
- retheme the trade route table header and cell spacing to reduce white space and align with Ghost Net styling

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: Next.js SWC transform rejects the deprecated `serverComponents` flag in bundled scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68e2031273988323b091ce86e193c650