### PR TITLE
Adjust trade route table presentation

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -423,11 +423,6 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   const originSystemDistanceDisplay = originSystemDistance.display || ''
   const destinationSystemDistanceDisplay = destinationSystemDistance.display || ''
 
-  const originReputationLabel = sanitizeInaraText(originStandingDisplay.statusLabel) || '--'
-  const destinationReputationLabel = sanitizeInaraText(destinationStandingDisplay.statusLabel) || '--'
-  const originReputationDisplay = originReputationLabel === '--' ? '' : originReputationLabel
-  const destinationReputationDisplay = destinationReputationLabel === '--' ? '' : destinationReputationLabel
-
   const outboundInfo = getRouteCommodityInfo(route, 'outbound')
   const returnInfo = getRouteCommodityInfo(route, 'return')
 
@@ -509,9 +504,12 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
       <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell}`}>
         <div className={styles.tradeRouteStationGrid}>
           <div className={styles.tradeRouteStationRow}>
-            <span className={styles.tradeRouteStationIcon}>
+            <span
+              className={styles.tradeRouteStationIcon}
+              title={originStandingDisplay.title || undefined}
+            >
               {originIconName
-                ? <StationIcon icon={originIconName} color={originStandingDisplay.color} size={28} />
+                ? <StationIcon icon={originIconName} color={originStandingDisplay.iconColor} size={28} />
                 : null}
             </span>
             <div className={styles.tradeRouteStationContent}>
@@ -532,13 +530,6 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
           </div>
           <div className={`${styles.tradeRouteStationRow} ${styles.tradeRouteStationRowSecondary}`}>
             <span className={styles.tradeRouteStationSystem} title={originSystemName || undefined}>{renderValue(originSystemName)}</span>
-            <div className={styles.tradeRouteStationChips}>
-              {renderMetricChip({
-                value: originReputationDisplay,
-                title: originStandingDisplay.title || 'Faction standing',
-                color: originStandingDisplay.color
-              })}
-            </div>
           </div>
         </div>
       </td>
@@ -575,9 +566,12 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
       <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell}`}>
         <div className={styles.tradeRouteStationGrid}>
           <div className={styles.tradeRouteStationRow}>
-            <span className={styles.tradeRouteStationIcon}>
+            <span
+              className={styles.tradeRouteStationIcon}
+              title={destinationStandingDisplay.title || undefined}
+            >
               {destinationIconName
-                ? <StationIcon icon={destinationIconName} color={destinationStandingDisplay.color} size={28} />
+                ? <StationIcon icon={destinationIconName} color={destinationStandingDisplay.iconColor} size={28} />
                 : null}
             </span>
             <div className={styles.tradeRouteStationContent}>
@@ -598,13 +592,6 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
           </div>
           <div className={`${styles.tradeRouteStationRow} ${styles.tradeRouteStationRowSecondary}`}>
             <span className={styles.tradeRouteStationSystem} title={destinationSystemName || undefined}>{renderValue(destinationSystemName)}</span>
-            <div className={styles.tradeRouteStationChips}>
-              {renderMetricChip({
-                value: destinationReputationDisplay,
-                title: destinationStandingDisplay.title || 'Faction standing',
-                color: destinationStandingDisplay.color
-              })}
-            </div>
           </div>
         </div>
       </td>
