### PR TITLE
Polish GhostNet nav visibility controls

### DIFF
--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -46,6 +46,7 @@ const NAV_BUTTONS = [
 ]
 
 let IS_WINDOWS_APP = false
+const GHOSTNET_NAV_VISIBILITY_KEY = 'ghostnet.nav.visible'
 
 export default function Header ({ connected, active }) {
   const router = useRouter()
@@ -54,6 +55,7 @@ export default function Header ({ connected, active }) {
   const [isPinned, setIsPinned] = useState(false)
   const [notificationsVisible, setNotificationsVisible] = useState(socketOptions.notifications)
   const [settingsVisible, setSettingsVisible] = useState(false)
+  const [ghostnetButtonVisible, setGhostnetButtonVisible] = useState(true)
   const [titleChars, setTitleChars] = useState(ORIGINAL_TITLE.split(''))
   const [titleAssimilated, setTitleAssimilated] = useState(false)
   const titleAnimationState = useRef({ running: false, completed: false })
@@ -62,6 +64,17 @@ export default function Header ({ connected, active }) {
   const titleGlitchLoopTimeout = useRef(null)
   const titleGlitchRevertTimeouts = useRef([])
   const activeTitleGlitchIndices = useRef(new Set())
+  const restoreGhostnetButtonRef = useRef(null)
+  const ghostnetNavButtonRef = useRef(null)
+  const ghostnetVisibilityHydrated = useRef(false)
+  const persistGhostnetVisibility = useCallback((isVisible) => {
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(GHOSTNET_NAV_VISIBILITY_KEY, isVisible ? 'true' : 'false')
+    } catch (err) {
+      // Ignore storage write issues
+    }
+  }, [])
   const currentPath = `/${(router.pathname.split('/')[1] || '').toLowerCase()}`
   const isGhostnetRouteActive = currentPath === '/ghostnet'
 
@@ -184,6 +197,44 @@ export default function Header ({ connected, active }) {
     }
   }, [clearTitleGlitchTimeouts])
 
