### PR TITLE
Improve trade route context display

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -4321,6 +4321,38 @@ function TradeRoutesPanel () {
     return formatRelativeTime(updated)
   }, [routeContext, selectedRoute])
 
+  const routeProfitMetrics = useMemo(() => {
+    if (!routeContext) return []
+
+    const metrics = []
+
+    const profitPerTrip = formatCredits(
+      selectedRoute?.summary?.profitPerTrip ?? selectedRoute?.profitPerTrip,
+      selectedRoute?.summary?.profitPerTripText || selectedRoute?.profitPerTripText
+    )
+    if (profitPerTrip && profitPerTrip !== '--') {
+      metrics.push({ key: 'trip', label: 'Profit / Trip', value: profitPerTrip })
+    }
+
+    const profitPerHour = formatCredits(
+      selectedRoute?.summary?.profitPerHour ?? selectedRoute?.profitPerHour,
+      selectedRoute?.summary?.profitPerHourText || selectedRoute?.profitPerHourText
+    )
+    if (profitPerHour && profitPerHour !== '--') {
+      metrics.push({ key: 'hour', label: 'Profit / Hour', value: profitPerHour })
+    }
+
+    const profitPerUnit = formatCredits(
+      selectedRoute?.summary?.profitPerUnit ?? selectedRoute?.profitPerUnit,
+      selectedRoute?.summary?.profitPerUnitText || selectedRoute?.profitPerUnitText
+    )
+    if (profitPerUnit && profitPerUnit !== '--') {
+      metrics.push({ key: 'unit', label: 'Profit / Tonne', value: profitPerUnit })
+    }
+
+    return metrics
+  }, [routeContext, selectedRoute])
+
   const buildMetricChipClasses = useCallback((variant = 'neutral') => {
     const classes = [styles.metricChip, styles.metricChipContext]
     const variantClass = METRIC_VARIANT_CLASS_MAP[variant] || METRIC_VARIANT_CLASS_MAP.neutral
@@ -4440,6 +4472,16 @@ function TradeRoutesPanel () {
             </div>
             {routeContext ? (
               <>
+                {routeProfitMetrics.length > 0 && (
+                  <div className={styles.tradeRouteContextProfitRow}>
+                    {routeProfitMetrics.map(metric => (
+                      <div key={`route-context-${metric.key}`} className={styles.tradeRouteContextProfitMetric}>
+                        <span className={styles.tradeRouteContextProfitLabel}>{metric.label}</span>
+                        <span className={styles.tradeRouteContextProfitValue}>{metric.value}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
                 <div className={styles.tradeRouteContextStations}>
                   <div className={`${styles.tradeRouteContextStationCard} ${styles.tradeRouteContextStationCardOrigin}`}>
                     <div className={styles.tradeRouteContextStationHeader}>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -1563,6 +1563,38 @@ button.terminalStatusPreview:focus-visible {
   color: var(--ghostnet-muted);
 }
 
+.tradeRouteContextProfitRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: clamp(0.75rem, 2.8vw, 1.65rem);
+  margin-top: clamp(0.85rem, 2.5vw, 1.2rem);
+}
+
+.tradeRouteContextProfitMetric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: clamp(0.8rem, 3vw, 1.1rem);
+  border-radius: 0.85rem;
+  background: color-mix(in srgb, var(--ghostnet-color-primary-dark) 48%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 30%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghostnet-color-primary) 16%, transparent);
+}
+
+.tradeRouteContextProfitLabel {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ghostnet-subdued);
+}
+
+.tradeRouteContextProfitValue {
+  font-size: clamp(1.35rem, 2.7vw, 1.85rem);
+  font-weight: 700;
+  color: var(--ghostnet-color-success);
+  line-height: 1.1;
+}
+
 .tradeRouteContextLabel {
   font-size: 0.8rem;
   letter-spacing: 0.08em;
@@ -1676,10 +1708,9 @@ button.terminalStatusPreview:focus-visible {
   justify-content: center;
   width: clamp(3.75rem, 7vw, 4.5rem);
   height: clamp(3.75rem, 7vw, 4.5rem);
-  border-radius: 1.1rem;
-  background: color-mix(in srgb, var(--ghostnet-color-primary) 32%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghostnet-color-primary-light) 55%, transparent),
-    0 0 1.5rem color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
   flex-shrink: 0;
 }
 
@@ -1773,7 +1804,7 @@ button.terminalStatusPreview:focus-visible {
 .tradeRouteContextConnectorLine {
   position: relative;
   flex: 1 1 auto;
-  height: 0.45rem;
+  min-height: clamp(2.5rem, 5vw, 3.2rem);
   border-radius: 999px;
   background: linear-gradient(90deg,
       color-mix(in srgb, var(--ghostnet-color-primary-light) 65%, transparent) 0%,
@@ -1782,8 +1813,8 @@ button.terminalStatusPreview:focus-visible {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 1.25rem;
-  overflow: hidden;
+  padding: 0.5rem clamp(1.1rem, 4vw, 1.6rem);
+  overflow: visible;
 }
 
 .tradeRouteContextConnectorPulse {
@@ -1853,7 +1884,7 @@ button.terminalStatusPreview:focus-visible {
   }
 
   .tradeRouteContextConnectorLine {
-    padding: 0 0.9rem;
+    padding: 0.45rem clamp(0.9rem, 4vw, 1.2rem);
   }
 
   .tradeRouteContextConnectorMetric {
@@ -1876,13 +1907,19 @@ button.terminalStatusPreview:focus-visible {
   }
 
   .tradeRouteContextConnectorLine {
-    padding: 0 0.6rem;
+    padding: 0.4rem clamp(0.6rem, 3vw, 0.9rem);
   }
 
   .tradeRouteContextConnectorMetric {
     font-size: 0.78rem;
     letter-spacing: 0.12em;
     padding: 0.18rem 0.55rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .tradeRouteContextProfitRow {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- surface profit per trip, hour, and tonne metrics in the trade route context panel
- remove decorative chrome from station icons and thicken the connector track so route distance remains visible
- update trade route context styling to emphasize the new profit row and maintain layout responsiveness

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js build cannot deserialize TransformOptions due to `serverComponents` field)*

------
https://chatgpt.com/codex/tasks/task_e_68e308a63dfc832385608a4e265e9f6b