### PR TITLE
Adjust GhostNet side navigation alignment

### DIFF
--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -31,7 +31,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: clamp(1.5rem, 4vw, 2.25rem) 0;
+  padding: 0 0 clamp(1.5rem, 4vw, 2.25rem);
   gap: 0.75rem;
 }
 


### PR DESCRIPTION
## Summary
- remove the extra top padding on the GhostNet side navigation so it meets the global header

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js build exits with `unknown field serverComponents` while parsing SWC TransformOptions)*

------
https://chatgpt.com/codex/tasks/task_e_68e2feb72c908323b9449084e77d9785