### PR TITLE
Keep trade route station icons aligned with stacked metadata

### DIFF
--- a/src/client/components/ghostnet/station-summary.js
+++ b/src/client/components/ghostnet/station-summary.js
@@ -31,7 +31,7 @@ StationIcon.defaultProps = {
 
 StationIcon.propTypes = {
   icon: PropTypes.string,
-  size: PropTypes.number,
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   color: PropTypes.string
 }
 

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -510,11 +510,12 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
               title={originStandingDisplay.title || undefined}
             >
               {originIconName
-                ? <StationIcon icon={originIconName} color={originStandingDisplay.iconColor} size={28} />
+                ? <StationIcon icon={originIconName} color={originStandingDisplay.iconColor} size='100%' />
                 : null}
             </span>
             <div className={styles.tradeRouteStationContent}>
               <span className={styles.tradeRouteStationName} title={originStationDisplay || undefined}>{renderValue(originStationDisplay)}</span>
+              <span className={styles.tradeRouteStationSystem} title={originSystemName || undefined}>{renderValue(originSystemName)}</span>
               <div className={styles.tradeRouteStationChips}>
                 {renderMetricChip({
                   value: originStationDistanceDisplay,
@@ -528,9 +529,6 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                 })}
               </div>
             </div>
-          </div>
-          <div className={`${styles.tradeRouteStationRow} ${styles.tradeRouteStationRowSecondary}`}>
-            <span className={styles.tradeRouteStationSystem} title={originSystemName || undefined}>{renderValue(originSystemName)}</span>
           </div>
         </div>
       </td>
@@ -572,11 +570,12 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
               title={destinationStandingDisplay.title || undefined}
             >
               {destinationIconName
-                ? <StationIcon icon={destinationIconName} color={destinationStandingDisplay.iconColor} size={28} />
+                ? <StationIcon icon={destinationIconName} color={destinationStandingDisplay.iconColor} size='100%' />
                 : null}
             </span>
             <div className={styles.tradeRouteStationContent}>
               <span className={styles.tradeRouteStationName} title={destinationStationDisplay || undefined}>{renderValue(destinationStationDisplay)}</span>
+              <span className={styles.tradeRouteStationSystem} title={destinationSystemName || undefined}>{renderValue(destinationSystemName)}</span>
               <div className={styles.tradeRouteStationChips}>
                 {renderMetricChip({
                   value: destinationStationDistanceDisplay,
@@ -590,9 +589,6 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                 })}
               </div>
             </div>
-          </div>
-          <div className={`${styles.tradeRouteStationRow} ${styles.tradeRouteStationRowSecondary}`}>
-            <span className={styles.tradeRouteStationSystem} title={destinationSystemName || undefined}>{renderValue(destinationSystemName)}</span>
           </div>
         </div>
       </td>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1682,30 +1682,39 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteStationRow {
   display: grid;
-  grid-template-columns: minmax(2.4rem, auto) minmax(0, 1fr);
-  align-items: start;
+  grid-template-columns: minmax(2.75rem, max-content) minmax(0, 1fr);
+  align-items: stretch;
   gap: 0.75rem;
   min-width: 0;
 }
 
-.tradeRouteStationRowSecondary {
-  grid-template-columns: minmax(0, 1fr);
-  align-items: center;
-}
-
 .tradeRouteStationIcon {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
-  width: 2.4rem;
-  height: 2.4rem;
+  align-self: stretch;
+  padding: 0.15rem;
+  min-width: 2.6rem;
+  min-height: 2.6rem;
+  max-width: 3.2rem;
+  height: 100%;
+  max-height: 100%;
   color: var(--ghostnet-accent);
+}
+
+.tradeRouteStationIcon :global(svg) {
+  display: block;
+  height: 100%;
+  width: auto;
+  max-height: 100%;
+  max-width: 100%;
 }
 
 .tradeRouteStationContent {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  align-items: flex-start;
+  gap: 0.3rem;
   min-width: 0;
 }
 
@@ -1715,6 +1724,7 @@ button.terminalStatusPreview:focus-visible {
   color: var(--ghostnet-ink);
   white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .tradeRouteStationSystem {
@@ -1722,16 +1732,13 @@ button.terminalStatusPreview:focus-visible {
   color: var(--ghostnet-muted);
   white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .tradeRouteStationChips {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
-}
-
-.tradeRouteStationRowSecondary .tradeRouteStationChips {
-  justify-content: flex-end;
 }
 
 .tradeRouteCommodityGrid {


### PR DESCRIPTION
## Summary
- tighten the trade route station icon column so the glyph stretches with its three-line stack without exceeding the row height
- ensure stacked station name and system text truncate cleanly when space is limited

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js SWC reports "unknown field `serverComponents`")*

------
https://chatgpt.com/codex/tasks/task_e_68e2e78151f48323bd369138f4ada9d0