### PR TITLE
Restyle GhostNet console with black terminal aesthetic

### DIFF
--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -241,14 +241,14 @@
   position: relative;
   width: 100%;
   max-width: none;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-surface) 92%, transparent) 0%, color-mix(in srgb, var(--ghostnet-color-background) 94%, transparent) 100%);
-  border: 1px solid var(--ghostnet-border-regular);
+  background: linear-gradient(180deg, rgba(6, 6, 12, 0.96) 0%, rgba(2, 2, 6, 0.98) 60%, rgba(0, 0, 0, 0.98) 100%);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-text-strong) 26%, transparent);
   border-bottom: none;
   border-radius: 1.5rem 1.5rem 0 0;
   color: var(--ghostnet-ink);
   pointer-events: auto;
-  box-shadow: 0 -1.25rem 2.75rem var(--ghostnet-shadow-deep), 0 0 1.75rem var(--ghostnet-glow);
-  backdrop-filter: blur(16px);
+  box-shadow: 0 -1.5rem 3rem rgba(0, 0, 0, 0.65), 0 0 2rem color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+  backdrop-filter: blur(10px);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -258,8 +258,8 @@
   border-radius: 0;
   border-left: none;
   border-right: none;
-  box-shadow: 0 -0.75rem 1.5rem color-mix(in srgb, var(--ghostnet-color-background) 62%, transparent);
-  background: color-mix(in srgb, var(--ghostnet-color-surface) 82%, transparent);
+  box-shadow: 0 -0.85rem 1.8rem rgba(0, 0, 0, 0.72);
+  background: linear-gradient(180deg, rgba(10, 10, 16, 0.95) 0%, rgba(0, 0, 0, 0.98) 100%);
 }
 
 .terminalCelebration {
@@ -325,8 +325,9 @@
   justify-content: space-between;
   gap: 1.5rem;
   padding: 1rem 1.5rem 0.75rem 1.5rem;
-  background: color-mix(in srgb, var(--ghostnet-color-primary) 12%, transparent);
-  border-bottom: 1px solid var(--ghostnet-border-soft);
+  background: linear-gradient(180deg, rgba(32, 32, 40, 0.92) 0%, rgba(12, 12, 18, 0.96) 60%, rgba(6, 6, 12, 0.98) 100%);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-text-strong) 22%, transparent);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.45);
 }
 
 .terminalHeader,
@@ -361,8 +362,8 @@
 
 .terminalHeaderCompressed {
   padding: 0.45rem 0.85rem;
-  background: color-mix(in srgb, var(--ghostnet-color-surface) 68%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-border-soft) 60%, transparent);
+  background: linear-gradient(180deg, rgba(28, 28, 34, 0.94) 0%, rgba(8, 8, 12, 0.98) 100%);
+  border-bottom: 1px solid color-mix(in srgb, var(--ghostnet-color-text-strong) 18%, transparent);
   gap: 0.85rem;
 }
 
@@ -393,29 +394,33 @@
 .terminalWindowControls {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.25rem;
   padding: 0.15rem 0;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-text-strong) 16%, transparent);
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.4);
 }
 
 .terminalHeaderCompressed .terminalWindowControls {
-  gap: 0.35rem;
+  gap: 0.2rem;
 }
 
 .terminalWindowControl {
-  width: 1.25rem;
-  height: 1.25rem;
-  border-radius: 999px;
-  border: 1px solid var(--ghostnet-border-soft);
+  width: 1.8rem;
+  height: 1.4rem;
+  border-radius: 4px;
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-text-strong) 18%, transparent);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 0.7rem;
   line-height: 1;
-  color: var(--ghostnet-color-background);
-  background: color-mix(in srgb, var(--ghostnet-color-primary) 52%, transparent);
+  color: var(--ghostnet-color-text-strong);
+  background: linear-gradient(180deg, rgba(24, 24, 32, 0.92) 0%, rgba(8, 8, 12, 0.98) 100%);
   cursor: pointer;
