### PR TITLE
Flatten trade route demand flow styling

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -433,8 +433,10 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   const returnCommodityDisplay = returnCommodity === '--' ? '' : returnCommodity
   const outboundPriceDisplay = resolvePriceDisplay(outboundInfo.buy, 'Buy')
   const returnPriceDisplay = resolvePriceDisplay(returnInfo.buy, 'Buy')
-  const outboundDemandDisplay = buildDemandDisplay(outboundInfo.sell, 'up')
-  const returnDemandDisplay = buildDemandDisplay(returnInfo.sell, 'up')
+  const outboundDemandState = resolveDemandFlowState(outboundInfo.sell)
+  const returnDemandState = resolveDemandFlowState(returnInfo.sell)
+  const outboundFlowClass = getDemandFlowClass(outboundDemandState)
+  const returnFlowClass = getDemandFlowClass(returnDemandState)
 
   const profitPerTon = formatCredits(route?.summary?.profitPerUnit ?? route?.profitPerUnit, route?.summary?.profitPerUnitText || route?.profitPerUnitText)
   const profitPerTrip = formatCredits(route?.summary?.profitPerTrip, route?.summary?.profitPerTripText)
@@ -538,8 +540,14 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
       </td>
       <td className={`${styles.tableCellTop} ${styles.tradeRoutesItemCell}`}>
         <div className={styles.tradeRouteCommodityGrid}>
-          <div className={`${styles.tradeRouteCommodityRow} ${styles.tradeRouteCommodityRowOutbound}`}>
+          <div className={`${styles.tradeRouteCommodityRow} ${styles.tradeRouteCommodityRowOutbound} ${outboundFlowClass}`}>
             <span className={styles.visuallyHidden}>Outbound to {destinationStationAria}</span>
+            {outboundDemandState ? (
+              <span className={styles.visuallyHidden}>
+                {outboundDemandState.label}
+                {outboundDemandState.text ? ` — ${outboundDemandState.text}` : ''}
+              </span>
+            ) : null}
             <span className={styles.tradeRouteCommodityIcon}>
               <CommodityIcon category={outboundInfo.buy?.category || outboundInfo.sell?.category || ''} size={24} />
             </span>
@@ -547,21 +555,21 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
             <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteHideMedium}`}>
               {renderValue(outboundPriceDisplay)}
             </span>
-            <span className={`${styles.tradeRouteCommodityDemand} ${styles.tradeRouteHideCompact}`}>
-              {renderValue(outboundDemandDisplay)}
-            </span>
           </div>
-          <div className={`${styles.tradeRouteCommodityRow} ${styles.tradeRouteCommodityRowReturn}`}>
+          <div className={`${styles.tradeRouteCommodityRow} ${styles.tradeRouteCommodityRowReturn} ${returnFlowClass}`}>
             <span className={styles.visuallyHidden}>Return to {originStationAria}</span>
+            {returnDemandState ? (
+              <span className={styles.visuallyHidden}>
+                {returnDemandState.label}
+                {returnDemandState.text ? ` — ${returnDemandState.text}` : ''}
+              </span>
+            ) : null}
             <span className={styles.tradeRouteCommodityIcon}>
               <CommodityIcon category={returnInfo.buy?.category || returnInfo.sell?.category || ''} size={24} />
             </span>
             <span className={styles.tradeRouteCommodityName}>{renderValue(returnCommodityDisplay)}</span>
             <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteHideMedium}`}>
               {renderValue(returnPriceDisplay)}
-            </span>
-            <span className={`${styles.tradeRouteCommodityDemand} ${styles.tradeRouteHideCompact}`}>
-              {renderValue(returnDemandDisplay)}
             </span>
           </div>
         </div>
@@ -1591,25 +1599,98 @@ function resolvePriceDisplay (entry, actionLabel) {
   return actionLabel ? `${actionLabel} ${formatted}` : formatted
 }
 