+  const scheduleFocus = useCallback((ref) => {
+    if (!ref) return
+    const setTimeoutFn = typeof window !== 'undefined' ? window.setTimeout : setTimeout
+    setTimeoutFn(() => {
+      if (ref.current && typeof ref.current.focus === 'function') {
+        ref.current.focus()
+      }
+    }, 0)
+  }, [])
+
+  const hideGhostnetNavButton = useCallback((event) => {
+    setGhostnetButtonVisible(false)
+    persistGhostnetVisibility(false)
+
+    const nativeEvent = event?.nativeEvent
+    const shouldFocusRestore = !nativeEvent || nativeEvent.detail === 0 || nativeEvent.pointerType === 'keyboard'
+
+    if (shouldFocusRestore) {
+      scheduleFocus(restoreGhostnetButtonRef)
+    } else if (event?.currentTarget && typeof event.currentTarget.blur === 'function') {
+      event.currentTarget.blur()
+    }
+  }, [persistGhostnetVisibility, scheduleFocus])
+
+  const showGhostnetNavButton = useCallback((event) => {
+    setGhostnetButtonVisible(true)
+    persistGhostnetVisibility(true)
+
+    const nativeEvent = event?.nativeEvent
+    const shouldFocusGhostnetNav = !nativeEvent || nativeEvent.detail === 0 || nativeEvent.pointerType === 'keyboard'
+
+    if (shouldFocusGhostnetNav) {
+      scheduleFocus(ghostnetNavButtonRef)
+    } else if (event?.currentTarget && typeof event.currentTarget.blur === 'function') {
+      event.currentTarget.blur()
+    }
+  }, [persistGhostnetVisibility, scheduleFocus])
+
   const startTitleMorph = useCallback(() => {
     if (titleAnimationState.current.running || titleAnimationState.current.completed) return
     clearTitleAnimationTimeouts()
@@ -293,6 +344,21 @@ export default function Header ({ connected, active }) {
   }, [])
 
   useEffect(() => {
+    if (typeof window === 'undefined' || ghostnetVisibilityHydrated.current) return undefined
+    try {
+      const storedVisibility = window.localStorage.getItem(GHOSTNET_NAV_VISIBILITY_KEY)
+      if (storedVisibility !== null) {
+        const isVisible = storedVisibility !== 'false'
+        setGhostnetButtonVisible(isVisible)
+      }
+    } catch (err) {
+      // Ignore storage access issues
+    }
+    ghostnetVisibilityHydrated.current = true
+    return undefined
+  }, [scheduleFocus])
+
+  useEffect(() => {
     return () => {
       clearTitleAnimationTimeouts()
       clearTitleGlitchTimeouts()
@@ -364,6 +430,8 @@ export default function Header ({ connected, active }) {
     router.push(path)
   }
 
+  const visibleNavButtons = (ghostnetButtonVisible ? NAV_BUTTONS : NAV_BUTTONS.filter(button => button.path !== '/ghostnet')).filter(Boolean)
+
   return (
     <header>
       <hr className='small' />
@@ -396,6 +464,19 @@ export default function Header ({ connected, active }) {
         </span>
       </h1>
       <div style={{ position: 'absolute', top: '1rem', right: '.5rem' }}>
+        {!ghostnetButtonVisible && (
+          <button
+            ref={restoreGhostnetButtonRef}
+            tabIndex='1'
+            onClick={(event) => showGhostnetNavButton(event)}
+            className='button--icon'
+            style={{ marginRight: '.5rem' }}
+            aria-label='Show GhostNet navigation'
+            title='Show GhostNet navigation'
+          >
+            <i className='icon icarus-terminal-warning' style={{ fontSize: '2rem' }} />
+          </button>
+        )}
         <p
           className='text-primary text-center text-uppercase'
           style={{ display: 'inline-block', padding: 0, margin: 0, lineHeight: '1rem', minWidth: '7.5rem' }}
@@ -434,20 +515,56 @@ export default function Header ({ connected, active }) {
       </div>
       <hr />
       <div id='primaryNavigation' className='button-group'>
-        {NAV_BUTTONS.filter(button => button).map((button, i) => {
+        {visibleNavButtons.map((button, i) => {
           const isActive = button.path === currentPath
           const isGhostNet = button.path === '/ghostnet'
           const exitActive = isGhostnetExitTransitionActive()
+
+          if (isGhostNet) {
+            return (
+              <div key={button.name} className='ghostnet-nav-button-wrapper'>
+                <button
+                  data-primary-navigation={i + 1}
+                  tabIndex='1'
+                  disabled={isActive || (isGhostNet && isGhostnetAssimilationActive()) || exitActive}
+                  aria-current={isActive ? 'page' : undefined}
+                  className={[
+                    isActive ? 'button--active' : '',
+                    'ghostnet-nav-button'
+                  ].filter(Boolean).join(' ')}
+                  onClick={() => handleNavigate(button.path)}
+                  style={{ fontSize: '1.5rem' }}
+                  ref={ghostnetNavButtonRef}
+                >
+                  <span className='visible-small'>{button.abbr}</span>
+                  <span className='hidden-small'>{button.name}</span>
+                </button>
+                <button
+                  type='button'
+                  className='ghostnet-nav-button__dismiss'
+                  aria-label='Hide GhostNet navigation'
+                  title='Hide GhostNet navigation'
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    event.preventDefault()
+                    hideGhostnetNavButton(event)
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+            )
+          }
+
           return (
             <button
               key={button.name}
               data-primary-navigation={i + 1}
               tabIndex='1'
-              disabled={isActive || (isGhostNet && isGhostnetAssimilationActive()) || exitActive}
+              disabled={isActive || exitActive}
               aria-current={isActive ? 'page' : undefined}
               className={[
-                isActive ? 'button--active' : '',
-                isGhostNet ? 'ghostnet-nav-button' : ''
+                isActive ? 'button--active' : ''
               ].filter(Boolean).join(' ')}
               onClick={() => handleNavigate(button.path)}
               style={{ fontSize: '1.5rem' }}

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -484,6 +484,20 @@ body.ghostnet-theme #secondaryNavigation .button--icon.button--secondary {
   border-right: 0;
 }
 
+#primaryNavigation.button-group > * {
+  flex: 1;
+}
+
+#primaryNavigation .ghostnet-nav-button-wrapper {
+  position: relative;
+  flex: 1;
+  --ghostnet-nav-dismiss-size: 2.25rem;
+}
+
+#primaryNavigation .ghostnet-nav-button-wrapper > .ghostnet-nav-button {
+  width: 100%;
+}
+
 #primaryNavigation .ghostnet-nav-button {
   --ghostnet-nav-accent: rgb(216, 180, 254);
   --ghostnet-nav-depth: rgba(73, 27, 115, 0.35);
@@ -494,11 +508,49 @@ body.ghostnet-theme #secondaryNavigation .button--icon.button--secondary {
   text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
   filter: none;
   transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  padding-right: calc(var(--ghostnet-nav-dismiss-size) + 0.75rem);
+  border-right: 0;
 }
 
 #primaryNavigation .ghostnet-nav-button .visible-small,
 #primaryNavigation .ghostnet-nav-button .hidden-small {
   text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
+}
+
+#primaryNavigation .ghostnet-nav-button__dismiss {
+  position: absolute;
+  top: 50%;
+  right: 0.45rem;
+  width: var(--ghostnet-nav-dismiss-size);
+  height: var(--ghostnet-nav-dismiss-size);
+  border-radius: 0.3rem;
+  border: 1px solid rgba(216, 180, 254, 0.45);
+  background: linear-gradient(180deg, rgba(63, 24, 96, 0.95), rgba(44, 18, 68, 0.85));
+  color: rgb(216, 180, 254);
+  font-size: 1.35rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
+  box-shadow: inset 0 0 1.05rem rgba(93, 46, 255, 0.25);
+  transform: translateY(-50%);
+  transition: color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  z-index: 1;
+}
+
+#primaryNavigation .ghostnet-nav-button__dismiss:hover,
+#primaryNavigation .ghostnet-nav-button__dismiss:focus-visible {
+  color: rgb(245, 241, 255);
+  box-shadow: 0 0 0.85rem rgba(216, 180, 254, 0.45), inset 0 0 0.55rem rgba(216, 180, 254, 0.45);
+  transform: translateY(calc(-50% - 1px));
+}
+
+#primaryNavigation .ghostnet-nav-button__dismiss:focus-visible {
+  outline: 2px solid rgba(41, 243, 195, 0.75);
+  outline-offset: 2px;
 }
 
 #primaryNavigation .ghostnet-nav-button.button--active {


### PR DESCRIPTION
## Summary
- persist the GhostNet navigation button visibility preference in localStorage while keeping focus handling intact for hide/show transitions
- enlarge and center the square dismiss affordance within the GhostNet nav button so it remains visually balanced without eclipsing the parent button content
- stop the restore control from appearing highlighted by default by only shifting focus for keyboard interactions and swap its icon to a notification-themed glyph

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: Next.js swc "unknown field 'serverComponents'")*

------
https://chatgpt.com/codex/tasks/task_e_68e2fe8e0aac83238a835ed0c73d6cad