### PR TITLE
Color GhostNet station distances by ship jump range

### DIFF
--- a/src/client/components/ghostnet/commodity-summary.js
+++ b/src/client/components/ghostnet/commodity-summary.js
@@ -13,6 +13,7 @@ import {
   formatSystemDistance
 } from '../../lib/ghostnet-formatters'
 import { stationIconFromType } from '../../lib/station-icons'
+import getDistanceSeverityColor from '../../lib/distance-colors'
 
 export function CommodityIcon ({ category, size = 26 }) {
   const config = getCommodityIconConfig(category)
@@ -55,7 +56,7 @@ function buildMetrics (entries) {
     .filter(Boolean)
 }
 
-export default function CommoditySummary ({ summary, shipSourceSegment, className, valueIcon }) {
+export default function CommoditySummary ({ summary, shipSourceSegment, className, valueIcon, shipJumpRange }) {
   const memoized = useMemo(() => {
     if (!summary) return null
 
@@ -72,6 +73,7 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
       : '--'
 
     const summarySystemDistance = formatSystemDistance(summary.distanceLy, summary.distanceLyText)
+    const summaryDistanceColor = getDistanceSeverityColor(summary.distanceLy, shipJumpRange)
     const summaryStationDistance = formatStationDistance(summary.distanceLs, summary.distanceLsText)
     const summaryUpdated = summary.updatedAt
       ? formatRelativeTime(summary.updatedAt)
@@ -148,7 +150,8 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
     const distanceSegment = {
       label: 'Distance',
       value: summarySystemDistance || '',
-      secondary: summaryStationDistance || ''
+      secondary: summaryStationDistance || '',
+      valueColor: summaryDistanceColor || undefined
     }
 
     const sourceSegment = shipSourceSegment
@@ -196,7 +199,7 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
         secondary: valueSecondary
       }
     }
-  }, [summary, shipSourceSegment, valueIcon])
+  }, [summary, shipSourceSegment, valueIcon, shipJumpRange])
 
   if (!memoized) return null
 
@@ -216,7 +219,8 @@ CommoditySummary.defaultProps = {
   summary: null,
   shipSourceSegment: null,
   className: '',
-  valueIcon: null
+  valueIcon: null,
+  shipJumpRange: null
 }
 
 CommoditySummary.propTypes = {
@@ -235,5 +239,6 @@ CommoditySummary.propTypes = {
     ariaLabel: PropTypes.string
   }),
   className: PropTypes.string,
-  valueIcon: PropTypes.node
+  valueIcon: PropTypes.node,
+  shipJumpRange: PropTypes.number
 }

--- a/src/client/components/ghostnet/transfer-context-summary.js
+++ b/src/client/components/ghostnet/transfer-context-summary.js
@@ -152,8 +152,10 @@ CommoditySegment.propTypes = {
   ariaLabel: PropTypes.string
 }
 
