### PR TITLE
Centralize GhostNet thematic copy

### DIFF
--- a/src/client/lib/ghostnet-addon.js
+++ b/src/client/lib/ghostnet-addon.js
@@ -1,0 +1,286 @@
+const DEFAULT_GHOSTNET_STRINGS = {
+  glyphs: {
+    greekSymbols: [
+      'alpha',
+      'beta',
+      'gamma',
+      'delta',
+      'epsilon',
+      'zeta',
+      'eta',
+      'theta',
+      'iota',
+      'kappa',
+      'lambda',
+      'mu',
+      'nu',
+      'xi',
+      'omicron',
+      'pi',
+      'rho',
+      'sigma',
+      'tau',
+      'upsilon',
+      'phi',
+      'chi',
+      'psi',
+      'omega'
+    ],
+    currencyGlyphs: [
+      '₿',
+      '¤',
+      'Ξ',
+      '§',
+      '₪',
+      '¥',
+      '₡',
+      '₢',
+      '₣',
+      '₤',
+      '₥',
+      '₦',
+      '₧',
+      '₨',
+      '₩',
+      '₫',
+      '€',
+      '£',
+      '₭',
+      '₮',
+      '₯',
+      '₰',
+      '₱',
+      '฿',
+      '₾'
+    ],
+    debitGlyphs: ['✖', '⛔', '⚠', '!', '−', '↓', '×', '⨯', '▾', '✕', '⛓']
+  },
+  terminal: {
+    transaction: {
+      vectorLabels: ['vector', 'conduit', 'relay', 'channel', 'flux', 'helix', 'circuit', 'vault'],
+      aliasWords: [
+        'Helios Bloom',
+        'Umbra Siphon',
+        'Specter Loom',
+        'Aurora Spindle',
+        'Perseus Vault',
+        'Nyx Cascade',
+        'Zenith Lattice',
+        'Dusk Prism'
+      ],
+      operations: [
+        'tribute splice',
+        'ledger weave',
+        'credit siphon',
+        'token handshake',
+        'cache imprint',
+        'mesh splice',
+        'flux injection',
+        'ledger braid'
+      ],
+      signalWords: ['pulse', 'cascade', 'flare', 'surge', 'ember', 'echo', 'flare', 'spark'],
+      sourcePrefixes: ['origin', 'source', 'channel', 'uplink', 'handoff', 'vector'],
+      reasonSuffixes: ['protocol', 'whisper', 'script', 'manifest', 'seeding', 'cipher', 'routine']
+    },
+    simulationBadges: ['SIMULATION MODE', 'TRAINING SCENARIO', 'SANDBOX RELAY'],
+    simulationTrails: [
+      'ghostfire rehearsal',
+      'tribute drill active',
+      'mesh rehearsal running',
+      'no live traffic detected'
+    ],
+    jackpotAsciiBanner: [
+      '══════════════════════════════════════════════════════════════════',
+      '   JACKPOT VECTOR LOCKED · CREDIT CASCADE INBOUND · TRIBUTE SURGE  ',
+      '══════════════════════════════════════════════════════════════════'
+    ],
+    jackpotSummaryIntros: [
+      'Encrypted cache recovered from',
+      'GhostNet dredged a tribute vault at',
+      'Covert intercept latched onto',
+      'Phantom escrow liberated within',
+      'Shadow broker ping returned from'
+    ],
+    jackpotSummaryTails: [
+      'Tribute surge rerouted to your ledger.',
+      'A million-token cascade detonates in your favour.',
+      'Ledger stabilised and humming with new resonance.',
+      'GhostNet celebrates with an ultraviolet windfall.',
+      'Balance spike recorded—enjoy the surge.'
+    ],
+    jackpotSwirlGlyphs: ['✶', '✷', '✺', '✹', '✸', '✧', '✦', '✩', '✪', '☄', '⚡', '⭑'],
+    fallbackLocations: ['Obsidian Relay', 'Nyx Archive', 'Perseus Node', 'Umbra Vault', 'Helios Array', 'Dusk Citadel'],
+    menace: {
+      alerts: [
+        (formatted) => `LEDGER IMBALANCE · ${formatted} TOKENS BELOW ZERO`,
+        (formatted) => `TRIBUTE DEFICIT DETECTED · ${formatted} TOKENS OUTSTANDING`,
+        (formatted) => `NEGATIVE CREDIT VECTOR · ${formatted} TOKENS OWED`
+      ],
+      echoes: [
+        () => 'GhostNet growls: repay your tribute or be assimilated.',
+        () => 'GhostNet whispers from the void: settle the debt before the mesh tightens.',
+        () => 'GhostNet watches. Tribute is expected. Delay invites eradication.'
+      ]
+    },
+    creditGlyphSymbols: [
+      '₿',
+      '¤',
+      'Ξ',
+      '§',
+      '₪',
+      '¥',
+      '₡',
+      '₢',
+      '₣',
+      '₤',
+      '₥',
+      '₦',
+      '₧',
+      '₨',
+      '₩',
+      '₫',
+      '€',
+      '£',
+      '₭',
+      '₮',
+      '₯',
+      '₰',
+      '₱',
+      '฿',
+      '₾',
+      '✧',
+      '✦',
+      '✺',
+      '✹',
+      '✶',
+      '✸',
+      '✳',
+      '⊚',
+      '⊛'
+    ],
+    creditCelebrationMessage: 'GhostNet intercept completed. Ledger flush inbound.'
+  },
+  exitTransition: {
+    dialog: {
+      ariaLabel: 'GhostNet disengaging',
+      title: 'ATLAS PROTOCOL // EXIT',
+      subtitle: 'Hard disconnect requested — securing GhostNet state.',
+      footnote: 'Residual spectral links will be locked by ATLAS if reconnection is attempted.'
+    },
+    logLines: [
+      {
+        text: 'Dumping volatile memory sectors',
+        status: 'FLUSHED',
+        tone: 'warning'
+      },
+      {
+        text: "Sanitizing ship's logs",
+        status: 'SCRUBBED',
+        tone: 'warning'
+      },
+      {
+        text: 'Kernel trace sweep',
+        status: 'CLEAR',
+        tone: 'info'
+      },
+      {
+        text: 'ATLAS protocol handshake',
+        status: 'CONFIRMED',
+        tone: 'success'
+      },
+      {
+        text: 'Terminating GhostNet process tree',
+        status: 'PURGED',
+        tone: 'warning'
+      }
+    ]
+  },
+  assimilation: {
+    dialog: {
+      ariaLabel: 'GhostNet assimilation in progress',
+      title: 'ATLAS PROTOCOL // LOCKDOWN',
+      subtitle: 'Intrusion confirmed — commandeering viewport to stabilise assimilation.',
+      footnote: 'Maintain focus on the console. ATLAS is shielding visual artifacts while GhostNet synchronises.'
+    },
+    alerts: [
+      {
+        text: 'Unauthorized GhostNet signal traced to active console',
+        status: 'LOCK',
+        tone: 'warning'
+      },
+      {
+        text: 'ATLAS rerouting control focus to assimilation viewport',
+        status: 'CLAIM',
+        tone: 'warning'
+      },
+      {
+        text: 'Spectral dampers amplifying misdirection channels',
+        status: 'JAM',
+        tone: 'info'
+      },
+      {
+        text: 'Telemetry loop saturating operator visual cortex',
+        status: 'FLOOD',
+        tone: 'warning'
+      },
+      {
+        text: 'Phantom command echoes deployed to mask load anomalies',
+        status: 'DECOY',
+        tone: 'warning'
+      }
+    ],
+    completion: {
+      forced: {
+        text: 'Interference detected. Forcing containment and masking residual artifacts.',
+        status: 'FORCE',
+        tone: 'warning'
+      },
+      stabilized: {
+        text: 'Viewport secured. GhostNet interface is stabilised for operator focus.',
+        status: 'SEALED',
+        tone: 'success'
+      }
+    }
+  }
+}
+
+function deepFreeze (value) {
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+
+  Object.keys(value).forEach((key) => {
+    const prop = value[key]
+    if (prop && typeof prop === 'object' && !Object.isFrozen(prop)) {
+      deepFreeze(prop)
+    }
+  })
+
+  return Object.freeze(value)
+}
+
+const ghostnetStrings = deepFreeze(DEFAULT_GHOSTNET_STRINGS)
+
+function resolvePath (path) {
+  if (!path) return undefined
+  const segments = Array.isArray(path) ? path : String(path).split('.').filter(Boolean)
+  let current = ghostnetStrings
+  for (const segment of segments) {
+    if (current == null) return undefined
+    current = current[segment]
+  }
+  return current
+}
+
+export function getGhostnetStrings (path, fallback) {
+  const value = resolvePath(path)
+  return value === undefined ? fallback : value
+}
+
+export function getGhostnetString (path, fallback = '') {
+  const value = resolvePath(path)
+  if (value == null) return fallback
+  return value
+}
+
+export default ghostnetStrings

