### PR TITLE
Keep trade route stations on a single row

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -19,6 +19,13 @@ import { stationIconFromType, getStationIconName } from '../lib/station-icons'
 import { createMockCargoManifest, createMockCommodityValuations, generateMockTradeRoutes, NON_COMMODITY_KEYS, normaliseCommodityKey } from '../lib/ghostnet-mock-data'
 import styles from './ghostnet.module.css'
 
+const METRIC_VARIANT_CLASS_MAP = {
+  neutral: styles.metricChipNeutral,
+  success: styles.metricChipSuccess,
+  caution: styles.metricChipCaution,
+  warning: styles.metricChipWarning
+}
+
 export const TERMINAL_PROMPT_TYPE_CLASS_MAP = {
   command: styles.terminalPromptCommand,
   response: styles.terminalPromptResponse,
@@ -4130,6 +4137,197 @@ function TradeRoutesPanel () {
     return hops.slice(originIndex, destinationIndex + 1)
   }, [navRoute?.route, routeContext])
 
+  const originFactionName = useMemo(() => {
+    if (!routeContext) return ''
+    const faction = resolveRouteFactionName(selectedRoute?.origin?.local, selectedRoute?.origin)
+    if (!faction) return ''
+    const sanitized = sanitizeInaraText(faction)
+    return sanitized || faction
+  }, [routeContext, selectedRoute])
+
+  const destinationFactionName = useMemo(() => {
+    if (!routeContext) return ''
+    const faction = resolveRouteFactionName(selectedRoute?.destination?.local, selectedRoute?.destination)
+    if (!faction) return ''
+    const sanitized = sanitizeInaraText(faction)
+    return sanitized || faction
+  }, [routeContext, selectedRoute])
+
+  const originStandingDisplay = useMemo(
+    () => getFactionStandingDisplay(originFactionName, factionStandings),
+    [originFactionName, factionStandings]
+  )
+
+  const destinationStandingDisplay = useMemo(
+    () => getFactionStandingDisplay(destinationFactionName, factionStandings),
+    [destinationFactionName, factionStandings]
+  )
+
+  const originStationDistance = useMemo(
+    () => (routeContext ? resolveStationDistance(selectedRoute?.origin) : { display: '', value: null }),
+    [routeContext, selectedRoute]
+  )
+
+  const destinationStationDistance = useMemo(
+    () => (routeContext ? resolveStationDistance(selectedRoute?.destination) : { display: '', value: null }),
+    [routeContext, selectedRoute]
+  )
+
+  const originSystemDistance = useMemo(
+    () => (routeContext ? resolveStationSystemDistance(selectedRoute, 'origin') : { display: '', value: null }),
+    [routeContext, selectedRoute]
+  )
+
+  const destinationSystemDistance = useMemo(
+    () => (routeContext ? resolveStationSystemDistance(selectedRoute, 'destination') : { display: '', value: null }),
+    [routeContext, selectedRoute]
+  )
+
+  const originStationDistanceVariant = getStationDistanceVariant(originStationDistance.value)
+  const destinationStationDistanceVariant = getStationDistanceVariant(destinationStationDistance.value)
+  const originSystemDistanceVariant = getSystemDistanceVariant(originSystemDistance.value, shipStatus?.maxJumpRange ?? null)
+  const destinationSystemDistanceVariant = getSystemDistanceVariant(destinationSystemDistance.value, shipStatus?.maxJumpRange ?? null)
+  const originSystemDistanceColor = getDistanceSeverityColor(originSystemDistance.value, shipStatus?.maxJumpRange ?? null)
+  const destinationSystemDistanceColor = getDistanceSeverityColor(destinationSystemDistance.value, shipStatus?.maxJumpRange ?? null)
+
+  const originStationType = useMemo(() => {
+    if (!routeContext) return ''
+    const station = selectedRoute?.origin || {}
+    const local = station?.local || {}
+    const candidates = [
+      local?.stationType,
+      local?.type,
+      station?.stationType,
+      station?.type,
+      station?.stationTypeName
+    ]
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        const sanitized = sanitizeInaraText(candidate)
+        return sanitized || candidate.trim()
+      }
+    }
+    return ''
+  }, [routeContext, selectedRoute])
+
+  const destinationStationType = useMemo(() => {
+    if (!routeContext) return ''
+    const station = selectedRoute?.destination || {}
+    const local = station?.local || {}
+    const candidates = [
+      local?.stationType,
+      local?.type,
+      station?.stationType,
+      station?.type,
+      station?.stationTypeName
+    ]
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        const sanitized = sanitizeInaraText(candidate)
+        return sanitized || candidate.trim()
+      }
+    }
+    return ''
+  }, [routeContext, selectedRoute])
+
+  const originEconomy = useMemo(() => {
+    if (!routeContext) return ''
+    const station = selectedRoute?.origin || {}
+    const local = station?.local || {}
+    const candidates = [
+      local?.economy,
+      local?.Economy,
+      local?.primaryEconomy,
+      local?.PrimaryEconomy,
+      station?.economy,
+      station?.primaryEconomy
+    ]
+    const seen = new Set()
+    const values = []
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        const sanitized = sanitizeInaraText(candidate) || candidate.trim()
+        if (!seen.has(sanitized)) {
+          values.push(sanitized)
+          seen.add(sanitized)
+        }
+      }
+    }
+    return values.join(' · ')
+  }, [routeContext, selectedRoute])
+
+  const destinationEconomy = useMemo(() => {
+    if (!routeContext) return ''
+    const station = selectedRoute?.destination || {}
+    const local = station?.local || {}
+    const candidates = [
+      local?.economy,
+      local?.Economy,
+      local?.primaryEconomy,
+      local?.PrimaryEconomy,
+      station?.economy,
+      station?.primaryEconomy
+    ]
+    const seen = new Set()
+    const values = []
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        const sanitized = sanitizeInaraText(candidate) || candidate.trim()
+        if (!seen.has(sanitized)) {
+          values.push(sanitized)
+          seen.add(sanitized)
+        }
+      }
+    }
+    return values.join(' · ')
+  }, [routeContext, selectedRoute])
+
+  const outboundCommodityContext = useMemo(() => {
+    if (!routeContext) return null
+    const info = getRouteCommodityInfo(selectedRoute, 'outbound')
+    return {
+      info,
+      price: resolvePriceDisplay(info.buy, 'Buy'),
+      demand: resolveDemandFlowState(info.sell),
+      quantity: resolveQuantityText(info.sell),
+      supply: resolveQuantityText(info.buy)
+    }
+  }, [routeContext, selectedRoute])
+
+  const inboundCommodityContext = useMemo(() => {
+    if (!routeContext) return null
+    const info = getRouteCommodityInfo(selectedRoute, 'return')
+    return {
+      info,
+      price: resolvePriceDisplay(info.buy, 'Buy'),
+      demand: resolveDemandFlowState(info.sell),
+      quantity: resolveQuantityText(info.sell),
+      supply: resolveQuantityText(info.buy)
+    }
+  }, [routeContext, selectedRoute])
+
+  const routeDistanceDisplay = useMemo(() => {
+    if (!routeContext) return ''
+    const value = extractSystemDistance(selectedRoute)
+    if (typeof value !== 'number' || Number.isNaN(value)) return ''
+    const precision = value < 10 ? 2 : 1
+    return `${value.toFixed(precision)} ly`
+  }, [routeContext, selectedRoute])
+
+  const routeUpdatedDisplay = useMemo(() => {
+    if (!routeContext) return ''
+    const updated = extractUpdatedAt(selectedRoute)
+    if (!updated) return ''
+    return formatRelativeTime(updated)
+  }, [routeContext, selectedRoute])
+
+  const buildMetricChipClasses = useCallback((variant = 'neutral') => {
+    const classes = [styles.metricChip, styles.metricChipContext]
+    const variantClass = METRIC_VARIANT_CLASS_MAP[variant] || METRIC_VARIANT_CLASS_MAP.neutral
+    if (variantClass) classes.push(variantClass)
+    return classes.join(' ')
+  }, [])
+
   const renderRoutesTable = () => (
     <div className={styles.dataTableContainer}>
       <table className={`${styles.dataTable} ${styles.dataTableDense} ${styles.tradeRoutesTable}`}>
@@ -4242,70 +4440,215 @@ function TradeRoutesPanel () {
             </div>
             {routeContext ? (
               <>
-                <div className={styles.tradeRouteContextGrid}>
-                  <div className={styles.tradeRouteContextItem}>
-                    <span className={styles.tradeRouteContextLabel}>Station A</span>
-                    <div className={styles.tradeRouteContextValue}>
-                      {routeContext.origin.iconName && (
-                        <span className={styles.tradeRouteContextIcon}>
-                          <StationIcon icon={routeContext.origin.iconName} size={28} />
+                <div className={styles.tradeRouteContextStations}>
+                  <div className={`${styles.tradeRouteContextStationCard} ${styles.tradeRouteContextStationCardOrigin}`}>
+                    <div className={styles.tradeRouteContextStationHeader}>
+                      <span className={styles.tradeRouteContextBadge}>Station A</span>
+                      {originStationType ? (
+                        <span className={styles.tradeRouteContextBadgeDetail}>{originStationType}</span>
+                      ) : null}
+                    </div>
+                    <div className={styles.tradeRouteContextStationBody}>
+                      {routeContext.origin.iconName ? (
+                        <span className={styles.tradeRouteContextStationIconLarge}>
+                          <StationIcon
+                            icon={routeContext.origin.iconName}
+                            size='100%'
+                            color={originStandingDisplay.iconColor}
+                          />
                         </span>
-                      )}
-                      <div className={styles.tradeRouteContextValueText}>
-                        <span className={styles.tradeRouteContextPrimary}>
+                      ) : null}
+                      <div className={styles.tradeRouteContextStationText}>
+                        <span className={styles.tradeRouteContextStationName}>
                           {routeContext.origin.station
                             ? <CopyOnClick copyMessageKey='station'>{routeContext.origin.station}</CopyOnClick>
                             : '--'}
                         </span>
-                        <span className={styles.tradeRouteContextMeta}>
+                        <span className={styles.tradeRouteContextStationSystem}>
                           {routeContext.origin.system
                             ? <CopyOnClick copyMessageKey='system'>{routeContext.origin.system}</CopyOnClick>
                             : '--'}
                         </span>
+                        {originFactionName ? (
+                          <span className={styles.tradeRouteContextStationFaction}>{originFactionName}</span>
+                        ) : null}
+                        {originEconomy ? (
+                          <span className={styles.tradeRouteContextStationEconomy}>{originEconomy}</span>
+                        ) : null}
                       </div>
                     </div>
-                  </div>
-                  <div className={styles.tradeRouteContextItem}>
-                    <span className={styles.tradeRouteContextLabel}>Commodity A</span>
-                    <div className={styles.tradeRouteContextValue}>
-                      <span className={styles.tradeRouteContextIcon}>
-                        <CommodityIcon category={routeContext.outbound.category || ''} size={24} />
-                      </span>
-                      <div className={styles.tradeRouteContextValueText}>
-                        <span className={styles.tradeRouteContextPrimary}>{routeContext.outbound.commodity || '--'}</span>
-                      </div>
-                    </div>
-                  </div>
-                  <div className={styles.tradeRouteContextItem}>
-                    <span className={styles.tradeRouteContextLabel}>Station B</span>
-                    <div className={styles.tradeRouteContextValue}>
-                      {routeContext.destination.iconName && (
-                        <span className={styles.tradeRouteContextIcon}>
-                          <StationIcon icon={routeContext.destination.iconName} size={28} />
+                    <div className={styles.tradeRouteContextMetrics}>
+                      <div className={styles.tradeRouteContextMetric}>
+                        <span className={styles.tradeRouteContextMetricLabel}>System Distance</span>
+                        <span
+                          className={buildMetricChipClasses(originSystemDistanceVariant)}
+                          style={originSystemDistanceColor ? { '--chip-color': originSystemDistanceColor } : undefined}
+                        >
+                          {originSystemDistance.display || '--'}
                         </span>
-                      )}
-                      <div className={styles.tradeRouteContextValueText}>
-                        <span className={styles.tradeRouteContextPrimary}>
+                      </div>
+                      <div className={styles.tradeRouteContextMetric}>
+                        <span className={styles.tradeRouteContextMetricLabel}>Orbital Distance</span>
+                        <span className={buildMetricChipClasses(originStationDistanceVariant)}>
+                          {originStationDistance.display || '--'}
+                        </span>
+                      </div>
+                      {originStandingDisplay?.statusLabel ? (
+                        <div className={styles.tradeRouteContextMetric}>
+                          <span className={styles.tradeRouteContextMetricLabel}>Faction Standing</span>
+                          <span
+                            className={buildMetricChipClasses('neutral')}
+                            style={originStandingDisplay.color ? { '--chip-color': originStandingDisplay.color } : undefined}
+                          >
+                            {originStandingDisplay.statusLabel}
+                          </span>
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className={styles.tradeRouteContextStationConnector}>
+                    <div className={styles.tradeRouteContextConnectorTrack}>
+                      <span className={styles.tradeRouteContextConnectorEndpoint} aria-hidden='true' />
+                      <span className={styles.tradeRouteContextConnectorLine}>
+                        {routeDistanceDisplay ? (
+                          <span className={styles.tradeRouteContextConnectorMetric}>{routeDistanceDisplay}</span>
+                        ) : null}
+                        <span className={styles.tradeRouteContextConnectorPulse} />
+                      </span>
+                      <span className={styles.tradeRouteContextConnectorEndpoint} aria-hidden='true' />
+                    </div>
+                    {routeUpdatedDisplay ? (
+                      <div className={styles.tradeRouteContextConnectorMeta}>
+                        <span className={styles.tradeRouteContextConnectorMetaText}>Updated {routeUpdatedDisplay}</span>
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className={`${styles.tradeRouteContextStationCard} ${styles.tradeRouteContextStationCardDestination}`}>
+                    <div className={styles.tradeRouteContextStationHeader}>
+                      <span className={styles.tradeRouteContextBadge}>Station B</span>
+                      {destinationStationType ? (
+                        <span className={styles.tradeRouteContextBadgeDetail}>{destinationStationType}</span>
+                      ) : null}
+                    </div>
+                    <div className={styles.tradeRouteContextStationBody}>
+                      {routeContext.destination.iconName ? (
+                        <span className={styles.tradeRouteContextStationIconLarge}>
+                          <StationIcon
+                            icon={routeContext.destination.iconName}
+                            size='100%'
+                            color={destinationStandingDisplay.iconColor}
+                          />
+                        </span>
+                      ) : null}
+                      <div className={styles.tradeRouteContextStationText}>
+                        <span className={styles.tradeRouteContextStationName}>
                           {routeContext.destination.station
                             ? <CopyOnClick copyMessageKey='station'>{routeContext.destination.station}</CopyOnClick>
                             : '--'}
                         </span>
-                        <span className={styles.tradeRouteContextMeta}>
+                        <span className={styles.tradeRouteContextStationSystem}>
                           {routeContext.destination.system
                             ? <CopyOnClick copyMessageKey='system'>{routeContext.destination.system}</CopyOnClick>
                             : '--'}
                         </span>
+                        {destinationFactionName ? (
+                          <span className={styles.tradeRouteContextStationFaction}>{destinationFactionName}</span>
+                        ) : null}
+                        {destinationEconomy ? (
+                          <span className={styles.tradeRouteContextStationEconomy}>{destinationEconomy}</span>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className={styles.tradeRouteContextMetrics}>
+                      <div className={styles.tradeRouteContextMetric}>
+                        <span className={styles.tradeRouteContextMetricLabel}>System Distance</span>
+                        <span
+                          className={buildMetricChipClasses(destinationSystemDistanceVariant)}
+                          style={destinationSystemDistanceColor ? { '--chip-color': destinationSystemDistanceColor } : undefined}
+                        >
+                          {destinationSystemDistance.display || '--'}
+                        </span>
+                      </div>
+                      <div className={styles.tradeRouteContextMetric}>
+                        <span className={styles.tradeRouteContextMetricLabel}>Orbital Distance</span>
+                        <span className={buildMetricChipClasses(destinationStationDistanceVariant)}>
+                          {destinationStationDistance.display || '--'}
+                        </span>
+                      </div>
+                      {destinationStandingDisplay?.statusLabel ? (
+                        <div className={styles.tradeRouteContextMetric}>
+                          <span className={styles.tradeRouteContextMetricLabel}>Faction Standing</span>
+                          <span
+                            className={buildMetricChipClasses('neutral')}
+                            style={destinationStandingDisplay.color ? { '--chip-color': destinationStandingDisplay.color } : undefined}
+                          >
+                            {destinationStandingDisplay.statusLabel}
+                          </span>
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+
+                <div className={styles.tradeRouteContextCommodities}>
+                  <div className={`${styles.tradeRouteContextCommodityCard} ${styles.tradeRouteContextCommodityOutbound}`}>
+                    <div className={styles.tradeRouteContextCommodityHeader}>
+                      <span className={styles.tradeRouteContextLabel}>Outbound Commodity</span>
+                      {outboundCommodityContext?.price ? (
+                        <span className={styles.tradeRouteContextCommodityPrice}>{outboundCommodityContext.price}</span>
+                      ) : null}
+                    </div>
+                    <div className={styles.tradeRouteContextCommodityBody}>
+                      <span className={styles.tradeRouteContextCommodityIconLarge}>
+                        <CommodityIcon category={routeContext.outbound.category || ''} size={32} />
+                      </span>
+                      <div className={styles.tradeRouteContextCommodityText}>
+                        <span className={styles.tradeRouteContextCommodityName}>{routeContext.outbound.commodity || '--'}</span>
+                        {outboundCommodityContext?.demand?.label ? (
+                          <span className={styles.tradeRouteContextCommodityMeta}>{outboundCommodityContext.demand.label}</span>
+                        ) : null}
+                        {outboundCommodityContext?.quantity ? (
+                          <span className={styles.tradeRouteContextCommodityFootnote}>
+                            Demand window: {outboundCommodityContext.quantity}
+                          </span>
+                        ) : null}
+                        {outboundCommodityContext?.supply ? (
+                          <span className={styles.tradeRouteContextCommodityFootnote}>
+                            Supply: {outboundCommodityContext.supply}
+                          </span>
+                        ) : null}
                       </div>
                     </div>
                   </div>
-                  <div className={styles.tradeRouteContextItem}>
-                    <span className={styles.tradeRouteContextLabel}>Commodity B</span>
-                    <div className={styles.tradeRouteContextValue}>
-                      <span className={styles.tradeRouteContextIcon}>
-                        <CommodityIcon category={routeContext.inbound.category || ''} size={24} />
+
+                  <div className={`${styles.tradeRouteContextCommodityCard} ${styles.tradeRouteContextCommodityReturn}`}>
+                    <div className={styles.tradeRouteContextCommodityHeader}>
+                      <span className={styles.tradeRouteContextLabel}>Return Commodity</span>
+                      {inboundCommodityContext?.price ? (
+                        <span className={styles.tradeRouteContextCommodityPrice}>{inboundCommodityContext.price}</span>
+                      ) : null}
+                    </div>
+                    <div className={styles.tradeRouteContextCommodityBody}>
+                      <span className={styles.tradeRouteContextCommodityIconLarge}>
+                        <CommodityIcon category={routeContext.inbound.category || ''} size={32} />
                       </span>
-                      <div className={styles.tradeRouteContextValueText}>
-                        <span className={styles.tradeRouteContextPrimary}>{routeContext.inbound.commodity || '--'}</span>
+                      <div className={styles.tradeRouteContextCommodityText}>
+                        <span className={styles.tradeRouteContextCommodityName}>{routeContext.inbound.commodity || '--'}</span>
+                        {inboundCommodityContext?.demand?.label ? (
+                          <span className={styles.tradeRouteContextCommodityMeta}>{inboundCommodityContext.demand.label}</span>
+                        ) : null}
+                        {inboundCommodityContext?.quantity ? (
+                          <span className={styles.tradeRouteContextCommodityFootnote}>
+                            Demand window: {inboundCommodityContext.quantity}
+                          </span>
+                        ) : null}
+                        {inboundCommodityContext?.supply ? (
+                          <span className={styles.tradeRouteContextCommodityFootnote}>
+                            Supply: {inboundCommodityContext.supply}
+                          </span>
+                        ) : null}
                       </div>
                     </div>
                   </div>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1563,19 +1563,6 @@ button.terminalStatusPreview:focus-visible {
   color: var(--ghostnet-muted);
 }
 
-.tradeRouteContextGrid {
-  display: grid;
-  gap: 1rem;
-  margin-top: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-.tradeRouteContextItem {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-}
-
 .tradeRouteContextLabel {
   font-size: 0.8rem;
   letter-spacing: 0.08em;
@@ -1583,31 +1570,407 @@ button.terminalStatusPreview:focus-visible {
   color: var(--ghostnet-subdued);
 }
 
-.tradeRouteContextValue {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
+.tradeRouteContextStations {
+  display: grid;
+  gap: clamp(0.75rem, 3vw, 1.75rem);
+  margin-top: 1.25rem;
+  grid-template-columns:
+    minmax(0, 1.2fr)
+    minmax(clamp(3.5rem, 12vw, 8.5rem), 0.6fr)
+    minmax(0, 1.2fr);
+  align-items: stretch;
 }
 
-.tradeRouteContextIcon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.1rem;
-  height: 2.1rem;
-  border-radius: 0.6rem;
-  background: color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghostnet-color-primary) 45%, transparent);
-}
-
-.tradeRouteContextValueText {
+.tradeRouteContextStationCard {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 1.15rem;
+  padding: clamp(1.25rem, 3vw, 1.65rem);
+  border-radius: 1rem;
+  background: linear-gradient(135deg,
+      color-mix(in srgb, var(--ghostnet-color-primary) 24%, transparent) 0%,
+      color-mix(in srgb, var(--ghostnet-color-primary-dark) 62%, transparent) 100%);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 42%, transparent);
+  box-shadow: 0 1.5rem 2.75rem color-mix(in srgb, var(--ghostnet-color-primary) 22%, transparent);
+  overflow: hidden;
+  isolation: isolate;
   min-width: 0;
 }
 
-.tradeRouteContextPrimary {
+.tradeRouteContextStationCard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at top right,
+      color-mix(in srgb, var(--ghostnet-color-success) 26%, transparent) 0%,
+      transparent 55%);
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.tradeRouteContextStationCard::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--ghostnet-color-primary-light) 18%, transparent) 0px,
+      color-mix(in srgb, var(--ghostnet-color-primary-light) 18%, transparent) 2px,
+      transparent 2px,
+      transparent 12px);
+  opacity: 0.12;
+  pointer-events: none;
+}
+
+.tradeRouteContextStationCardOrigin::before {
+  background: radial-gradient(circle at 15% 15%,
+      color-mix(in srgb, var(--ghostnet-color-success) 32%, transparent) 0%,
+      transparent 60%);
+}
+
+.tradeRouteContextStationCardDestination::before {
+  background: radial-gradient(circle at 85% 15%,
+      color-mix(in srgb, var(--ghostnet-accent) 35%, transparent) 0%,
+      transparent 60%);
+}
+
+.tradeRouteContextStationHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.tradeRouteContextBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 30%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary-light) 45%, transparent);
+  color: var(--ghostnet-ink);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghostnet-color-primary-light) 35%, transparent);
+}
+
+.tradeRouteContextBadgeDetail {
+  font-size: 0.8rem;
+  color: var(--ghostnet-subdued);
+  white-space: nowrap;
+}
+
+.tradeRouteContextStationBody {
+  display: flex;
+  align-items: flex-start;
+  gap: clamp(0.85rem, 2.5vw, 1.35rem);
+  flex-wrap: wrap;
+}
+
+.tradeRouteContextStationIconLarge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(3.75rem, 7vw, 4.5rem);
+  height: clamp(3.75rem, 7vw, 4.5rem);
+  border-radius: 1.1rem;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 32%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghostnet-color-primary-light) 55%, transparent),
+    0 0 1.5rem color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+  flex-shrink: 0;
+}
+
+.tradeRouteContextStationText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+  flex: 1 1 12rem;
+}
+
+.tradeRouteContextStationName {
+  font-size: clamp(1.35rem, 4vw, 1.75rem);
+  font-weight: 700;
+  color: var(--ghostnet-ink);
+  line-height: 1.15;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.tradeRouteContextStationSystem {
+  font-size: 1rem;
+  color: color-mix(in srgb, var(--ghostnet-ink) 88%, transparent);
+  white-space: normal;
+  word-break: break-word;
+}
+
+.tradeRouteContextStationFaction {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ghostnet-accent) 78%, transparent);
+}
+
+.tradeRouteContextStationEconomy {
+  font-size: 0.85rem;
+  color: var(--ghostnet-subdued);
+}
+
+.tradeRouteContextMetrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 0.9rem;
+}
+
+.tradeRouteContextMetric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.tradeRouteContextMetricLabel {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ghostnet-subdued);
+}
+
+.metricChipContext {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.8rem;
+  box-shadow: 0 0 1.4rem color-mix(in srgb, var(--chip-color) 40%, transparent);
+}
+
+.tradeRouteContextStationConnector {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: clamp(0.75rem, 2vw, 1rem);
+  padding: clamp(0.75rem, 2vw, 1rem);
+  min-width: 0;
+}
+
+.tradeRouteContextConnectorTrack {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.5rem, 1.25vw, 0.9rem);
+}
+
+.tradeRouteContextConnectorEndpoint {
+  flex: 0 0 auto;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--ghostnet-color-success) 65%, transparent);
+  box-shadow: 0 0 0.95rem color-mix(in srgb, var(--ghostnet-color-success) 35%, transparent);
+}
+
+.tradeRouteContextConnectorLine {
+  position: relative;
+  flex: 1 1 auto;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg,
+      color-mix(in srgb, var(--ghostnet-color-primary-light) 65%, transparent) 0%,
+      color-mix(in srgb, var(--ghostnet-color-primary-dark) 55%, transparent) 100%);
+  box-shadow: 0 0 1.6rem color-mix(in srgb, var(--ghostnet-color-primary) 24%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 1.25rem;
+  overflow: hidden;
+}
+
+.tradeRouteContextConnectorPulse {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg,
+      transparent 0%,
+      color-mix(in srgb, var(--ghostnet-color-success) 55%, transparent) 50%,
+      transparent 100%);
+  opacity: 0.7;
+  animation: tradeRoutePulse 5s ease-in-out infinite;
+}
+
+.tradeRouteContextConnectorMetric {
+  position: relative;
+  z-index: 1;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ghostnet-ink);
+  padding: 0.25rem 0.85rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 45%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary-light) 35%, transparent);
+  box-shadow: 0 0 1.1rem color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent);
+}
+
+.tradeRouteContextConnectorMeta {
+  display: flex;
+  justify-content: center;
+}
+
+.tradeRouteContextConnectorMetaText {
+  font-size: 0.78rem;
+  color: var(--ghostnet-subdued);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 1200px) {
+  .tradeRouteContextStations {
+    grid-template-columns:
+      minmax(0, 1.1fr)
+      minmax(clamp(3.25rem, 11vw, 7.5rem), 0.5fr)
+      minmax(0, 1.1fr);
+  }
+}
+
+@media (max-width: 900px) {
+  .tradeRouteContextStations {
+    grid-template-columns:
+      minmax(0, 1fr)
+      minmax(clamp(3rem, 16vw, 6.25rem), 0.4fr)
+      minmax(0, 1fr);
+    gap: clamp(0.65rem, 2.5vw, 1.1rem);
+  }
+
+  .tradeRouteContextStationBody {
+    gap: clamp(0.7rem, 2vw, 1rem);
+  }
+
+  .tradeRouteContextStationIconLarge {
+    width: clamp(3.1rem, 12vw, 3.9rem);
+    height: clamp(3.1rem, 12vw, 3.9rem);
+  }
+
+  .tradeRouteContextConnectorLine {
+    padding: 0 0.9rem;
+  }
+
+  .tradeRouteContextConnectorMetric {
+    font-size: 0.85rem;
+    padding: 0.22rem 0.7rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .tradeRouteContextStations {
+    grid-template-columns:
+      minmax(0, 1fr)
+      minmax(clamp(2.6rem, 22vw, 5.5rem), 0.32fr)
+      minmax(0, 1fr);
+    gap: clamp(0.55rem, 2vw, 0.85rem);
+  }
+
+  .tradeRouteContextStationConnector {
+    padding-inline: clamp(0.35rem, 2vw, 0.65rem);
+  }
+
+  .tradeRouteContextConnectorLine {
+    padding: 0 0.6rem;
+  }
+
+  .tradeRouteContextConnectorMetric {
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+    padding: 0.18rem 0.55rem;
+  }
+}
+
+.tradeRouteContextCommodities {
+  display: grid;
+  gap: clamp(0.85rem, 3vw, 1.35rem);
+  margin-top: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.tradeRouteContextCommodityCard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: clamp(1rem, 3vw, 1.35rem);
+  border-radius: 0.9rem;
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 55%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 35%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent);
+  overflow: hidden;
+}
+
+.tradeRouteContextCommodityCard::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg,
+      transparent 0%,
+      color-mix(in srgb, var(--ghostnet-color-primary-light) 24%, transparent) 55%,
+      transparent 100%);
+  opacity: 0.16;
+  pointer-events: none;
+}
+
+.tradeRouteContextCommodityOutbound::after {
+  background: linear-gradient(120deg,
+      transparent 0%,
+      color-mix(in srgb, var(--ghostnet-color-success) 32%, transparent) 55%,
+      transparent 100%);
+}
+
+.tradeRouteContextCommodityReturn::after {
+  background: linear-gradient(120deg,
+      transparent 0%,
+      color-mix(in srgb, var(--ghostnet-accent) 38%, transparent) 55%,
+      transparent 100%);
+}
+
+.tradeRouteContextCommodityHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+}
+
+.tradeRouteContextCommodityPrice {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--ghostnet-ink) 82%, transparent);
+  white-space: nowrap;
+}
+
+.tradeRouteContextCommodityBody {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+}
+
+.tradeRouteContextCommodityIconLarge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.8rem;
+  background: color-mix(in srgb, var(--ghostnet-color-primary) 22%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghostnet-color-primary-light) 45%, transparent);
+  flex-shrink: 0;
+}
+
+.tradeRouteContextCommodityText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.tradeRouteContextCommodityName {
   font-size: 1.05rem;
   font-weight: 600;
   color: var(--ghostnet-ink);
@@ -1616,12 +1979,33 @@ button.terminalStatusPreview:focus-visible {
   text-overflow: ellipsis;
 }
 
-.tradeRouteContextMeta {
+.tradeRouteContextCommodityMeta {
   font-size: 0.85rem;
+  color: color-mix(in srgb, var(--ghostnet-color-success) 70%, transparent);
+}
+
+.tradeRouteContextCommodityFootnote {
+  font-size: 0.75rem;
   color: var(--ghostnet-subdued);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+}
+
+@keyframes tradeRoutePulse {
+  0% {
+    opacity: 0.18;
+    transform: translateY(-100%);
+  }
+  45% {
+    opacity: 0.7;
+    transform: translateY(0%);
+  }
+  70% {
+    opacity: 0.4;
+    transform: translateY(55%);
+  }
+  100% {
+    opacity: 0.18;
+    transform: translateY(120%);
+  }
 }
 
 .tradeRouteContextEmpty {


### PR DESCRIPTION
## Summary
- update the trade route context grid to keep both station cards sharing a single row while letting the distance indicator shrink first
- let station details wrap within their cards so the large typography remains legible on narrow widths and refine responsive connector sizing

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: Next.js SWC transform rejects the `serverComponents` option in this environment)*
- `npm run dev:web` *(fails: Next.js dev server hits the same SWC transform error)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fda991dc83238b027736570e0a29