-function DistanceSegment ({ label, value, secondary }) {
+function DistanceSegment ({ label, value, secondary, valueColor }) {
   if (!label && !value && !secondary) return null
+
+  const valueStyle = valueColor ? { color: valueColor } : undefined
 
   return (
     <div className={`${styles.segment} ${styles.distanceSegment}`}>
@@ -161,8 +163,14 @@ function DistanceSegment ({ label, value, secondary }) {
         {String.fromCharCode(0x279E)}
       </span>
       {label ? <span className={`${styles.metricLabel} ${styles.optionalMedium}`}>{sanitizeText(label)}</span> : null}
-      {value ? <span className={styles.distanceValue}>{sanitizeText(value)}</span> : null}
-      {secondary ? <span className={`${styles.distanceSecondary} ${styles.optionalWide}`}>{sanitizeText(secondary)}</span> : null}
+      {value ? <span className={styles.distanceValue} style={valueStyle}>{sanitizeText(value)}</span> : null}
+      {secondary
+        ? (
+            <span className={`${styles.distanceSecondary} ${styles.optionalWide}`} style={valueStyle}>
+              {sanitizeText(secondary)}
+            </span>
+          )
+        : null}
     </div>
   )
 }
@@ -170,13 +178,15 @@ function DistanceSegment ({ label, value, secondary }) {
 DistanceSegment.defaultProps = {
   label: '',
   value: '',
-  secondary: ''
+  secondary: '',
+  valueColor: ''
 }
 
 DistanceSegment.propTypes = {
   label: PropTypes.string,
   value: PropTypes.string,
-  secondary: PropTypes.string
+  secondary: PropTypes.string,
+  valueColor: PropTypes.string
 }
 
 function ValueSegment ({ icon, label, value, secondary }) {

--- a/src/client/lib/distance-colors.js
+++ b/src/client/lib/distance-colors.js
@@ -1,0 +1,27 @@
+export function getDistanceSeverityColor (distanceLy, jumpRangeLy, options = {}) {
+  const maxMultiplier = typeof options.maxMultiplier === 'number' && options.maxMultiplier > 1
+    ? options.maxMultiplier
+    : 5
+
+  if (!Number.isFinite(distanceLy) || !Number.isFinite(jumpRangeLy) || jumpRangeLy <= 0) {
+    return null
+  }
+
+  if (distanceLy <= 0 || distanceLy <= jumpRangeLy) {
+    return 'var(--ghostnet-color-success)'
+  }
+
+  const ratio = Math.max(1, distanceLy / jumpRangeLy)
+  const cappedRatio = Math.min(ratio, maxMultiplier)
+  const normalized = (cappedRatio - 1) / (maxMultiplier - 1)
+  const warningWeight = Math.min(100, Math.max(0, Math.round(normalized * 100)))
+  const successWeight = 100 - warningWeight
+
+  if (warningWeight === 100) {
+    return 'var(--ghostnet-color-warning)'
+  }
+
+  return `color-mix(in srgb, var(--ghostnet-color-success) ${successWeight}%, var(--ghostnet-color-warning) ${warningWeight}%)`
+}
+
+export default getDistanceSeverityColor

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -13,6 +13,7 @@ import animateTableEffect from '../lib/animate-table-effect'
 import { useSocket, sendEvent, eventListener } from '../lib/socket'
 import { getShipLandingPadSize } from '../lib/ship-pad-sizes'
 import { formatCredits, formatRelativeTime, formatStationDistance, formatSystemDistance } from '../lib/ghostnet-formatters'
+import getDistanceSeverityColor from '../lib/distance-colors'
 import { sanitizeInaraText } from '../lib/sanitize-inara-text'
 import { stationIconFromType, getStationIconName } from '../lib/station-icons'
 import { createMockCargoManifest, createMockCommodityValuations, generateMockTradeRoutes, NON_COMMODITY_KEYS, normaliseCommodityKey } from '../lib/ghostnet-mock-data'
@@ -390,7 +391,8 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   onSelect,
   onKeyDown,
   factionStandings,
-  isSelected = false
+  isSelected = false,
+  shipJumpRange = null
 }) {
   const originLocal = route?.origin?.local
   const destinationLocal = route?.destination?.local
@@ -477,9 +479,12 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
 
   const originStationDistanceVariant = getStationDistanceVariant(originStationDistance.value)
   const destinationStationDistanceVariant = getStationDistanceVariant(destinationStationDistance.value)
-  const originSystemDistanceVariant = getSystemDistanceVariant(originSystemDistance.value)
-  const destinationSystemDistanceVariant = getSystemDistanceVariant(destinationSystemDistance.value)
-  const routeDistanceVariant = getSystemDistanceVariant(routeDistance.value)
+  const originSystemDistanceVariant = getSystemDistanceVariant(originSystemDistance.value, shipJumpRange)
+  const destinationSystemDistanceVariant = getSystemDistanceVariant(destinationSystemDistance.value, shipJumpRange)
+  const routeDistanceVariant = getSystemDistanceVariant(routeDistance.value, shipJumpRange)
+  const originSystemDistanceColor = getDistanceSeverityColor(originSystemDistance.value, shipJumpRange)
+  const destinationSystemDistanceColor = getDistanceSeverityColor(destinationSystemDistance.value, shipJumpRange)
+  const routeDistanceColor = getDistanceSeverityColor(routeDistance.value, shipJumpRange)
 
   const handleClick = () => onSelect(route)
   const handleKeyDown = event => onKeyDown(event, route)
@@ -525,7 +530,8 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                 {renderMetricChip({
                   value: originSystemDistanceDisplay,
                   variant: originSystemDistanceVariant,
-                  title: 'Distance to system'
+                  title: 'Distance to system',
+                  color: originSystemDistanceColor || undefined
                 })}
               </div>
             </div>
@@ -587,7 +593,8 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                 {renderMetricChip({
                   value: destinationSystemDistanceDisplay,
                   variant: destinationSystemDistanceVariant,
-                  title: 'Distance to system'
+                  title: 'Distance to system',
+                  color: destinationSystemDistanceColor || undefined
                 })}
               </div>
             </div>
@@ -623,7 +630,8 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
             {renderMetricChip({
               value: routeDistance.display,
               variant: routeDistanceVariant,
-              title: 'Total route distance'
+              title: 'Total route distance',
+              color: routeDistanceColor || undefined
             })}
             {renderMetricChip({
               value: updatedDisplay,
@@ -1499,10 +1507,17 @@ function getStationDistanceVariant (value) {
   return 'warning'
 }
 
-function getSystemDistanceVariant (value) {
+function getSystemDistanceVariant (value, jumpRange) {
   if (typeof value !== 'number' || Number.isNaN(value)) return 'neutral'
-  if (value <= 15) return 'success'
-  if (value <= 35) return 'caution'
+  if (typeof jumpRange !== 'number' || Number.isNaN(jumpRange) || jumpRange <= 0) {
+    if (value <= 15) return 'success'
+    if (value <= 35) return 'caution'
+    return 'warning'
+  }
+
+  const ratio = value / jumpRange
+  if (ratio <= 1) return 'success'
+  if (ratio <= 2) return 'caution'
   return 'warning'
 }
 
@@ -3012,10 +3027,12 @@ function CargoHoldPanel () {
             detail.commoditySymbol && detail.commoditySymbol !== detail.commodityName ? detail.commoditySymbol : null,
             profitPerUnitDisplay && profitPerUnitDisplay !== '--' ? `Profit/t ${profitPerUnitDisplay}` : null
           ].filter(Boolean)
+          const distanceColor = getDistanceSeverityColor(resolvedListing?.distanceLy ?? null, ship?.maxJumpRange ?? null)
           const distanceSegment = {
             label: 'Distance',
             value: selectedSystemDistance || '',
-            secondary: selectedStationDistance || ''
+            secondary: selectedStationDistance || '',
+            valueColor: distanceColor || undefined
           }
           const valueSecondaryParts = []
           if (profitPerUnitDisplay && profitPerUnitDisplay !== '--') valueSecondaryParts.push(`Per t ${profitPerUnitDisplay}`)
@@ -3149,6 +3166,7 @@ function CargoHoldPanel () {
                             const isSelected = listing.__id === defaultSelectedId
                             const stationIcon = stationIconFromType(listing.stationType || '')
                             const systemDistanceDisplay = formatSystemDistance(listing.distanceLy, listing.distanceLyText)
+                            const systemDistanceColor = getDistanceSeverityColor(listing.distanceLy ?? null, ship?.maxJumpRange ?? null)
                             const stationDistanceDisplay = formatStationDistance(listing.distanceLs, listing.distanceLsText)
                             const demandDisplay = sanitizeInaraText(listing.demandText) || (typeof listing.demand === 'number' ? listing.demand.toLocaleString() : '')
                             const updatedDisplay = listing.updatedAt
@@ -3185,7 +3203,15 @@ function CargoHoldPanel () {
                                     isSelected={isSelected}
                                   />
                                 </td>
-                                <td className={`${styles.tableCellTop} ${styles.tableCellWrap}`}>{systemDistanceDisplay || '--'}</td>
+                                <td className={`${styles.tableCellTop} ${styles.tableCellWrap}`}>
+                                  {systemDistanceDisplay
+                                    ? (
+                                      <span style={systemDistanceColor ? { color: systemDistanceColor } : undefined}>
+                                        {systemDistanceDisplay}
+                                      </span>
+                                      )
+                                    : '--'}
+                                </td>
                                 <td className={`${styles.tableCellTop} ${styles.tableCellWrap}`}>{stationDistanceDisplay || '--'}</td>
                                 <td className={`${styles.tableCellTop} ${styles.tableCellWrap}`}>
                                   {((listing.demandText || demandDisplay) && (listing.demandText || demandDisplay).toString().trim())
@@ -3226,6 +3252,7 @@ function CargoHoldPanel () {
                     shipSourceSegment={shipSourceSegment}
                     className={styles.transferSummaryBar}
                     valueIcon={<CreditsIcon size={22} />}
+                    shipJumpRange={ship?.maxJumpRange ?? null}
                   />
                 ) : null}
 
@@ -3327,6 +3354,9 @@ function CargoHoldPanel () {
                     const contextSummary = isContextRow ? commodityContext : null
                     const contextDistance = contextSummary ? formatStationDistance(contextSummary.distanceLs, contextSummary.distanceLsText) : ''
                     const contextSystemDistance = contextSummary ? formatSystemDistance(contextSummary.distanceLy, contextSummary.distanceLyText) : ''
+                    const contextSystemDistanceColor = contextSummary
+                      ? getDistanceSeverityColor(contextSummary.distanceLy ?? null, ship?.maxJumpRange ?? null)
+                      : null
                     const rowClassNames = [styles.tableRowInteractive]
                     if (isContextRow) rowClassNames.push(styles.tableRowContext)
 
@@ -3378,7 +3408,15 @@ function CargoHoldPanel () {
                                   </span>
                                   {(contextSystemDistance || contextDistance) && (
                                     <span className={styles.tableContextFootnote}>
-                                      {[contextSystemDistance, contextDistance].filter(Boolean).join(' / ')}
+                                      {contextSystemDistance
+                                        ? (
+                                          <span style={contextSystemDistanceColor ? { color: contextSystemDistanceColor } : undefined}>
+                                            {contextSystemDistance}
+                                          </span>
+                                          )
+                                        : null}
+                                      {contextSystemDistance && contextDistance ? ' / ' : null}
+                                      {contextDistance || null}
                                     </span>
                                   )}
                                 </div>
@@ -4142,6 +4180,7 @@ function TradeRoutesPanel () {
               onKeyDown={handleRouteKeyDown}
               factionStandings={factionStandings}
               isSelected={selectedRoute === route}
+              shipJumpRange={shipStatus?.maxJumpRange ?? null}
             />
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- add a distance severity helper to map jump range multiples to GhostNet palette colors
- color GhostNet distance displays in summaries, listings, and trade route chips using the active ship's jump range

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js SWC transform rejects `serverComponents` option in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ea58d1248323a5d34735ea477362