### PR TITLE
feat: add clipboard toast for stations

### DIFF
--- a/src/client/components/copy-on-click.js
+++ b/src/client/components/copy-on-click.js
@@ -1,16 +1,50 @@
-import { useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import notification from 'lib/notification'
 
-export default function CopyOnClick ({ children, prepend, append }) {
+export const COPY_MESSAGES = {
+  default: 'Value copied to clipboard',
+  station: 'Station name copied to clipboard',
+  system: 'System name copied to clipboard'
+}
+
+export default function CopyOnClick ({ children, prepend, append, copyMessage, copyMessageKey }) {
   const selectableText = useRef()
-  function copyText (e) {
-    try {
-      const text = selectableText.current.innerHTML
-      document.execCommand('copy')
-      navigator.clipboard.writeText(text)
-      notification(() => <p><span className='text-primary'>text copied</span><br/><span>{`"${text}"`}</span></p>)
-    } catch { /* don't care */ }
+
+  const resolveMessage = () => {
+    if (copyMessage) return copyMessage
+    if (copyMessageKey && COPY_MESSAGES[copyMessageKey]) return COPY_MESSAGES[copyMessageKey]
+    return COPY_MESSAGES.default
   }
+
+  const copyText = useCallback(() => {
+    try {
+      const text = selectableText.current?.textContent?.trim()
+      if (!text) return
+
+      if (navigator?.clipboard?.writeText) {
+        navigator.clipboard.writeText(text).catch(() => {})
+      } else {
+        const selection = window.getSelection()
+        const range = document.createRange()
+        range.selectNodeContents(selectableText.current)
+        selection.removeAllRanges()
+        selection.addRange(range)
+        try {
+          document.execCommand('copy')
+        } catch {}
+        selection.removeAllRanges()
+      }
+
+      notification(() => (
+        <p>
+          <span className='text-primary'>{resolveMessage()}</span>
+          <br />
+          <span className='text-no-transform'>{`"${text}"`}</span>
+        </p>
+      ))
+    } catch { /* don't care */ }
+  }, [copyMessage, copyMessageKey])
+
   return (
     <span className='selectable selectable-wrapper' onClick={copyText}>
       {prepend}

--- a/src/client/components/ghostnet/commodity-summary.js
+++ b/src/client/components/ghostnet/commodity-summary.js
@@ -5,6 +5,7 @@ import { StationIcon, DemandIndicator } from './station-summary'
 import Icons from '../../lib/icons'
 import { getCommodityIconConfig } from '../../lib/commodity-icons'
 import { sanitizeInaraText } from '../../lib/sanitize-inara-text'
+import CopyOnClick from '../copy-on-click'
 import {
   formatCredits,
   formatRelativeTime,
@@ -107,8 +108,14 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
     const destinationIconName = stationName ? stationIconFromType(stationType || '') : null
     const originIconName = summary.originStationName ? stationIconFromType(originType || '') : null
 
-    const originSubtexts = [originSystem, originType].filter(Boolean)
-    const destinationSubtexts = [systemName, stationType].filter(Boolean)
+    const originSubtexts = [
+      originSystem ? <CopyOnClick copyMessageKey='system'>{originSystem}</CopyOnClick> : null,
+      originType
+    ].filter(Boolean)
+    const destinationSubtexts = [
+      systemName ? <CopyOnClick copyMessageKey='system'>{systemName}</CopyOnClick> : null,
+      stationType
+    ].filter(Boolean)
     const commoditySubtexts = [
       commoditySymbol && commoditySymbol !== commodityName ? commoditySymbol : null,
       summaryPriceDisplay && summaryPriceDisplay !== '--' ? `@ ${summaryPriceDisplay}` : null
@@ -150,13 +157,13 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
           subtexts: [
             ...(Array.isArray(shipSourceSegment.subtexts) ? shipSourceSegment.subtexts : []),
             originName && originName !== shipSourceSegment.name ? `Docked: ${originName}` : null,
-            originSystem
+            originSystem ? <CopyOnClick copyMessageKey='system'>{originSystem}</CopyOnClick> : null
           ].filter(Boolean),
           metrics: buildMetrics(sourceMetrics)
         }
       : {
           icon: originIconName ? <StationIcon icon={originIconName} size={24} /> : null,
-          name: originName,
+          name: originName ? <CopyOnClick copyMessageKey='station'>{originName}</CopyOnClick> : originName,
           subtexts: originSubtexts,
           metrics: buildMetrics(sourceMetrics),
           ariaLabel: originName ? `Origin station ${originName}` : 'Local market origin'
@@ -164,7 +171,7 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
 
     const destinationSegment = {
       icon: destinationIconName ? <StationIcon icon={destinationIconName} size={24} /> : null,
-      name: stationName,
+      name: stationName ? <CopyOnClick copyMessageKey='station'>{stationName}</CopyOnClick> : stationName,
       subtexts: destinationSubtexts,
       metrics: buildMetrics(destinationMetrics),
       ariaLabel: `Destination station ${stationName}`

--- a/src/client/components/ghostnet/station-cell.js
+++ b/src/client/components/ghostnet/station-cell.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { sanitizeInaraText } from '../../lib/sanitize-inara-text'
+import CopyOnClick from '../copy-on-click'
 import StackedCell from './stacked-cell'
 import styles from './trade-route-cells.module.css'
 
@@ -30,11 +31,15 @@ function StationLeg ({ label, leg }) {
           className={styles.stationName}
           style={leg.color ? { color: leg.color } : undefined}
         >
-          {name}
+          <CopyOnClick copyMessageKey='station'>{name}</CopyOnClick>
         </span>
       </div>
       <div className={styles.stationMetaRow}>
-        {system ? <span className={styles.stationSystem}>{system}</span> : null}
+        {system ? (
+          <span className={styles.stationSystem}>
+            <CopyOnClick copyMessageKey='system'>{system}</CopyOnClick>
+          </span>
+        ) : null}
         {type ? <span className={styles.stationType}>{type}</span> : null}
         {distance ? <span className={styles.stationDistance}>{distance}</span> : null}
         {status

--- a/src/client/components/ghostnet/station-summary.js
+++ b/src/client/components/ghostnet/station-summary.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Icons from '../../lib/icons'
 import { sanitizeInaraText } from '../../lib/sanitize-inara-text'
+import CopyOnClick from '../copy-on-click'
 import styles from './station-summary.module.css'
 
 const DEMAND_ARROW_PATTERN = /[▲△▴▵▼▽▾▿↑↓]/g
@@ -111,8 +112,14 @@ export default function StationSummary ({
     <div className={styles.stationCell}>
       {resolvedIcon}
       <div className={styles.stationCellText}>
-        <div className={styles.stationName}>{normalizedName}</div>
-        {normalizedSystem ? <div className={styles.stationSystem}>{normalizedSystem}</div> : null}
+        <div className={styles.stationName}>
+          <CopyOnClick copyMessageKey='station'>{normalizedName}</CopyOnClick>
+        </div>
+        {normalizedSystem ? (
+          <div className={styles.stationSystem}>
+            <CopyOnClick copyMessageKey='system'>{normalizedSystem}</CopyOnClick>
+          </div>
+        ) : null}
         {hasMetaRow ? (
           <div className={styles.stationMetaRow}>
             {normalizedType ? <div className={styles.stationMeta}>{normalizedType}</div> : null}

--- a/src/client/components/ghostnet/transfer-context-summary.js
+++ b/src/client/components/ghostnet/transfer-context-summary.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import CopyOnClick from '../copy-on-click'
 import styles from './transfer-context-summary.module.css'
 
 const BAD_TEXT_PATTERN = /[\u25A0-\u25A3\u25A9\uFFFD]/g
@@ -14,6 +15,7 @@ function StationSegment ({ icon, name, color, subtexts, metrics, ariaLabel }) {
     return null
   }
 
+  const normalizedName = sanitizeText(name)
   const normalizedSubtexts = Array.isArray(subtexts)
     ? subtexts.map(entry => sanitizeText(entry)).filter(Boolean)
     : []
@@ -36,9 +38,11 @@ function StationSegment ({ icon, name, color, subtexts, metrics, ariaLabel }) {
   return (
     <div className={`${styles.segment} ${styles.stationSegment}`} aria-label={ariaLabel || undefined}>
       {icon ? <span className={styles.icon}>{icon}</span> : null}
-      {name ? (
+      {normalizedName ? (
         <span className={styles.primary} style={color ? { color } : undefined}>
-          {name}
+          {React.isValidElement(normalizedName)
+            ? normalizedName
+            : <CopyOnClick copyMessageKey='station'>{normalizedName}</CopyOnClick>}
         </span>
       ) : null}
 

--- a/src/client/components/panels/nav/navigation-inspector-panel.js
+++ b/src/client/components/panels/nav/navigation-inspector-panel.js
@@ -81,7 +81,7 @@ export default function NavigationInspectorPanel ({ systemObject, setSystemObjec
       <div className='inspector__contents scrollable'>
         <div className='navigation-panel__inspector-heading'>
           <i className={iconClass} />
-          <h2 className='text-info'><CopyOnClick>{systemObject.name}</CopyOnClick></h2>
+          <h2 className='text-info'><CopyOnClick copyMessageKey='system'>{systemObject.name}</CopyOnClick></h2>
           <h3 className='text-primary'>{systemObjectSubType}</h3>
         </div>
         <hr />

--- a/src/client/components/panels/nav/navigation-list-panel.js
+++ b/src/client/components/panels/nav/navigation-list-panel.js
@@ -29,7 +29,7 @@ export default function NavigationListPanel ({ system, systemObject, setSystemOb
             <tr>
               <th style={{ paddingTop: '.4rem' }} className='text-info'>
                 <i style={{ fontSize: '1.5rem', marginRight: '.25rem', position: 'relative', left: '.1rem', xtop: '-.1rem' }} className='float-left icarus-terminal-system-orbits' />
-                <CopyOnClick append=' system'>{system.name}</CopyOnClick>
+                <CopyOnClick append=' system' copyMessageKey='system'>{system.name}</CopyOnClick>
               </th>
               <th style={{ width: '1rem' }} className='hidden-small'>&nbsp;</th>
             </tr>

--- a/src/client/components/panels/nav/navigation-system-map-panel.js
+++ b/src/client/components/panels/nav/navigation-system-map-panel.js
@@ -60,7 +60,7 @@ export default function NavigationSystemMapPanel ({ system, systemObject, setSys
             <div className='system-map__info fx-fade-in text-uppercase'>
               <span className='text-info'>
                 <i className='icarus-terminal-system-orbits' style={{ fontSize: '1.5rem', float: 'left', position: 'relative', left: '-.15rem' }} />
-                <CopyOnClick append=' system'>{system?.name}</CopyOnClick>
+                <CopyOnClick append=' system' copyMessageKey='system'>{system?.name}</CopyOnClick>
               </span>
               <div className='system-map__info--system-facilities'>
                 <span className='text-primary text-muted'>Unknown System</span>
@@ -183,7 +183,7 @@ export default function NavigationSystemMapPanel ({ system, systemObject, setSys
           <div className='system-map__info fx-fade-in text-uppercase'>
             <span className='text-info'>
               <i className='icarus-terminal-system-orbits' style={{ fontSize: '1.5rem', float: 'left', position: 'relative', left: '-.15rem' }} />
-              <CopyOnClick append=' system'>{system.name}</CopyOnClick>
+              <CopyOnClick append=' system' copyMessageKey='system'>{system.name}</CopyOnClick>
             </span>
             <span className='text-center-vertical' style={{pointerEvents: 'none'}}>
              {system.detail && system.detail.bodies && system.detail.bodies.length > 0 &&

--- a/src/client/pages/eng/blueprints.js
+++ b/src/client/pages/eng/blueprints.js
@@ -294,7 +294,7 @@ export default function EngineeringMaterialsPage () {
                   </td>
                   <td className='text-right'>
                     <span className='text-right'>
-                      <CopyOnClick>{selectedBlueprint?.engineers[engineer]?.system}</CopyOnClick>
+                      <CopyOnClick copyMessageKey='system'>{selectedBlueprint?.engineers[engineer]?.system}</CopyOnClick>
                     </span>
                     {(currentSystem?.position && selectedBlueprint?.engineers[engineer]?.location) &&
                       <span className='text-muted text-no-transform'>

--- a/src/client/pages/eng/engineers.js
+++ b/src/client/pages/eng/engineers.js
@@ -127,7 +127,7 @@ function ListEngineers ({ engineers, currentSystem }) {
               </td>
               <td className='text-right'>
                 <span className='text-right'>
-                  <CopyOnClick>{engineer.system.name}</CopyOnClick>
+                  <CopyOnClick copyMessageKey='system'>{engineer.system.name}</CopyOnClick>
                 </span>
                 {currentSystem?.position &&
                   <span className='text-muted text-no-transform'>

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -6,6 +6,7 @@ import Icons from '../lib/icons'
 import TransferContextSummary from '../components/ghostnet/transfer-context-summary'
 import StationSummary, { StationIcon, DemandIndicator } from '../components/ghostnet/station-summary'
 import CommoditySummary, { CommodityIcon } from '../components/ghostnet/commodity-summary'
+import CopyOnClick from '../components/copy-on-click'
 import PirateRadioPanel from '../components/ghostnet/pirate-radio'
 import NavigationInspectorPanel from '../components/panels/nav/navigation-inspector-panel'
 import animateTableEffect from '../lib/animate-table-effect'
@@ -2111,7 +2112,9 @@ function MissionsPanel () {
                             : (
                               <i className='icon system-object-icon icarus-terminal-location' style={{ marginRight: '.5rem', color: 'var(--ghostnet-subdued)' }} />
                               )}
-                          {mission.system || '--'}
+                          {mission.system
+                            ? <CopyOnClick copyMessageKey='system'>{mission.system}</CopyOnClick>
+                            : '--'}
                         </div>
                       </td>
                       <td className={`${styles.tableCellTop} hidden-small text-right`}>{distanceDisplay || '--'}</td>
@@ -2176,7 +2179,7 @@ function CargoHoldPanel () {
     const subtexts = [
       shipIdent ? `ID ${shipIdent}` : null,
       shipType && shipType !== shipName ? shipType : null,
-      systemName
+      systemName ? <CopyOnClick copyMessageKey='system'>{systemName}</CopyOnClick> : null
     ].filter(Boolean)
     return {
       icon: <StationIcon icon='ship' size={24} />,
@@ -2728,9 +2731,21 @@ function CargoHoldPanel () {
       : 'History'
     const stationName = sanitizeInaraText(entryData.stationName) || entryData.stationName || ''
     const systemName = sanitizeInaraText(entryData.systemName) || entryData.systemName || ''
-    const stationLine = stationName
-      ? `${stationName}${systemName ? ` · ${systemName}` : ''}`
-      : ''
+    const stationLineContent = stationName
+      ? (
+          <>
+            <CopyOnClick copyMessageKey='station'>{stationName}</CopyOnClick>
+            {systemName
+              ? (
+                <>
+                  {' · '}
+                  <CopyOnClick copyMessageKey='system'>{systemName}</CopyOnClick>
+                </>
+                )
+              : null}
+          </>
+        )
+      : null
     const distanceDisplay = typeof entryData.distanceLs === 'number' && !Number.isNaN(entryData.distanceLs)
       ? formatStationDistance(entryData.distanceLs)
       : ''
@@ -2747,7 +2762,7 @@ function CargoHoldPanel () {
           <span className={styles.tableEntrySource}>{resolvedSource}</span>
         </div>
         {label ? <div className={styles.tableEntryLabel}>{label}</div> : null}
-        {stationLine ? <div className={styles.tableEntryMeta}>{stationLine}</div> : null}
+        {stationLineContent ? <div className={styles.tableEntryMeta}>{stationLineContent}</div> : null}
         {distanceDisplay ? <div className={styles.tableEntryFootnote}>Distance: {distanceDisplay}</div> : null}
         {timestampDisplay ? <div className={styles.tableEntryFootnote}>As of {timestampDisplay}</div> : null}
       </div>
@@ -3339,8 +3354,13 @@ function CargoHoldPanel () {
                                 <div className={styles.tableContextIndicator}>
                                   <span className={styles.tableContextLabel}>Station Context</span>
                                   <span className={styles.tableContextValue}>
-                                    {contextSummary.stationName}
-                                    {contextSummary.systemName ? ` · ${contextSummary.systemName}` : ''}
+                                    <CopyOnClick copyMessageKey='station'>{contextSummary.stationName}</CopyOnClick>
+                                    {contextSummary.systemName ? (
+                                      <>
+                                        {' · '}
+                                        <CopyOnClick copyMessageKey='system'>{contextSummary.systemName}</CopyOnClick>
+                                      </>
+                                    ) : null}
                                   </span>
                                   {(contextSystemDistance || contextDistance) && (
                                     <span className={styles.tableContextFootnote}>
@@ -3369,8 +3389,13 @@ function CargoHoldPanel () {
                           <div>{ghostnetPriceDisplay}</div>
                           {ghostnetStation && (
                             <div className={styles.tableSubtext}>
-                              {ghostnetStation}
-                              {ghostnetSystem ? ` · ${ghostnetSystem}` : ''}
+                              <CopyOnClick copyMessageKey='station'>{ghostnetStation}</CopyOnClick>
+                              {ghostnetSystem ? (
+                                <>
+                                  {' · '}
+                                  <CopyOnClick copyMessageKey='system'>{ghostnetSystem}</CopyOnClick>
+                                </>
+                              ) : null}
                             </div>
                           )}
                           {ghostnetDemand && (
@@ -4155,8 +4180,16 @@ function TradeRoutesPanel () {
                         </span>
                       )}
                       <div className={styles.tradeRouteContextValueText}>
-                        <span className={styles.tradeRouteContextPrimary}>{routeContext.origin.station || '--'}</span>
-                        <span className={styles.tradeRouteContextMeta}>{routeContext.origin.system || '--'}</span>
+                        <span className={styles.tradeRouteContextPrimary}>
+                          {routeContext.origin.station
+                            ? <CopyOnClick copyMessageKey='station'>{routeContext.origin.station}</CopyOnClick>
+                            : '--'}
+                        </span>
+                        <span className={styles.tradeRouteContextMeta}>
+                          {routeContext.origin.system
+                            ? <CopyOnClick copyMessageKey='system'>{routeContext.origin.system}</CopyOnClick>
+                            : '--'}
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -4180,8 +4213,16 @@ function TradeRoutesPanel () {
                         </span>
                       )}
                       <div className={styles.tradeRouteContextValueText}>
-                        <span className={styles.tradeRouteContextPrimary}>{routeContext.destination.station || '--'}</span>
-                        <span className={styles.tradeRouteContextMeta}>{routeContext.destination.system || '--'}</span>
+                        <span className={styles.tradeRouteContextPrimary}>
+                          {routeContext.destination.station
+                            ? <CopyOnClick copyMessageKey='station'>{routeContext.destination.station}</CopyOnClick>
+                            : '--'}
+                        </span>
+                        <span className={styles.tradeRouteContextMeta}>
+                          {routeContext.destination.system
+                            ? <CopyOnClick copyMessageKey='system'>{routeContext.destination.system}</CopyOnClick>
+                            : '--'}
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -4561,7 +4602,11 @@ function PristineMiningPanel () {
                               : (
                                 <i className='icon system-object-icon icarus-terminal-location' style={{ marginRight: '.5rem', color: 'var(--ghostnet-subdued)' }} />
                                 )}
-                            <span className='ghostnet-accent'>{location.system || '--'}</span>
+                            <span className='ghostnet-accent'>
+                              {location.system
+                                ? <CopyOnClick copyMessageKey='system'>{location.system}</CopyOnClick>
+                                : '--'}
+                            </span>
                           </div>
                         </td>
                         <td className={`hidden-small text-right text-no-wrap ${styles.tableCellTop} ${styles.tableCellTight}`}>{bodyDistanceDisplay || '--'}</td>

--- a/src/client/pages/nav/route.js
+++ b/src/client/pages/nav/route.js
@@ -82,7 +82,7 @@ export default function NavListPage () {
                       Location
                     </h3>
                     <h2 className='navigation-panel__route-heading text-info'>
-                      <CopyOnClick>{navRoute.currentSystem?.name}</CopyOnClick>
+                      <CopyOnClick copyMessageKey='system'>{navRoute.currentSystem?.name}</CopyOnClick>
                     </h2>
                   </>}
               </td>
@@ -95,7 +95,7 @@ export default function NavListPage () {
                     </h3>
                     <h2 className='navigation-panel__route-heading text-info text-right'>
                       {navRoute?.destination?.distance > 0
-                        ? <CopyOnClick>{navRoute?.destination?.system}</CopyOnClick>
+                        ? <CopyOnClick copyMessageKey='system'>{navRoute?.destination?.system}</CopyOnClick>
                         : <span className='text-muted'>—</span>}
                     </h2>
                   </>}


### PR DESCRIPTION
## Summary
- wrap station and system name renderers with the existing CopyOnClick helper so clicking copies the label
- update GhostNet commodity, station, and route panels to emit copyable station/system names throughout
- ensure mission and pristine mining tables also expose copy-to-clipboard behavior for system values
- surface a consistent toast message when copying station or system names so commanders get explicit feedback

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: next-swc TransformOptions `serverComponents` field error)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d9d61c548323bd7b4f8f782d1a34