--- a/src/client/lib/ghostnet-assimilation.js
+++ b/src/client/lib/ghostnet-assimilation.js
@@ -2,6 +2,7 @@ import {
   getAssimilationDurationSeconds,
   ASSIMILATION_DURATION_DEFAULT
 } from 'lib/ghostnet-settings'
+import { getGhostnetStrings, getGhostnetString } from './ghostnet-addon'
 
 let assimilationInProgress = false
 let assimilationStartTime = 0
@@ -148,7 +149,14 @@ function isInAssimilationOverlaySection (element) {
   return false
 }
 
-const ASSIMILATION_ALERT_LINES = [
+const DEFAULT_ASSIMILATION_DIALOG = {
+  ariaLabel: 'GhostNet assimilation in progress',
+  title: 'ATLAS PROTOCOL // LOCKDOWN',
+  subtitle: 'Intrusion confirmed — commandeering viewport to stabilise assimilation.',
+  footnote: 'Maintain focus on the console. ATLAS is shielding visual artifacts while GhostNet synchronises.'
+}
+
+const DEFAULT_ASSIMILATION_ALERT_LINES = [
   {
     text: 'Unauthorized GhostNet signal traced to active console',
     status: 'LOCK',
@@ -176,6 +184,23 @@ const ASSIMILATION_ALERT_LINES = [
   }
 ]
 
+const DEFAULT_ASSIMILATION_COMPLETION = {
+  forced: {
+    text: 'Interference detected. Forcing containment and masking residual artifacts.',
+    status: 'FORCE',
+    tone: 'warning'
+  },
+  stabilized: {
+    text: 'Viewport secured. GhostNet interface is stabilised for operator focus.',
+    status: 'SEALED',
+    tone: 'success'
+  }
+}
+
+const ASSIMILATION_ALERT_LINES = getGhostnetStrings('assimilation.alerts', DEFAULT_ASSIMILATION_ALERT_LINES)
+const ASSIMILATION_DIALOG_COPY = getGhostnetStrings('assimilation.dialog', DEFAULT_ASSIMILATION_DIALOG)
+const ASSIMILATION_COMPLETION_COPY = getGhostnetStrings('assimilation.completion', DEFAULT_ASSIMILATION_COMPLETION)
+
 let assimilationOverlayState = null
 let assimilationOverlayTimer = null
 
@@ -188,7 +213,10 @@ function buildAssimilationOverlay () {
   dialog.className = 'ghostnet-exit-dialog ghostnet-assimilation-dialog'
   dialog.setAttribute('role', 'alertdialog')
   dialog.setAttribute('aria-live', 'assertive')
-  dialog.setAttribute('aria-label', 'GhostNet assimilation in progress')
+  dialog.setAttribute(
+    'aria-label',
+    getGhostnetString('assimilation.dialog.ariaLabel', DEFAULT_ASSIMILATION_DIALOG.ariaLabel)
+  )
 
   const header = document.createElement('div')
   header.className = 'ghostnet-exit-dialog__header'
@@ -215,11 +243,11 @@ function buildAssimilationOverlay () {
 
   const title = document.createElement('p')
   title.className = 'ghostnet-exit-dialog__title'
-  title.textContent = 'ATLAS PROTOCOL // LOCKDOWN'
+  title.textContent = ASSIMILATION_DIALOG_COPY.title || DEFAULT_ASSIMILATION_DIALOG.title
 
   const subtitle = document.createElement('p')
   subtitle.className = 'ghostnet-exit-dialog__subtitle'
-  subtitle.textContent = 'Intrusion confirmed — commandeering viewport to stabilise assimilation.'
+  subtitle.textContent = ASSIMILATION_DIALOG_COPY.subtitle || DEFAULT_ASSIMILATION_DIALOG.subtitle
 
   headerText.appendChild(title)
   headerText.appendChild(subtitle)
@@ -248,7 +276,7 @@ function buildAssimilationOverlay () {
 
   const footnote = document.createElement('p')
   footnote.className = 'ghostnet-exit-dialog__footnote ghostnet-assimilation-dialog__footnote'
-  footnote.textContent = 'Maintain focus on the console. ATLAS is shielding visual artifacts while GhostNet synchronises.'
+  footnote.textContent = ASSIMILATION_DIALOG_COPY.footnote || DEFAULT_ASSIMILATION_DIALOG.footnote
 
   dialog.appendChild(header)
   dialog.appendChild(log)
@@ -1428,18 +1456,11 @@ export function initiateGhostnetAssimilation (callback) {
       // Ignore storage write issues
     }
 
-    const finalLine = forced
-      ? {
-          text: 'Interference detected. Forcing containment and masking residual artifacts.',
-          status: 'FORCE',
-          tone: 'warning'
-        }
-      : {
-          text: 'Viewport secured. GhostNet interface is stabilised for operator focus.',
-          status: 'SEALED',
-          tone: 'success'
-        }
-    freezeAssimilationOverlayMessage(finalLine)
+    const forcedLine = ASSIMILATION_COMPLETION_COPY.forced || DEFAULT_ASSIMILATION_COMPLETION.forced
+    const stabilizedLine =
+      ASSIMILATION_COMPLETION_COPY.stabilized || DEFAULT_ASSIMILATION_COMPLETION.stabilized
+    const finalLineTemplate = forced ? forcedLine : stabilizedLine
+    freezeAssimilationOverlayMessage({ ...finalLineTemplate })
 
     let viewportStabilized = false
     const stabilizeViewport = () => {

--- a/src/client/lib/ghostnet-exit-transition.js
+++ b/src/client/lib/ghostnet-exit-transition.js
@@ -1,4 +1,6 @@
-const TERMINAL_LINES = [
+import { getGhostnetStrings, getGhostnetString } from './ghostnet-addon'
+
+const DEFAULT_EXIT_LOG_LINES = [
   {
     text: 'Dumping volatile memory sectors',
     status: 'FLUSHED',
@@ -25,6 +27,16 @@ const TERMINAL_LINES = [
     tone: 'warning'
   }
 ]
+
+const DEFAULT_EXIT_DIALOG = {
+  ariaLabel: 'GhostNet disengaging',
+  title: 'ATLAS PROTOCOL // EXIT',
+  subtitle: 'Hard disconnect requested — securing GhostNet state.',
+  footnote: 'Residual spectral links will be locked by ATLAS if reconnection is attempted.'
+}
+
+const TERMINAL_LINES = getGhostnetStrings('exitTransition.logLines', DEFAULT_EXIT_LOG_LINES)
+const EXIT_DIALOG_COPY = getGhostnetStrings('exitTransition.dialog', DEFAULT_EXIT_DIALOG)
 
 const TYPE_INTERVAL = 14
 const INITIAL_LINE_DELAY = 120
@@ -69,7 +81,10 @@ function buildOverlay () {
   dialog.className = 'ghostnet-exit-dialog'
   dialog.setAttribute('role', 'alertdialog')
   dialog.setAttribute('aria-live', 'assertive')
-  dialog.setAttribute('aria-label', 'GhostNet disengaging')
+  dialog.setAttribute(
+    'aria-label',
+    getGhostnetString('exitTransition.dialog.ariaLabel', DEFAULT_EXIT_DIALOG.ariaLabel)
+  )
 
   const header = document.createElement('div')
   header.className = 'ghostnet-exit-dialog__header'
@@ -96,11 +111,11 @@ function buildOverlay () {
 
   const title = document.createElement('p')
   title.className = 'ghostnet-exit-dialog__title'
-  title.textContent = 'ATLAS PROTOCOL // EXIT'
+  title.textContent = EXIT_DIALOG_COPY.title || DEFAULT_EXIT_DIALOG.title
 
   const subtitle = document.createElement('p')
   subtitle.className = 'ghostnet-exit-dialog__subtitle'
-  subtitle.textContent = 'Hard disconnect requested — securing GhostNet state.'
+  subtitle.textContent = EXIT_DIALOG_COPY.subtitle || DEFAULT_EXIT_DIALOG.subtitle
 
   headerText.appendChild(title)
   headerText.appendChild(subtitle)
@@ -115,7 +130,7 @@ function buildOverlay () {
 
   const footnote = document.createElement('p')
   footnote.className = 'ghostnet-exit-dialog__footnote'
-  footnote.textContent = 'Residual spectral links will be locked by ATLAS if reconnection is attempted.'
+  footnote.textContent = EXIT_DIALOG_COPY.footnote || DEFAULT_EXIT_DIALOG.footnote
 
   dialog.appendChild(header)
   dialog.appendChild(log)

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -17,6 +17,7 @@ import getDistanceSeverityColor from '../lib/distance-colors'
 import { sanitizeInaraText } from '../lib/sanitize-inara-text'
 import { stationIconFromType, getStationIconName } from '../lib/station-icons'
 import { createMockCargoManifest, createMockCommodityValuations, generateMockTradeRoutes, NON_COMMODITY_KEYS, normaliseCommodityKey } from '../lib/ghostnet-mock-data'
+import { getGhostnetStrings, getGhostnetString } from '../lib/ghostnet-addon'
 import styles from './ghostnet.module.css'
 
 export const TERMINAL_PROMPT_TYPE_CLASS_MAP = {
@@ -4748,7 +4749,33 @@ function PristineMiningPanel () {
   )
 }
 
-const GREEK_SYMBOLS = ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta', 'theta', 'iota', 'kappa', 'lambda', 'mu', 'nu', 'xi', 'omicron', 'pi', 'rho', 'sigma', 'tau', 'upsilon', 'phi', 'chi', 'psi', 'omega']
+const DEFAULT_GREEK_SYMBOLS = [
+  'alpha',
+  'beta',
+  'gamma',
+  'delta',
+  'epsilon',
+  'zeta',
+  'eta',
+  'theta',
+  'iota',
+  'kappa',
+  'lambda',
+  'mu',
+  'nu',
+  'xi',
+  'omicron',
+  'pi',
+  'rho',
+  'sigma',
+  'tau',
+  'upsilon',
+  'phi',
+  'chi',
+  'psi',
+  'omega'
+]
+const GREEK_SYMBOLS = getGhostnetStrings('glyphs.greekSymbols', DEFAULT_GREEK_SYMBOLS)
 const TERMINAL_BUFFER = 36
 const TERMINAL_WINDOW = 7
 const TERMINAL_WINDOW_EXPANDED = 14
@@ -4800,15 +4827,41 @@ function generateCipherString (length = 48) {
   return Array.from({ length }).map(() => randomChoice(glyphs)).join('')
 }
 
-const CURRENCY_GLYPHS = [
-  '₿', '¤', 'Ξ', '§', '₪', '¥', '₡', '₢', '₣', '₤', '₥', '₦', '₧', '₨', '₩', '₫', '€', '£', '₭', '₮', '₯', '₰', '₱', '฿', '₾'
+const DEFAULT_CURRENCY_GLYPHS = [
+  '₿',
+  '¤',
+  'Ξ',
+  '§',
+  '₪',
+  '¥',
+  '₡',
+  '₢',
+  '₣',
+  '₤',
+  '₥',
+  '₦',
+  '₧',
+  '₨',
+  '₩',
+  '₫',
+  '€',
+  '£',
+  '₭',
+  '₮',
+  '₯',
+  '₰',
+  '₱',
+  '฿',
+  '₾'
 ]
+const CURRENCY_GLYPHS = getGhostnetStrings('glyphs.currencyGlyphs', DEFAULT_CURRENCY_GLYPHS)
 
 function generateCurrencyCascadeString (length = 96) {
   return Array.from({ length }).map(() => randomChoice(CURRENCY_GLYPHS)).join('')
 }
 
-const DEBIT_GLYPHS = ['✖', '⛔', '⚠', '!', '−', '↓', '×', '⨯', '▾', '✕', '⛓']
+const DEFAULT_DEBIT_GLYPHS = ['✖', '⛔', '⚠', '!', '−', '↓', '×', '⨯', '▾', '✕', '⛓']
+const DEBIT_GLYPHS = getGhostnetStrings('glyphs.debitGlyphs', DEFAULT_DEBIT_GLYPHS)
 
 function generateDebitGlyphString (length = 72) {
   const debitPool = [...DEBIT_GLYPHS, ...'XXXX----!!!!']
@@ -4950,35 +5003,90 @@ function generateGlitchString (length = 64) {
   return Array.from({ length }).map(() => randomChoice(glyphs)).join('')
 }
 
-const TRANSACTION_VECTOR_LABELS = ['vector', 'conduit', 'relay', 'channel', 'flux', 'helix', 'circuit', 'vault']
-const TRANSACTION_ALIAS_WORDS = ['Helios Bloom', 'Umbra Siphon', 'Specter Loom', 'Aurora Spindle', 'Perseus Vault', 'Nyx Cascade', 'Zenith Lattice', 'Dusk Prism']
-const TRANSACTION_OPERATIONS = ['tribute splice', 'ledger weave', 'credit siphon', 'token handshake', 'cache imprint', 'mesh splice', 'flux injection', 'ledger braid']
-const TRANSACTION_SIGNAL_WORDS = ['pulse', 'cascade', 'flare', 'surge', 'ember', 'echo', 'flare', 'spark']
-const TRANSACTION_SOURCE_PREFIXES = ['origin', 'source', 'channel', 'uplink', 'handoff', 'vector']
-const TRANSACTION_REASON_SUFFIXES = ['protocol', 'whisper', 'script', 'manifest', 'seeding', 'cipher', 'routine']
-const SIMULATION_BADGES = ['SIMULATION MODE', 'TRAINING SCENARIO', 'SANDBOX RELAY']
-const SIMULATION_TRAILS = ['ghostfire rehearsal', 'tribute drill active', 'mesh rehearsal running', 'no live traffic detected']
-const JACKPOT_ASCII_BANNER = [
+const DEFAULT_TRANSACTION_VECTOR_LABELS = ['vector', 'conduit', 'relay', 'channel', 'flux', 'helix', 'circuit', 'vault']
+const DEFAULT_TRANSACTION_ALIAS_WORDS = [
+  'Helios Bloom',
+  'Umbra Siphon',
+  'Specter Loom',
+  'Aurora Spindle',
+  'Perseus Vault',
+  'Nyx Cascade',
+  'Zenith Lattice',
+  'Dusk Prism'
+]
+const DEFAULT_TRANSACTION_OPERATIONS = [
+  'tribute splice',
+  'ledger weave',
+  'credit siphon',
+  'token handshake',
+  'cache imprint',
+  'mesh splice',
+  'flux injection',
+  'ledger braid'
+]
+const DEFAULT_TRANSACTION_SIGNAL_WORDS = ['pulse', 'cascade', 'flare', 'surge', 'ember', 'echo', 'flare', 'spark']
+const DEFAULT_TRANSACTION_SOURCE_PREFIXES = ['origin', 'source', 'channel', 'uplink', 'handoff', 'vector']
+const DEFAULT_TRANSACTION_REASON_SUFFIXES = ['protocol', 'whisper', 'script', 'manifest', 'seeding', 'cipher', 'routine']
+const DEFAULT_SIMULATION_BADGES = ['SIMULATION MODE', 'TRAINING SCENARIO', 'SANDBOX RELAY']
+const DEFAULT_SIMULATION_TRAILS = [
+  'ghostfire rehearsal',
+  'tribute drill active',
+  'mesh rehearsal running',
+  'no live traffic detected'
+]
+const DEFAULT_JACKPOT_ASCII_BANNER = [
   '══════════════════════════════════════════════════════════════════',
   '   JACKPOT VECTOR LOCKED · CREDIT CASCADE INBOUND · TRIBUTE SURGE  ',
   '══════════════════════════════════════════════════════════════════'
 ]
-const JACKPOT_SUMMARY_INTROS = [
+const DEFAULT_JACKPOT_SUMMARY_INTROS = [
   'Encrypted cache recovered from',
   'GhostNet dredged a tribute vault at',
   'Covert intercept latched onto',
   'Phantom escrow liberated within',
   'Shadow broker ping returned from'
 ]
-const JACKPOT_SUMMARY_TAILS = [
+const DEFAULT_JACKPOT_SUMMARY_TAILS = [
   'Tribute surge rerouted to your ledger.',
   'A million-token cascade detonates in your favour.',
   'Ledger stabilised and humming with new resonance.',
   'GhostNet celebrates with an ultraviolet windfall.',
   'Balance spike recorded—enjoy the surge.'
 ]
-const JACKPOT_SWIRL_GLYPHS = ['✶', '✷', '✺', '✹', '✸', '✧', '✦', '✩', '✪', '☄', '⚡', '⭑']
-const FALLBACK_LOCATIONS = ['Obsidian Relay', 'Nyx Archive', 'Perseus Node', 'Umbra Vault', 'Helios Array', 'Dusk Citadel']
+const DEFAULT_JACKPOT_SWIRL_GLYPHS = ['✶', '✷', '✺', '✹', '✸', '✧', '✦', '✩', '✪', '☄', '⚡', '⭑']
+const DEFAULT_FALLBACK_LOCATIONS = ['Obsidian Relay', 'Nyx Archive', 'Perseus Node', 'Umbra Vault', 'Helios Array', 'Dusk Citadel']
+
+const TRANSACTION_VECTOR_LABELS = getGhostnetStrings(
+  'terminal.transaction.vectorLabels',
+  DEFAULT_TRANSACTION_VECTOR_LABELS
+)
+const TRANSACTION_ALIAS_WORDS = getGhostnetStrings(
+  'terminal.transaction.aliasWords',
+  DEFAULT_TRANSACTION_ALIAS_WORDS
+)
+const TRANSACTION_OPERATIONS = getGhostnetStrings(
+  'terminal.transaction.operations',
+  DEFAULT_TRANSACTION_OPERATIONS
+)
+const TRANSACTION_SIGNAL_WORDS = getGhostnetStrings(
+  'terminal.transaction.signalWords',
+  DEFAULT_TRANSACTION_SIGNAL_WORDS
+)
+const TRANSACTION_SOURCE_PREFIXES = getGhostnetStrings(
+  'terminal.transaction.sourcePrefixes',
+  DEFAULT_TRANSACTION_SOURCE_PREFIXES
+)
+const TRANSACTION_REASON_SUFFIXES = getGhostnetStrings(
+  'terminal.transaction.reasonSuffixes',
+  DEFAULT_TRANSACTION_REASON_SUFFIXES
+)
+const SIMULATION_BADGES = getGhostnetStrings('terminal.simulationBadges', DEFAULT_SIMULATION_BADGES)
+const SIMULATION_TRAILS = getGhostnetStrings('terminal.simulationTrails', DEFAULT_SIMULATION_TRAILS)
+const JACKPOT_ASCII_BANNER = getGhostnetStrings('terminal.jackpotAsciiBanner', DEFAULT_JACKPOT_ASCII_BANNER)
+const JACKPOT_SUMMARY_INTROS = getGhostnetStrings('terminal.jackpotSummaryIntros', DEFAULT_JACKPOT_SUMMARY_INTROS)
+const JACKPOT_SUMMARY_TAILS = getGhostnetStrings('terminal.jackpotSummaryTails', DEFAULT_JACKPOT_SUMMARY_TAILS)
+const JACKPOT_SWIRL_GLYPHS = getGhostnetStrings('terminal.jackpotSwirlGlyphs', DEFAULT_JACKPOT_SWIRL_GLYPHS)
+const FALLBACK_LOCATIONS = getGhostnetStrings('terminal.fallbackLocations', DEFAULT_FALLBACK_LOCATIONS)
 
 function generateSwirlGlyphString (length = 48) {
   return Array.from({ length }).map(() => randomChoice([...JACKPOT_SWIRL_GLYPHS, ...CURRENCY_GLYPHS])).join('')
@@ -5149,23 +5257,62 @@ function generateAlertText () {
   return `${randomChoice(['ANOMALY', 'INTRUSION', 'SIGNAL'])} ${randomChoice(['DELTA', 'OMEGA', 'SIGMA'])} DETECTED · cascade ${randomInteger(1000, 9999)}`
 }
 
-const MENACE_ALERTS = [
+const DEFAULT_MENACE_ALERTS = [
   formatted => `LEDGER IMBALANCE · ${formatted} TOKENS BELOW ZERO`,
   formatted => `TRIBUTE DEFICIT DETECTED · ${formatted} TOKENS OUTSTANDING`,
   formatted => `NEGATIVE CREDIT VECTOR · ${formatted} TOKENS OWED`
 ]
 
-const MENACE_ECHOES = [
+const DEFAULT_MENACE_ECHOES = [
   () => 'GhostNet growls: repay your tribute or be assimilated.',
   () => 'GhostNet whispers from the void: settle the debt before the mesh tightens.',
   () => 'GhostNet watches. Tribute is expected. Delay invites eradication.'
 ]
 
-const CREDIT_GLYPH_SYMBOLS = [
-  '₿', '¤', 'Ξ', '§', '₪', '¥', '₡', '₢', '₣', '₤', '₥', '₦', '₧', '₨', '₩', '₪', '₫', '€', '£', '₭', '₮', '₯', '₰', '₱', '฿', '₾', '✧', '✦', '✺', '✹', '✶', '✸', '✳', '⊚', '⊛'
+const DEFAULT_CREDIT_GLYPH_SYMBOLS = [
+  '₿',
+  '¤',
+  'Ξ',
+  '§',
+  '₪',
+  '¥',
+  '₡',
+  '₢',
+  '₣',
+  '₤',
+  '₥',
+  '₦',
+  '₧',
+  '₨',
+  '₩',
+  '₫',
+  '€',
+  '£',
+  '₭',
+  '₮',
+  '₯',
+  '₰',
+  '₱',
+  '฿',
+  '₾',
+  '✧',
+  '✦',
+  '✺',
+  '✹',
+  '✶',
+  '✸',
+  '✳',
+  '⊚',
+  '⊛'
 ]
 
-const CREDIT_CELEBRATION_MESSAGE = 'GhostNet intercept completed. Ledger flush inbound.'
+const MENACE_ALERTS = getGhostnetStrings('terminal.menace.alerts', DEFAULT_MENACE_ALERTS)
+const MENACE_ECHOES = getGhostnetStrings('terminal.menace.echoes', DEFAULT_MENACE_ECHOES)
+const CREDIT_GLYPH_SYMBOLS = getGhostnetStrings('terminal.creditGlyphSymbols', DEFAULT_CREDIT_GLYPH_SYMBOLS)
+const CREDIT_CELEBRATION_MESSAGE = getGhostnetString(
+  'terminal.creditCelebrationMessage',
+  'GhostNet intercept completed. Ledger flush inbound.'
+)
 
 function generateCreditGlyphsConfig (count = 32) {
   const seed = Date.now().toString(36)


### PR DESCRIPTION
## Summary
- add a GhostNet add-on module that holds all thematic copy, glyphs, and dialog strings in one place with helper accessors
- refactor the assimilation and exit transition overlays to pull their messaging from the shared add-on defaults instead of in-file literals
- update the GhostNet page terminal generators to read all themed string arrays via the add-on so the UI references a single translation source

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: next-swc cannot deserialize TransformOptions due to unknown field `serverComponents` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3075e2ee48323b37f3c169963b8e7