-  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
-  box-shadow: 0 0 10px color-mix(in srgb, var(--ghostnet-color-primary) 24%, transparent);
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease, border-color 180ms ease;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.55), 0 0 10px rgba(0, 0, 0, 0.45);
 }
 
 .terminalWindowControl span {
@@ -425,6 +430,8 @@
 button.terminalWindowControl:hover,
 button.terminalWindowControl:focus-visible {
   transform: translateY(-1px);
+  background: linear-gradient(180deg, rgba(36, 36, 48, 0.96) 0%, rgba(12, 12, 18, 0.98) 100%);
+  border-color: color-mix(in srgb, var(--ghostnet-color-text-strong) 28%, transparent);
 }
 
 button.terminalWindowControl:focus-visible {
@@ -434,39 +441,40 @@ button.terminalWindowControl:focus-visible {
 
 button.terminalWindowControl:active {
   transform: translateY(1px);
+  background: linear-gradient(180deg, rgba(14, 14, 22, 0.96) 0%, rgba(4, 4, 10, 0.98) 100%);
 }
 
 .terminalWindowControlMinimize {
-  background: color-mix(in srgb, var(--ghostnet-color-warning) 60%, transparent);
-  border-color: color-mix(in srgb, var(--ghostnet-color-warning) 52%, transparent);
-  box-shadow: 0 0 12px color-mix(in srgb, var(--ghostnet-color-warning) 28%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-warning) 22%, transparent) 0%, rgba(20, 20, 28, 0.98) 100%);
+  border-color: color-mix(in srgb, var(--ghostnet-color-warning) 26%, transparent);
+  color: color-mix(in srgb, var(--ghostnet-color-warning) 86%, transparent);
 }
 
 button.terminalWindowControlMinimize:hover,
 button.terminalWindowControlMinimize:focus-visible {
-  background: color-mix(in srgb, var(--ghostnet-color-warning) 72%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-warning) 32%, transparent) 0%, rgba(24, 24, 32, 0.98) 100%);
 }
 
 .terminalWindowControlMaximize {
-  background: color-mix(in srgb, var(--ghostnet-color-success) 68%, transparent);
-  border-color: color-mix(in srgb, var(--ghostnet-color-success) 58%, transparent);
-  box-shadow: 0 0 12px color-mix(in srgb, var(--ghostnet-color-success) 30%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-success) 28%, transparent) 0%, rgba(20, 24, 28, 0.98) 100%);
+  border-color: color-mix(in srgb, var(--ghostnet-color-success) 32%, transparent);
+  color: color-mix(in srgb, var(--ghostnet-color-success) 82%, transparent);
 }
 
 button.terminalWindowControlMaximize:hover,
 button.terminalWindowControlMaximize:focus-visible {
-  background: color-mix(in srgb, var(--ghostnet-color-success) 80%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-success) 38%, transparent) 0%, rgba(26, 30, 34, 0.98) 100%);
 }
 
 .terminalWindowControlClose {
-  background: color-mix(in srgb, var(--ghostnet-color-primary) 82%, transparent);
-  border-color: color-mix(in srgb, var(--ghostnet-color-primary) 68%, transparent);
-  box-shadow: 0 0 14px color-mix(in srgb, var(--ghostnet-color-primary) 36%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-primary) 38%, transparent) 0%, rgba(24, 16, 36, 0.98) 100%);
+  border-color: color-mix(in srgb, var(--ghostnet-color-primary) 36%, transparent);
+  color: color-mix(in srgb, var(--ghostnet-color-primary) 88%, transparent);
 }
 
 button.terminalWindowControlClose:hover,
 button.terminalWindowControlClose:focus-visible {
-  background: color-mix(in srgb, var(--ghostnet-color-primary) 92%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--ghostnet-color-primary) 48%, transparent) 0%, rgba(30, 20, 44, 0.98) 100%);
 }
 
 .terminalStatusPreview {
@@ -620,14 +628,10 @@ button.terminalTokenButton:disabled {
 .terminalBody {
   flex: 1;
   padding: 1.25rem 1.5rem 1.5rem;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent) 0%,
-    color-mix(in srgb, var(--ghostnet-color-primary) 4%, transparent) 60%,
-    transparent 100%
-  );
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.92) 0%, rgba(0, 0, 0, 0.98) 40%, rgba(4, 4, 12, 0.98) 100%);
   overflow: hidden;
   display: flex;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghostnet-color-text-strong) 12%, transparent);
 }
 
 .terminalFeed {


### PR DESCRIPTION
## Summary
- restyle the GhostNet console shell with a black terminal-inspired backdrop and stronger borders
- update the header treatment and window controls to echo a Windows chrome while preserving GhostNet accents
- reinforce the console body framing to emphasize the feed within the new theme

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js SWC transform error about `serverComponents` field)*

------
https://chatgpt.com/codex/tasks/task_e_68e204c5550483239bf0de1c26a5ac39