### PR TITLE
Remove commodity icons from trade route rows

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -552,9 +552,6 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                 {outboundDemandState.text ? ` — ${outboundDemandState.text}` : ''}
               </span>
             ) : null}
-            <span className={styles.tradeRouteCommodityIcon}>
-              <CommodityIcon category={outboundInfo.buy?.category || outboundInfo.sell?.category || ''} size={24} />
-            </span>
             <span className={styles.tradeRouteCommodityName}>{renderValue(outboundCommodityDisplay)}</span>
             <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteHideMedium}`}>
               {renderValue(outboundPriceDisplay)}
@@ -568,9 +565,6 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                 {returnDemandState.text ? ` — ${returnDemandState.text}` : ''}
               </span>
             ) : null}
-            <span className={styles.tradeRouteCommodityIcon}>
-              <CommodityIcon category={returnInfo.buy?.category || returnInfo.sell?.category || ''} size={24} />
-            </span>
             <span className={styles.tradeRouteCommodityName}>{renderValue(returnCommodityDisplay)}</span>
             <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteHideMedium}`}>
               {renderValue(returnPriceDisplay)}

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -2136,12 +2136,12 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteCommodityRow {
   display: grid;
-  grid-template-columns: minmax(2.1rem, auto) minmax(0, 1fr) max-content;
+  grid-template-columns: minmax(0, 1fr) max-content;
   align-items: center;
   gap: 0.35rem;
   min-width: 0;
   position: relative;
-  padding: 0.4rem 0.6rem;
+  padding: 0.4rem 0.75rem;
   border-radius: 0.75rem;
   overflow: hidden;
   z-index: 0;
@@ -2200,20 +2200,12 @@ button.terminalStatusPreview:focus-visible {
   --trade-route-flow-fill: rgba(255, 95, 193, 0.52);
 }
 
-.tradeRouteCommodityIcon {
-  grid-column: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--ghostnet-accent);
-  justify-self: center;
-}
-
 .tradeRouteCommodityName {
-  grid-column: 2;
+  grid-column: 1;
   font-size: 1rem;
   font-weight: 600;
   color: var(--ghostnet-ink);
+  text-align: center;
   white-space: nowrap;
   overflow: hidden;
   min-width: 0;
@@ -2222,7 +2214,7 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tradeRouteCommodityPrice {
-  grid-column: 3;
+  grid-column: 2;
   color: var(--ghostnet-text-soft);
   font-size: 0.9rem;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- remove the commodity icon element from each trade route table row so only the text and price remain
- retune the commodity row grid layout and spacing to keep the name centered after removing the icon column

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: next_swc reports `unknown field serverComponents` while compiling core Next.js pages)*
- `npm run dev:web` *(fails with the same `serverComponents` deserialization error from next_swc)*

------
https://chatgpt.com/codex/tasks/task_e_68e309fc0c6483238ae3236fe554cc7f