### PR TITLE
Fix trade route distance ordering and station column sizing

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -521,15 +521,15 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
               <span className={styles.tradeRouteStationSystem} title={originSystemName || undefined}>{renderValue(originSystemName)}</span>
               <div className={styles.tradeRouteStationChips}>
                 {renderMetricChip({
-                  value: originStationDistanceDisplay,
-                  variant: originStationDistanceVariant,
-                  title: 'Distance to station'
-                })}
-                {renderMetricChip({
                   value: originSystemDistanceDisplay,
                   variant: originSystemDistanceVariant,
                   title: 'Distance to system',
                   color: originSystemDistanceColor || undefined
+                })}
+                {renderMetricChip({
+                  value: originStationDistanceDisplay,
+                  variant: originStationDistanceVariant,
+                  title: 'Distance to station'
                 })}
               </div>
             </div>
@@ -582,15 +582,15 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
               <span className={styles.tradeRouteStationSystem} title={destinationSystemName || undefined}>{renderValue(destinationSystemName)}</span>
               <div className={styles.tradeRouteStationChips}>
                 {renderMetricChip({
-                  value: destinationStationDistanceDisplay,
-                  variant: destinationStationDistanceVariant,
-                  title: 'Distance to station'
-                })}
-                {renderMetricChip({
                   value: destinationSystemDistanceDisplay,
                   variant: destinationSystemDistanceVariant,
                   title: 'Distance to system',
                   color: destinationSystemDistanceColor || undefined
+                })}
+                {renderMetricChip({
+                  value: destinationStationDistanceDisplay,
+                  variant: destinationStationDistanceVariant,
+                  title: 'Distance to station'
                 })}
               </div>
             </div>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1445,10 +1445,10 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRoutesTable {
   --trade-route-caret-column-width: 2.75rem;
-  --trade-route-station-column-width: 18.5rem;
+  --trade-route-station-column-width: 19.5rem;
   --trade-route-profit-column-width: 15rem;
   --trade-route-commodity-min-width: 18rem;
-  min-width: 980px;
+  min-width: 1080px;
   width: 100%;
   border-collapse: separate;
   border-spacing: 0;
@@ -1491,21 +1491,21 @@ button.terminalStatusPreview:focus-visible {
 
 @media (max-width: 1680px) {
   .tradeRoutesTable {
-    --trade-route-station-column-width: 17.25rem;
+    --trade-route-station-column-width: 18.5rem;
     --trade-route-profit-column-width: 14.25rem;
   }
 }
 
 @media (max-width: 1480px) {
   .tradeRoutesTable {
-    --trade-route-station-column-width: 16rem;
+    --trade-route-station-column-width: 17.5rem;
     --trade-route-profit-column-width: 13.5rem;
   }
 }
 
 @media (max-width: 1320px) {
   .tradeRoutesTable {
-    --trade-route-station-column-width: 15rem;
+    --trade-route-station-column-width: 16.5rem;
     --trade-route-profit-column-width: 12.75rem;
     --trade-route-commodity-min-width: 16.5rem;
   }
@@ -1513,7 +1513,7 @@ button.terminalStatusPreview:focus-visible {
 
 @media (max-width: 1180px) {
   .tradeRoutesTable {
-    --trade-route-station-column-width: 14rem;
+    --trade-route-station-column-width: 15.5rem;
     --trade-route-profit-column-width: 12rem;
     --trade-route-commodity-min-width: 15.5rem;
   }
@@ -1684,7 +1684,7 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteStationRow {
   display: grid;
-  grid-template-columns: minmax(2.75rem, max-content) minmax(0, 1fr);
+  grid-template-columns: minmax(2.75rem, max-content) minmax(calc(var(--trade-route-station-column-width, 18.5rem) - 3.25rem), 1fr);
   align-items: stretch;
   gap: 0.75rem;
   min-width: 0;
@@ -1741,6 +1741,7 @@ button.terminalStatusPreview:focus-visible {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
+  width: 100%;
 }
 
 .tradeRouteCommodityGrid {


### PR DESCRIPTION
## Summary
- ensure trade route rows render system distance ahead of station distance chips
- enlarge the Station A/B columns and chip container so distance metrics fit beneath the station details

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js SWC unknown field `serverComponents`)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f35d55b08323a8ece44efa3103af