### PR TITLE
Reorder trade route filters above context panel

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -4068,6 +4068,24 @@ function TradeRoutesPanel () {
         <h2 id='trade-routes-filters-heading' className={styles.tableSectionTitle}>Find Trade Routes</h2>
         <p className={styles.sectionHint}>Cross-reference GHOSTNET freight whispers to surface lucrative corridors suited to your ship profile.</p>
       </div>
+      <TradeRouteFilterPanel
+        filters={filters}
+        onFilterChange={setFilterValue}
+        options={filterOptions}
+        cargoCapacityDisplay={cargoCapacityDisplay}
+        selectedSystemName={selectedSystemName}
+        systemSelection={systemSelection}
+        systemInput={systemInput}
+        systemOptions={systemOptions}
+        onSystemChange={handleSystemChange}
+        onManualSystemChange={handleManualSystemChange}
+        filtersCollapsed={filtersCollapsed}
+        onToggleFilters={() => setFiltersCollapsed(prev => !prev)}
+        onSubmit={handleSubmit}
+        isRefreshing={isRefreshing}
+        padSizeAutoDetected={padSizeAutoDetected}
+        initialShipInfoLoaded={initialShipInfoLoaded}
+      />
       <div className={styles.tradeRouteContext} role='group' aria-label='Selected route context'>
         <div className={styles.tradeRouteContextTitleRow}>
           <span className={styles.tradeRouteContextTitle}>Route Context</span>
@@ -4153,24 +4171,6 @@ function TradeRoutesPanel () {
           <div className={styles.tradeRouteContextEmpty}>Select a trade route to populate the context.</div>
         )}
       </div>
-      <TradeRouteFilterPanel
-        filters={filters}
-        onFilterChange={setFilterValue}
-        options={filterOptions}
-        cargoCapacityDisplay={cargoCapacityDisplay}
-        selectedSystemName={selectedSystemName}
-        systemSelection={systemSelection}
-        systemInput={systemInput}
-        systemOptions={systemOptions}
-        onSystemChange={handleSystemChange}
-        onManualSystemChange={handleManualSystemChange}
-        filtersCollapsed={filtersCollapsed}
-        onToggleFilters={() => setFiltersCollapsed(prev => !prev)}
-        onSubmit={handleSubmit}
-        isRefreshing={isRefreshing}
-        padSizeAutoDetected={padSizeAutoDetected}
-        initialShipInfoLoaded={initialShipInfoLoaded}
-      />
       <div className='ghostnet-panel-table'>
         <div className='scrollable' style={TABLE_SCROLL_AREA_STYLE}>
           {message && status !== 'idle' && status !== 'loading' && (


### PR DESCRIPTION
## Summary
- move the trade route filters above the route context panel in the GhostNet trade route view to match the requested layout

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: Next.js build cannot deserialize TransformOptions because of unknown `serverComponents` field in next_swc)*

------
https://chatgpt.com/codex/tasks/task_e_68e293f73c648323b98142a57a6cc493