### PR TITLE
Refine trade route commodity flow backgrounds

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -561,7 +561,8 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
       </td>
       <td className={`${styles.tableCellTop} ${styles.tradeRoutesItemCell}`}>
         <div className={styles.tradeRouteCommodityGrid}>
-          <div className={styles.tradeRouteCommodityRow}>
+          <div className={`${styles.tradeRouteCommodityRow} ${styles.tradeRouteCommodityRowOutbound}`}>
+            <span className={styles.visuallyHidden}>Outbound to {destinationStationAria}</span>
             <span className={styles.tradeRouteCommodityIcon}>
               <CommodityIcon category={outboundInfo.buy?.category || outboundInfo.sell?.category || ''} size={24} />
             </span>
@@ -572,15 +573,8 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
             <span className={`${styles.tradeRouteCommodityDemand} ${styles.tradeRouteHideCompact}`}>
               {renderValue(outboundDemandDisplay)}
             </span>
-            <span className={styles.tradeRouteCommodityArrow} aria-hidden='true'>
-              {String.fromCharCode(0x2192)}
-            </span>
-            <span className={styles.visuallyHidden}>Outbound to {destinationStationAria}</span>
           </div>
           <div className={`${styles.tradeRouteCommodityRow} ${styles.tradeRouteCommodityRowReturn}`}>
-            <span className={styles.tradeRouteCommodityArrow} aria-hidden='true'>
-              {String.fromCharCode(0x2190)}
-            </span>
             <span className={styles.visuallyHidden}>Return to {originStationAria}</span>
             <span className={styles.tradeRouteCommodityIcon}>
               <CommodityIcon category={returnInfo.buy?.category || returnInfo.sell?.category || ''} size={24} />

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1563,36 +1563,66 @@ button.terminalTokenButton:disabled {
 
 .tradeRouteCommodityRow {
   display: grid;
-  grid-template-columns: minmax(1.6rem, auto) minmax(2.1rem, auto) minmax(0, 1.3fr) minmax(0, 0.95fr) minmax(0, 1.05fr) minmax(1.6rem, auto);
+  grid-template-columns: minmax(2.2rem, auto) minmax(0, 1.35fr) minmax(0, 0.95fr) minmax(0, 1.05fr);
   align-items: center;
   gap: 0.45rem;
   min-width: 0;
   position: relative;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  z-index: 0;
 }
 
-.tradeRouteCommodityRowReturn .tradeRouteCommodityArrow {
-  grid-column: 1;
-  justify-self: start;
+.tradeRouteCommodityRow > * {
+  position: relative;
+  z-index: 1;
 }
 
-.tradeRouteCommodityRowReturn .tradeRouteCommodityIcon {
-  grid-column: 2;
+.tradeRouteCommodityRow::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: transparent;
+  opacity: 1;
+  transition: transform 160ms ease, opacity 160ms ease;
+  pointer-events: none;
 }
 
-.tradeRouteCommodityRowReturn .tradeRouteCommodityName {
-  grid-column: 3;
+.tradeRouteCommodityRowOutbound::before {
+  background-image:
+    linear-gradient(90deg, rgba(93, 46, 255, 0.24), rgba(93, 46, 255, 0.08) 70%, rgba(41, 243, 195, 0.32)),
+    repeating-linear-gradient(90deg, rgba(140, 92, 255, 0.22) 0 4px, rgba(140, 92, 255, 0) 4px 12px);
+  clip-path: polygon(0 0, 100% 0, calc(100% - 1.65rem) 50%, 100% 100%, 0 100%);
 }
 
-.tradeRouteCommodityRowReturn .tradeRouteCommodityPrice {
-  grid-column: 4;
+.tradeRouteCommodityRowReturn::before {
+  background-image:
+    linear-gradient(270deg, rgba(93, 46, 255, 0.24), rgba(93, 46, 255, 0.08) 70%, rgba(255, 95, 193, 0.28)),
+    repeating-linear-gradient(270deg, rgba(140, 92, 255, 0.22) 0 4px, rgba(140, 92, 255, 0) 4px 12px);
+  clip-path: polygon(1.65rem 0, 100% 0, 100% 100%, 1.65rem 100%, 0 50%);
 }
 
-.tradeRouteCommodityRowReturn .tradeRouteCommodityDemand {
-  grid-column: 5;
+.tradeRouteCommodityRow:hover::before,
+.tradeRouteCommodityRow:focus-within::before {
+  opacity: 1;
+  transform: scale(1.015);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tradeRouteCommodityRow::before {
+    transition: opacity 160ms ease;
+  }
+
+  .tradeRouteCommodityRow:hover::before,
+  .tradeRouteCommodityRow:focus-within::before {
+    transform: none;
+  }
 }
 
 .tradeRouteCommodityIcon {
-  grid-column: 2;
+  grid-column: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1601,7 +1631,7 @@ button.terminalTokenButton:disabled {
 }
 
 .tradeRouteCommodityName {
-  grid-column: 3;
+  grid-column: 2;
   font-size: 1rem;
   font-weight: 600;
   color: var(--ghostnet-ink);
@@ -1610,7 +1640,7 @@ button.terminalTokenButton:disabled {
 }
 
 .tradeRouteCommodityPrice {
-  grid-column: 4;
+  grid-column: 3;
   color: var(--ghostnet-text-soft);
   font-size: 0.9rem;
   white-space: nowrap;
@@ -1618,7 +1648,7 @@ button.terminalTokenButton:disabled {
 }
 
 .tradeRouteCommodityDemand {
-  grid-column: 5;
+  grid-column: 4;
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
@@ -1626,17 +1656,6 @@ button.terminalTokenButton:disabled {
   gap: 0.35rem;
   white-space: nowrap;
   justify-self: end;
-}
-
-.tradeRouteCommodityArrow {
-  grid-column: 6;
-  font-size: 1.2rem;
-  color: var(--ghostnet-text-soft);
-  justify-self: end;
-}
-
-.tradeRouteCommodityRowReturn .tradeRouteCommodityArrow {
-  justify-self: start;
 }
 
 .tradeRoutePlaceholder {


### PR DESCRIPTION
## Summary
- replace inline arrow glyphs with directional gradient backgrounds on trade route commodity rows while keeping screen-reader direction hints
- tighten the commodity row grid spacing and add hover/focus treatments with motion-safe fallbacks for the new backgrounds

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js SWC cannot deserialize TransformOptions because of the unknown `serverComponents` field in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2082121a08323aac82d196f3b9af0