@@ -878,7 +865,8 @@ function getFactionStandingDisplay(factionName, standings) {
     statusLabel: null,
     statusDescription: undefined,
     hasData: false,
-    color: '#7f8697'
+    color: '#7f8697',
+    iconColor: '#7f8697'
   }
 
   if (!key || !standings) {
@@ -920,16 +908,16 @@ function getFactionStandingDisplay(factionName, standings) {
 
   const normalizedStanding = typeof info.standing === 'string' ? info.standing.trim().toLowerCase() : ''
   let className = null
-  let color = 'var(--ghostnet-subdued)'
+  let baseColor = 'var(--ghostnet-subdued)'
   if (normalizedStanding === 'ally') {
     className = styles.tableTextSuccess
-    color = '#29f3c3'
+    baseColor = '#29f3c3'
   } else if (normalizedStanding === 'hostile') {
     className = styles.tableTextDanger
-    color = '#ff5fc1'
+    baseColor = '#ff5fc1'
   } else if (normalizedStanding) {
     className = styles.tableTextNeutral
-    color = 'var(--ghostnet-accent)'
+    baseColor = 'var(--ghostnet-accent)'
   }
 
   const reputationLabel = typeof info.reputation === 'number'
@@ -939,6 +927,13 @@ function getFactionStandingDisplay(factionName, standings) {
     .filter(Boolean)
     .join(' · ') || undefined
 
+  const reputationValue = clampReputationValue(info.reputation)
+  if (reputationValue !== null) {
+    baseColor = reputationValue >= 0 ? '#29f3c3' : '#ff5fc1'
+  }
+
+  const iconColor = applyStandingColorIntensity(baseColor, reputationValue)
+
   return {
     info,
     className,
@@ -946,7 +941,49 @@ function getFactionStandingDisplay(factionName, standings) {
     statusLabel,
     statusDescription,
     hasData: true,
-    color
+    color: iconColor,
+    iconColor
+  }
+}
+
+function clampReputationValue(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return null
+  if (value > 100) return 100
+  if (value < -100) return -100
+  return value
+}
+
+function applyStandingColorIntensity(baseColor, reputationValue) {
+  if (!baseColor) return baseColor
+  if (typeof reputationValue !== 'number') {
+    return baseColor
+  }
+
+  if (!isHexColor(baseColor)) return baseColor
+
+  const { r, g, b } = hexToRgb(baseColor)
+  const intensity = Math.abs(reputationValue) / 100
+  const minAlpha = 0.35
+  const alpha = minAlpha + (1 - minAlpha) * intensity
+  const roundedAlpha = Math.round(alpha * 100) / 100
+
+  return `rgba(${r}, ${g}, ${b}, ${roundedAlpha})`
+}
+
+function isHexColor(value) {
+  return typeof value === 'string' && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value.trim())
+}
+
+function hexToRgb(hex) {
+  const value = hex.trim().replace('#', '')
+  const normalized = value.length === 3
+    ? value.split('').map(char => `${char}${char}`).join('')
+    : value
+  const int = parseInt(normalized, 16)
+  return {
+    r: (int >> 16) & 255,
+    g: (int >> 8) & 255,
+    b: int & 255
   }
 }
 

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1611,7 +1611,7 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tradeRouteStationRowSecondary {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   align-items: center;
 }
 
@@ -1656,23 +1656,30 @@ button.terminalStatusPreview:focus-visible {
   justify-content: flex-end;
 }
 
+.tradeRoutesTable th:nth-child(3),
+.tradeRoutesTable td:nth-child(3),
+.tradeRoutesItemCell {
+  width: clamp(15rem, 24vw, 19rem);
+}
+
 .tradeRouteCommodityGrid {
   display: grid;
-  gap: 0.55rem;
+  gap: 0.45rem;
   min-width: 0;
 }
 
 .tradeRouteCommodityRow {
   display: grid;
-  grid-template-columns: minmax(2.2rem, auto) minmax(0, 1.35fr) minmax(0, 0.95fr) minmax(0, 1.05fr);
+  grid-template-columns: minmax(2.1rem, auto) minmax(0, max-content) max-content max-content;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.35rem;
   min-width: 0;
   position: relative;
-  padding: 0.45rem 0.75rem;
+  padding: 0.4rem 0.6rem;
   border-radius: 0.75rem;
   overflow: hidden;
   z-index: 0;
+  justify-content: flex-start;
 }
 
 .tradeRouteCommodityRow > * {
@@ -1738,6 +1745,7 @@ button.terminalStatusPreview:focus-visible {
   color: var(--ghostnet-ink);
   white-space: nowrap;
   overflow: hidden;
+  max-width: 12.5rem;
 }
 
 .tradeRouteCommodityPrice {
@@ -1766,16 +1774,19 @@ button.terminalStatusPreview:focus-visible {
 
 
 .tradeRouteProfitGrid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   gap: 0.55rem;
   min-width: 0;
 }
 
 .tradeRouteProfitRow {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 1rem;
+  width: 100%;
 }
 
 .tradeRouteProfitMetric {
@@ -1783,6 +1794,8 @@ button.terminalStatusPreview:focus-visible {
   flex-direction: column;
   gap: 0.28rem;
   min-width: 0;
+  align-items: flex-end;
+  text-align: right;
 }
 
 .tradeRouteProfitLabel {
@@ -1790,6 +1803,7 @@ button.terminalStatusPreview:focus-visible {
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--ghostnet-text-soft);
+  text-align: right;
 }
 
 .tradeRouteProfitValue {
@@ -1797,6 +1811,7 @@ button.terminalStatusPreview:focus-visible {
   font-weight: 600;
   color: var(--ghostnet-ink);
   white-space: nowrap;
+  text-align: right;
 }
 
 .tradeRouteProfitMeta {
@@ -1804,6 +1819,7 @@ button.terminalStatusPreview:focus-visible {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
+  justify-content: flex-end;
 }
 
 @media (max-width: 1440px) {


### PR DESCRIPTION
## Summary
- remove the faction standing chip from trade route rows and rely on the station icon tooltip and color
- scale station icon reputation colors based on faction reputation and tune the trade route table layout widths
- tighten commodity and profit column styling so station columns have more room and profit values align

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: Next.js SWC transform rejects the legacy `serverComponents` option in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a0d61e0083238ceea19cd5ee7b51