### PR TITLE
Fix outbound trade flow arrow tip orientation

### DIFF
--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1594,7 +1594,7 @@ button.terminalTokenButton:disabled {
   background-image:
     linear-gradient(90deg, rgba(93, 46, 255, 0.24), rgba(93, 46, 255, 0.08) 70%, rgba(41, 243, 195, 0.32)),
     repeating-linear-gradient(90deg, rgba(140, 92, 255, 0.22) 0 4px, rgba(140, 92, 255, 0) 4px 12px);
-  clip-path: polygon(0 0, 100% 0, calc(100% - 1.65rem) 50%, 100% 100%, 0 100%);
+  clip-path: polygon(0 0, calc(100% - 1.65rem) 0, 100% 50%, calc(100% - 1.65rem) 100%, 0 100%);
 }
 
 .tradeRouteCommodityRowReturn::before {


### PR DESCRIPTION
## Summary
- update the outbound trade flow background clip path so the header arrow tip points in the correct direction

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: next-swc transform options report `unknown field serverComponents` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e20ead8df88323b4ead43f351cee33