-function buildDemandDisplay (entry, direction = 'up') {
-  if (!entry) return null
-  const quantityText = resolveQuantityText(entry)
-  const priceDiffText = typeof entry.priceDiffText === 'string' ? sanitizeInaraText(entry.priceDiffText) : ''
-  const infoParts = [quantityText, priceDiffText].filter(Boolean)
-  if (infoParts.length === 0) return null
+function resolveDemandFlowState (entry) {
+  if (!entry || typeof entry !== 'object') return null
 
-  const arrowSymbol = direction === 'down' ? String.fromCharCode(0x25BC) : String.fromCharCode(0x25B2)
-  const arrowCount = Math.min(Math.max(Number(entry.level) || 1, 1), 4)
-  const labelText = `${arrowSymbol.repeat(arrowCount)} ${infoParts.join(' • ')}`.trim()
+  const quantityTextRaw = typeof entry.quantityText === 'string' ? sanitizeInaraText(entry.quantityText) : ''
+  const quantityText = quantityTextRaw.trim()
+  const normalizedText = quantityText.toLowerCase()
+  const levelValue = Number.isFinite(entry.level) ? Math.max(Math.min(Math.round(entry.level), 4), 1) : null
+  const priceDiff = Number.isFinite(entry.priceDiff) ? entry.priceDiff : null
+  const priceDiffPercent = Number.isFinite(entry.priceDiffPercent) ? entry.priceDiffPercent : null
 
-  return (
-    <DemandIndicator
-      label={labelText}
-      fallbackLabel={infoParts.join(' • ')}
-      isLow={direction === 'down'}
-      subtle
-    />
-  )
+  let descriptor = null
+  if (normalizedText.includes('very high')) {
+    descriptor = 'very high'
+  } else if (normalizedText.includes('high')) {
+    descriptor = 'high'
+  } else if (normalizedText.includes('medium') || normalizedText.includes('med')) {
+    descriptor = 'medium'
+  } else if (normalizedText.includes('very low')) {
+    descriptor = 'very low'
+  } else if (normalizedText.includes('low')) {
+    descriptor = 'low'
+  } else if (normalizedText.includes('none') || normalizedText.includes('zero')) {
+    descriptor = 'none'
+  }
+
+  let tone = null
+  if (priceDiffPercent !== null && priceDiffPercent !== 0) {
+    tone = priceDiffPercent > 0 ? 'positive' : 'negative'
+  } else if (priceDiff !== null && priceDiff !== 0) {
+    tone = priceDiff > 0 ? 'positive' : 'negative'
+  }
+
+  if (!tone && descriptor) {
+    tone = ['low', 'very low', 'none'].includes(descriptor) ? 'negative' : 'positive'
+  }
+
+  if (!tone) tone = 'neutral'
+
+  let intensity = null
+  if (levelValue !== null) {
+    if (tone === 'positive') {
+      if (levelValue >= 4) intensity = 3
+      else if (levelValue === 3) intensity = 2
+      else intensity = 1
+    } else if (tone === 'negative') {
+      if (levelValue <= 1) intensity = 3
+      else if (levelValue === 2) intensity = 2
+      else intensity = 1
+    } else {
+      intensity = levelValue >= 3 ? 2 : 1
+    }
+  }
+
+  if (intensity === null && descriptor) {
+    if (tone === 'positive') {
+      if (descriptor === 'very high') intensity = 3
+      else if (descriptor === 'high') intensity = 3
+      else if (descriptor === 'medium') intensity = 2
+      else intensity = 1
+    } else if (tone === 'negative') {
+      if (descriptor === 'none' || descriptor === 'very low') intensity = 3
+      else if (descriptor === 'low') intensity = 2
+      else intensity = 1
+    }
+  }
+
+  if (intensity === null) {
+    intensity = tone === 'neutral' ? 2 : 1
+  }
+
+  intensity = Math.max(1, Math.min(intensity, 3))
+
+  let label = 'Demand unavailable'
+  if (tone === 'positive') {
+    label = intensity === 3 ? 'High demand' : intensity === 2 ? 'Moderate demand' : 'Low demand'
+  } else if (tone === 'negative') {
+    label = intensity === 3 ? 'Demand minimal' : intensity === 2 ? 'Demand limited' : 'Demand below average'
+  }
+
+  return { tone, intensity, label, text: quantityText }
+}
+
+function getDemandFlowClass (state) {
+  if (!state) return styles.tradeRouteFlowNeutral
+  const intensity = Math.max(1, Math.min(state.intensity || 1, 3))
+  if (state.tone === 'positive') {
+    return styles[`tradeRouteFlowPositive${intensity}`] || styles.tradeRouteFlowNeutral
+  }
+  if (state.tone === 'negative') {
+    return styles[`tradeRouteFlowNegative${intensity}`] || styles.tradeRouteFlowNeutral
+  }
+  return styles.tradeRouteFlowNeutral
 }
 
 function extractProfitPerTrip (route) {

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1751,7 +1751,7 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteCommodityRow {
   display: grid;
-  grid-template-columns: minmax(2.1rem, auto) minmax(0, 1fr) max-content max-content;
+  grid-template-columns: minmax(2.1rem, auto) minmax(0, 1fr) max-content;
   align-items: center;
   gap: 0.35rem;
   min-width: 0;
@@ -1761,6 +1761,7 @@ button.terminalStatusPreview:focus-visible {
   overflow: hidden;
   z-index: 0;
   justify-content: flex-start;
+  --trade-route-flow-fill: rgba(93, 46, 255, 0.24);
 }
 
 .tradeRouteCommodityRow > * {
@@ -1773,41 +1774,45 @@ button.terminalStatusPreview:focus-visible {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: transparent;
+  background: var(--trade-route-flow-fill);
   opacity: 1;
-  transition: transform 160ms ease, opacity 160ms ease;
   pointer-events: none;
 }
 
 .tradeRouteCommodityRowOutbound::before {
-  background-image:
-    linear-gradient(90deg, rgba(93, 46, 255, 0.24), rgba(93, 46, 255, 0.08) 70%, rgba(41, 243, 195, 0.32)),
-    repeating-linear-gradient(90deg, rgba(140, 92, 255, 0.22) 0 4px, rgba(140, 92, 255, 0) 4px 12px);
   clip-path: polygon(0 0, calc(100% - 1.65rem) 0, 100% 50%, calc(100% - 1.65rem) 100%, 0 100%);
 }
 
 .tradeRouteCommodityRowReturn::before {
-  background-image:
-    linear-gradient(270deg, rgba(93, 46, 255, 0.24), rgba(93, 46, 255, 0.08) 70%, rgba(255, 95, 193, 0.28)),
-    repeating-linear-gradient(270deg, rgba(140, 92, 255, 0.22) 0 4px, rgba(140, 92, 255, 0) 4px 12px);
   clip-path: polygon(1.65rem 0, 100% 0, 100% 100%, 1.65rem 100%, 0 50%);
 }
 
-.tradeRouteCommodityRow:hover::before,
-.tradeRouteCommodityRow:focus-within::before {
-  opacity: 1;
-  transform: scale(1.015);
+.tradeRouteFlowNeutral {
+  --trade-route-flow-fill: rgba(93, 46, 255, 0.24);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .tradeRouteCommodityRow::before {
-    transition: opacity 160ms ease;
-  }
+.tradeRouteFlowPositive1 {
+  --trade-route-flow-fill: rgba(41, 243, 195, 0.22);
+}
 
-  .tradeRouteCommodityRow:hover::before,
-  .tradeRouteCommodityRow:focus-within::before {
-    transform: none;
-  }
+.tradeRouteFlowPositive2 {
+  --trade-route-flow-fill: rgba(41, 243, 195, 0.34);
+}
+
+.tradeRouteFlowPositive3 {
+  --trade-route-flow-fill: rgba(41, 243, 195, 0.48);
+}
+
+.tradeRouteFlowNegative1 {
+  --trade-route-flow-fill: rgba(255, 95, 193, 0.24);
+}
+
+.tradeRouteFlowNegative2 {
+  --trade-route-flow-fill: rgba(255, 95, 193, 0.38);
+}
+
+.tradeRouteFlowNegative3 {
+  --trade-route-flow-fill: rgba(255, 95, 193, 0.52);
 }
 
 .tradeRouteCommodityIcon {
@@ -1835,17 +1840,6 @@ button.terminalStatusPreview:focus-visible {
   grid-column: 3;
   color: var(--ghostnet-text-soft);
   font-size: 0.9rem;
-  white-space: nowrap;
-  justify-self: end;
-}
-
-.tradeRouteCommodityDemand {
-  grid-column: 4;
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  color: var(--ghostnet-text-soft);
-  gap: 0.35rem;
   white-space: nowrap;
   justify-self: end;
 }


### PR DESCRIPTION
## Summary
- replace the trade route flow background gradients with solid fill colors at each demand intensity
- drop the hover scale animation from trade route commodity rows to keep the arrows static

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js bundled SWC rejects the serverComponents option)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f85d4d908323aacc4ce640567eb6