### PR TITLE
Control INARA navigation visibility via settings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ When crafting prompts for CODEX agents to develop features or fix bugs, you MUST
 
 **Treat this as a non-negotiable requirement.** If you ever return a prompt in any other format, it will be considered a critical error.
 
-All feature mapping, shortnames, and endpoint details for ICARUS Terminal and GhostNet are now maintained in `FEATURES.md` in the project root. All CODEX agents MUST keep `FEATURES.md` up to date with ANY changes to features, endpoints, or feature mappings. If you add, remove, or modify a feature, update `FEATURES.md` immediately. Do NOT document features elsewhere—always refer to and update `FEATURES.md`.
+All feature mapping, shortnames, and endpoint details for ICARUS Terminal and INARA are now maintained in `FEATURES.md` in the project root. All CODEX agents MUST keep `FEATURES.md` up to date with ANY changes to features, endpoints, or feature mappings. If you add, remove, or modify a feature, update `FEATURES.md` immediately. Do NOT document features elsewhere—always refer to and update `FEATURES.md`.
 
 See [`FEATURES.md`](../FEATURES.md) for the current feature mapping and details.
 
@@ -25,7 +25,7 @@ See [`FEATURES.md`](../FEATURES.md) for the current feature mapping and details.
 ICARUS Terminal is a free, immersive, context-sensitive companion app and second screen interface for Elite Dangerous. It provides:
 - Real-time ship, cargo, mission, and system intelligence by ingesting Elite Dangerous journal files and community data (GHOSTNET, EDSM, EDDB).
 - A multi-platform UI (Windows-native, browser, touch devices) designed for quick access to trade routes, mining leads, ship outfitting, and more.
-- Features like trade route scouting, cargo valuation, mining mission radar, and pristine ring finder, all surfaced in a unified GhostNet page.
+- Features like trade route scouting, cargo valuation, mining mission radar, and pristine ring finder, all surfaced in a unified INARA page.
 
 **Goal:** Help commanders make smarter decisions in-game by surfacing actionable, up-to-date intel and context-sensitive overlays, while maintaining a responsive, visually cohesive experience.
 
@@ -33,8 +33,8 @@ ICARUS Terminal is a free, immersive, context-sensitive companion app and second
 - **Three main components:**
   - `src/app/` (Go): Windows launcher, window management, updater, save-game discovery.
   - `src/service/` (Node): Backend, ingests Elite Dangerous journal files, normalizes telemetry, exposes HTTP/WebSocket APIs.
-  - `src/client/` (Next/React): Browser UI for ICARUS/GhostNet, with shared layout primitives in `components/` and main views in `pages/`.
-- **GhostNet page** is the primary UI surface for enhancements. Legacy "Icarus" code should be minimally changed unless required for GhostNet.
+  - `src/client/` (Next/React): Browser UI for ICARUS/INARA, with shared layout primitives in `components/` and main views in `pages/`.
+- **INARA page** is the primary UI surface for enhancements. Legacy "Icarus" code should be minimally changed unless required for INARA.
 - **Data flow:** Game logs → Node service → WebSocket/HTTP → React UI. Use broadcast events and request/response handlers for communication.
 
 ## Developer Workflow
@@ -52,12 +52,12 @@ ICARUS Terminal is a free, immersive, context-sensitive companion app and second
 - **Screenshots:** Use Playwright in a `browser_container` for UI verification. Always reference screenshot paths in notes.
 
 ## Project Conventions
-- **GhostNet theming:**
+- **INARA theming:**
   - Use tokens from `src/client/css/pages/ghostnet.css`.
   - Royal purple (`#5D2EFF`) is primary; gradients, neutrals, and accents follow palette rules in `AGENTS.md`.
 - **UI composition:**
   - Use shared primitives (`SectionFrame`, `SectionHeader`, table shells) from `src/client/components/`.
-  - Data tables must use GhostNet shells, not be nested in section frames.
+  - Data tables must use INARA shells, not be nested in section frames.
   - Table rows open full-page views, never expand inline.
 - **Feature mapping:**
   - See `AGENTS.md` for shortnames (e.g., ROUTESCOUT, CARGO_LEDGER) and API endpoints.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Your primary role is to craft prompts for CODEX agents to develop features and f
 
 All other conventions and requirements apply. You must also ensure your instructions cover the following:
 
-- The canonical list of features, shortnames, and their mapping for ICARUS Terminal and GhostNet is now maintained in `FEATURES.md` in the project root.
+- The canonical list of features, shortnames, and their mapping for ICARUS Terminal and INARA is now maintained in `FEATURES.md` in the project root.
 - All CODEX agents MUST keep `FEATURES.md` up to date with ANY changes to features, endpoints, or feature mappings. If you add, remove, or modify a feature, update `FEATURES.md` immediately. Do NOT document features in `AGENTS.md`—always refer to and update `FEATURES.md`.
 
 See [`FEATURES.md`](./FEATURES.md) for the current feature mapping and details.
@@ -33,7 +33,7 @@ See [`FEATURES.md`](./FEATURES.md) for the current feature mapping and details.
   3. Implement the adjustments, refresh the app, and capture another screenshot.
   4. Repeat until the screenshots demonstrate a clear, polished improvement that satisfies the original ask.
 - Summarize the outcome of this iterative loop in your final notes by highlighting what changed between the first and final captures and why the result addresses the user's needs.
-- **GhostNet screenshot workflow checklist:**
+- **INARA screenshot workflow checklist:**
   1. Run `npm test -- --runInBand --config jest.config.js` (serial mode keeps Jest aligned with `jest.config.js`). The repo includes the optional dependency `@next/swc-linux-x64-gnu@12.3.4` so the build will not fail on missing SWC binaries.
   2. Run `npm run build:client` to regenerate the static export required for screenshots.
   3. In a dedicated shell start one of the preview servers above.
@@ -87,43 +87,43 @@ See `resources/mock-game-data/events/README.md` for details and rationale.
 - Cross-platform headless builds land in `dist/` via `npm run build:standalone`. Run with `--help` for usage details and keep binaries in-place on Linux so bundled assets resolve.
 - Treat `src/app` (Go launcher), `src/service` (Node backend), and `src/client` (Next/React UI) as separate concerns; the launcher expects the service binary in the same directory or it will exit on startup.
 
-## GhostNet theming & asset references
+## INARA theming & asset references
 - Primary surfaces live in `src/client/pages/ghostnet.js` and `src/client/pages/ghostnet.module.css`; the hero animation draws from `src/client/public/ghostnet/signal-mesh.svg`.
 - Jest + Testing Library smoke tests in `src/client/__tests__/ghostnet.test.js` validate accessibility affordances. Extend mocks in `test/setupTests.js` if you add socket- or browser-dependent behaviors.
 - Maintain the Ghost Net copy and animation rhythm introduced during the rebrand. Hero tickers pull from `tickerMessages` in `GhostnetPage`; update both arrays to keep the loop seamless.
 - When undoing Ghost Net changes, delete `ghostnet.module.css`, the asset folder (`src/client/public/ghostnet/`), and associated imports, then remove the Jest configuration and dependencies if the testing stack is no longer desired.
 - Respect the palette guidance below—new CSS tokens must document their intent and derive from `src/client/css/pages/ghostnet.css` rather than introducing bespoke colors.
 
-## GhostNet implementation principles
-- Treat the **GhostNet** page as the sole surface for intentional UI enhancements. References to "the app" in these instructions should be interpreted as the GhostNet page unless a task explicitly states otherwise.
-- Keep modifications to the legacy "Icarus" experience as lean as possible while still enabling GhostNet to function. Prefer composing new behavior around existing Icarus code instead of overhauling it.
-- Maintain a unified visual language by reusing GhostNet's established color palette across any UI you touch.
+## INARA implementation principles
+- Treat the **INARA** page as the sole surface for intentional UI enhancements. References to "the app" in these instructions should be interpreted as the INARA page unless a task explicitly states otherwise.
+- Keep modifications to the legacy "Icarus" experience as lean as possible while still enabling INARA to function. Prefer composing new behavior around existing Icarus code instead of overhauling it.
+- Maintain a unified visual language by reusing INARA's established color palette across any UI you touch.
 - Ensure every UI adjustment remains responsive and accessible across a wide range of device sizes.
 - Where it adds value, introduce tasteful animations and micro-interactions to help the interface feel vibrant and alive.
-- Mirror the structural patterns and layout conventions of other Icarus pages so the product feels cohesive, while still honoring GhostNet's unique identity.
-- GhostNet pages must never render beneath the secondary navigation rail—always supply navigation items through the `<Panel>` component so it applies the `layout__panel--secondary-navigation` spacing instead of mounting `PanelNavigation` manually.
-- Keep data tables outside of `SectionFrame` containers; tables should rely on GhostNet table shells (`dataTableContainer`, `dataTable`) for structure instead of being nested inside section frames.
-- Standardize list presentations around the shared GhostNet table wrappers (`DataTableShell` and companions). When building a new table or refreshing an existing one, slot headers and rows into these shells so scroll areas, padding, empty states, and ARIA wiring remain uniform across panels.
+- Mirror the structural patterns and layout conventions of other Icarus pages so the product feels cohesive, while still honoring INARA's unique identity.
+- INARA pages must never render beneath the secondary navigation rail—always supply navigation items through the `<Panel>` component so it applies the `layout__panel--secondary-navigation` spacing instead of mounting `PanelNavigation` manually.
+- Keep data tables outside of `SectionFrame` containers; tables should rely on INARA table shells (`dataTableContainer`, `dataTable`) for structure instead of being nested inside section frames.
+- Standardize list presentations around the shared INARA table wrappers (`DataTableShell` and companions). When building a new table or refreshing an existing one, slot headers and rows into these shells so scroll areas, padding, empty states, and ARIA wiring remain uniform across panels.
 - Table rows must never expand inline like a drawer. Selecting a row should always open a dedicated full-page view in the workspace, mirroring the behavior on the Find Trade Routes page. This ensures a clean experience on smaller displays.
-- Before introducing a new layout or page, inspect existing GhostNet surfaces and lift their structure directly—copy the baseline layout (navigation placement, section frames, typographic hierarchy, spacing rhythm) and adjust only the dynamic content. When in doubt, start from an existing component file and refactor it into shared primitives instead of authoring novel markup.
+- Before introducing a new layout or page, inspect existing INARA surfaces and lift their structure directly—copy the baseline layout (navigation placement, section frames, typographic hierarchy, spacing rhythm) and adjust only the dynamic content. When in doubt, start from an existing component file and refactor it into shared primitives instead of authoring novel markup.
 - Favor composing UI from the shared layout primitives in `src/client/components` (e.g., `SectionFrame`, `SectionHeader`, table shells, detail drawers). If a new view needs a combination that does not yet exist, build the combination as a reusable component and place it alongside its peers so future pages can inherit it.
 - Consistency of data presentation is critical: station summaries should always follow the pattern `Icon → Name → Key Metrics → Secondary metadata`. Expanders and drawers must surface the same canonical fields (`status`, `ownership`, `location`, `throughput`, and `alerts`) in the same order across the app.
-- GhostNet now exposes shared primitives for these summaries—compose station surfaces with `StationSummary` and commodity views with `CommoditySummary` so iconography, metric stacks, and accessibility copy stay synchronized. If a view needs additional metadata, extend the shared component API instead of forking markup in-page.
-- Avoid ad-hoc styling or bespoke CSS for one-off views. Extend the GhostNet CSS tokens or shared utility classes, and document any new token additions with rationale and usage guidance.
+- INARA now exposes shared primitives for these summaries—compose station surfaces with `StationSummary` and commodity views with `CommoditySummary` so iconography, metric stacks, and accessibility copy stay synchronized. If a view needs additional metadata, extend the shared component API instead of forking markup in-page.
+- Avoid ad-hoc styling or bespoke CSS for one-off views. Extend the INARA CSS tokens or shared utility classes, and document any new token additions with rationale and usage guidance.
 
 ### Palette hygiene
-- Keep the GhostNet palette constrained to the core tokens defined in `src/client/css/pages/ghostnet.css`.
+- Keep the INARA palette constrained to the core tokens defined in `src/client/css/pages/ghostnet.css`.
 - When a design needs subtle variation, derive it with opacity or other modifiers from the shared tokens instead of introducing new hex values.
 - Avoid dumping long lists of bespoke color variables into module files; rely on the shared palette for consistency and easier maintenance.
 - Declare each palette token with a single color format (hex **or** rgb, not both) and document its primary usage with a block comment so future contributors understand the intent.
 - Keep gradients lightweight—prefer blending a small number of shared tokens with transparency rather than stacking many distinct color stops.
 
-### GhostNet Purple Theme Specification
-- **Primary hue:** GhostNet surfaces should lean on a rich royal purple (`#5D2EFF`) for primary actions, interactive accents, and key highlights.
+### INARA Purple Theme Specification
+- **Primary hue:** INARA surfaces should lean on a rich royal purple (`#5D2EFF`) for primary actions, interactive accents, and key highlights.
 - **Gradient treatments:** When gradients are needed, blend from the primary hue into a deeper indigo (`#2A0E82`) and finish with a soft ultraviolet (`#8C5CFF`) to preserve depth.
 - **Neutrals:** Use a charcoal base (`#0D0B1A`) for backgrounds, `#1C1633` for elevated surfaces, and `#F5F1FF` for high-contrast text and iconography.
 - **Supporting accents:** Emerald (`#29F3C3`) is the sanctioned success color, while warnings should leverage warm magenta (`#FF5FC1`); avoid introducing additional accent families.
-- **Typography:** Headings remain in the existing GhostNet display face, but always tinted `#F5F1FF`; body copy should default to `rgba(245, 241, 255, 0.84)` to soften contrast on dark surfaces.
+- **Typography:** Headings remain in the existing INARA display face, but always tinted `#F5F1FF`; body copy should default to `rgba(245, 241, 255, 0.84)` to soften contrast on dark surfaces.
 - **Shadows & glows:** Apply atmospheric glows using `rgba(93, 46, 255, 0.45)` with a 24px blur, and keep elevation shadows subtle (`rgba(13, 11, 26, 0.55)` at 12px blur, 0 offset).
 - **Borders & dividers:** Use semi-transparent borders `rgba(140, 92, 255, 0.35)` for cards or panels; dividers should sit at `rgba(245, 241, 255, 0.16)`.
 - **Interactive states:** Hover states brighten the primary hue by 8%, focus rings use a 2px outline of `#29F3C3`, and pressed states darken to `#2A0E82` with the glow removed.
@@ -132,16 +132,16 @@ See `resources/mock-game-data/events/README.md` for details and rationale.
 ## Repository orientation
 - **`src/app/` (Go)** – Windows-native bootstrapper responsible for creating the launcher/terminal window, spawning the Node service, and monitoring lifecycle state. Keep this layer focused on window management, updater orchestration, and save-game directory discovery (`main.go`, `execute.go`, `updater.go`).
 - **`src/service/` (Node)** – Backend process that tails Elite Dangerous journal files, normalizes live JSON telemetry, and exposes both HTTP endpoints and a WebSocket bridge. `main.js` wires up static asset serving, dev proxying, and the WebSocket server; `lib/events.js` binds log readers and publishes broadcast events.
-- **`src/client/` (Next/React)** – Browser UI for ICARUS/GhostNet. Components in `components/` provide shared layout primitives, while `pages/` contain route-specific views (including the monolithic `ghostnet.js`). CSS modules live alongside their consumers.
-- **`src/service/lib/event-handlers/`** – Domain-specific modules that respond to ingested journal/state changes. They form the authoritative source for Commander/system data queried by GhostNet panels (e.g., ship inventory, mission caches, route lookup helpers).
+- **`src/client/` (Next/React)** – Browser UI for ICARUS/INARA. Components in `components/` provide shared layout primitives, while `pages/` contain route-specific views (including the monolithic `ghostnet.js`). CSS modules live alongside their consumers.
+- **`src/service/lib/event-handlers/`** – Domain-specific modules that respond to ingested journal/state changes. They form the authoritative source for Commander/system data queried by INARA panels (e.g., ship inventory, mission caches, route lookup helpers).
 - **`resources/mock-game-data/`** – Development fixtures consumed when the service cannot reach real journal directories. Respect the `USING_MOCK_DATA` guard so the UI clearly communicates when mock values drive results.
 
-## GhostNet feature mapping
+## INARA feature mapping
 
 
 ## Feature Mapping Reference
 
-The canonical list of features, shortnames, and their mapping for ICARUS Terminal and GhostNet has been moved to `FEATURES.md` in the project root.
+The canonical list of features, shortnames, and their mapping for ICARUS Terminal and INARA has been moved to `FEATURES.md` in the project root.
 
 **IMPORTANT:** All CODEX agents MUST keep `FEATURES.md` up to date with ANY changes to features, endpoints, or feature mappings. If you add, remove, or modify a feature, update `FEATURES.md` immediately. Do NOT document features here—always refer to and update `FEATURES.md`.
 
@@ -154,7 +154,7 @@ See [`FEATURES.md`](./FEATURES.md) for the current feature mapping and details.
   2. Register an entry in `ICARUS_EVENTS` within `events.js` to translate one or more journal `event` names into higher-level broadcasts. Keep the `loadingInProgress` guard so the initial replay does not flood the UI.
 - **Request/response handlers.** Expose pull-based APIs by adding functions to `eventHandlers` via `EventHandlers.getEventHandlers()`. These respond to `sendEvent('handlerName')` calls from the client. Prefer returning plain JSON—complex formatting belongs client-side.
 - **Client listeners.** Components subscribe to broadcasts by calling `eventListener('<eventName>', callback)` from `src/client/lib/socket.js`. Always clean up subscriptions in the `useEffect` teardown to prevent duplicate handlers when panels remount. Use `useSocket()` if you need connection status (e.g., disable refresh actions until `ready === true`).
-- **Triggering refreshes.** Let journal events drive updates whenever possible. For example, `TradeRoutesPanel` refreshes ship-derived filters whenever `SHIP_STATUS_UPDATE_EVENTS` arrives, and `useSystemSelector` refetches the commander's location on `Location`/`FSDJump`. When adding new GhostNet features, decide whether to listen for an existing broadcast or to extend the service layer with a new broadcast tailored to your feature.
+- **Triggering refreshes.** Let journal events drive updates whenever possible. For example, `TradeRoutesPanel` refreshes ship-derived filters whenever `SHIP_STATUS_UPDATE_EVENTS` arrives, and `useSystemSelector` refetches the commander's location on `Location`/`FSDJump`. When adding new INARA features, decide whether to listen for an existing broadcast or to extend the service layer with a new broadcast tailored to your feature.
 - **Development ergonomics.** The client automatically queues outbound `sendEvent` calls while disconnected. Avoid manual retry loops—trust the socket layer. When mocking, use the `ghostnetUseMockData` flag so production builds continue to hit the live service.
 
 ## Scope

--- a/CURRENCY.md
+++ b/CURRENCY.md
@@ -1,8 +1,8 @@
-# GhostNet Token Ledger Overview
+# INARA Token Ledger Overview
 
 ## Local ledger implementation
 
-The GhostNet/ICARUS service process now instantiates a `TokenLedger` singleton on boot. The ledger:
+The INARA/ICARUS service process now instantiates a `TokenLedger` singleton on boot. The ledger:
 
 - Persists balance snapshots at `~/.config/Icarus/tokens/ledger.json` and appends transactions to `transactions.jsonl` in the same directory.
 - Supports debits (`recordSpend`) and credits (`recordEarn`) while allowing negative balances. Each transaction entry contains `{ id, type, amount, delta, balance, timestamp, metadata, mode, remote }`.
@@ -25,8 +25,8 @@ The remote mirror is only activated when `ICARUS_TOKENS_REMOTE_MODE=MIRROR` **an
 
 ## Client behaviour
 
-- The GhostNet console footer now renders the live token balance, a status badge describing whether the ledger is simulated or mirrored, and a grant button that triggers a simulated jackpot payout via the `triggerJackpot` socket event. The helper multiplies a random base credit by the jackpot multiplier so testers can rehearse the full celebration sequence on demand.
-- When the balance drops below zero, GhostNet injects “menacing” warnings into the console feed to remind the commander that tribute is overdue.
+- The INARA console footer now renders the live token balance, a status badge describing whether the ledger is simulated or mirrored, and a grant button that triggers a simulated jackpot payout via the `triggerJackpot` socket event. The helper multiplies a random base credit by the jackpot multiplier so testers can rehearse the full celebration sequence on demand.
+- When the balance drops below zero, INARA injects “menacing” warnings into the console feed to remind the commander that tribute is overdue.
 - Balance updates arrive via the existing `ghostnetTokensUpdated` broadcast; the UI also polls `getTokenBalance` on page load.
 
 ## Planned remote service API

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,14 +1,14 @@
 # ICARUS Terminal – Features Reference
 
-This file contains the canonical list of features, shortnames, and their mapping for the ICARUS Terminal and GhostNet. All CODEX agents MUST keep this file up to date with ANY changes to features, endpoints, or feature mappings. If you add, remove, or modify a feature, update this file immediately.
+This file contains the canonical list of features, shortnames, and their mapping for the ICARUS Terminal and INARA. All CODEX agents MUST keep this file up to date with ANY changes to features, endpoints, or feature mappings. If you add, remove, or modify a feature, update this file immediately.
 
-## GhostNet Feature Mapping
+## INARA Feature Mapping
 
 
 ## Trade Route Table Modular Display & Responsive Grid
 
 
-GhostNet now uses a grid-based, multi-row modular display for trade route tables, engineered for maximum data density and minimal whitespace. Each table row is split into multiple display rows for stations, commodities, and profit, using a tight, stable grid layout:
+INARA now uses a grid-based, multi-row modular display for trade route tables, engineered for maximum data density and minimal whitespace. Each table row is split into multiple display rows for stations, commodities, and profit, using a tight, stable grid layout:
 
 - **Stations:** Displayed in two stacked rows per cell, with icon, station name, distance to station, system, reputation, and distance to system. All text and metrics are tightly aligned left-to-right, with minimal padding and whitespace. Columns scale and overflow content is hidden (never truncated or wrapped), so only the most important info remains visible as space runs out.
 - **Commodities:** Displayed in two stacked rows per cell, with icon, commodity name, price, demand, and directional arrows. Layout is compact, with all fields lined up precisely and excess info hidden responsively.
@@ -26,34 +26,34 @@ GhostNet now uses a grid-based, multi-row modular display for trade route tables
 
 This layout is designed to surface as much actionable data as possible, with tight, compact rows and precise text alignment. All legacy granular columns and truncation logic have been removed in favor of dense, modular displays.
 
-Use these shortnames when coordinating GhostNet work:
+Use these shortnames when coordinating INARA work:
 
-- **ROUTESCOUT – Trade Route Intelligence.** `TradeRoutesPanel` combines auto-detected ship stats (cargo capacity + landing pad size pulled via `getShipStatus`) with manual filters before calling `/api/ghostnet-trade-routes`. The panel normalizes GhostNet HTML into structured legs, exposes inline sort/filter controls, and surfaces contextual overlays summarizing faction relations and station metadata. Respect the `SHIP_STATUS_UPDATE_EVENTS` set when refreshing ship-derived filters and debounce outbound fetches when mutating filter state (`ghostnet.js`).
-- **CARGO_LEDGER – Cargo Hold Valuation.** `CargoHoldPanel` pulls the live ship loadout and cargo inventory, derives a memoized cargo fingerprint, and requests `/api/ghostnet-commodity-values` to merge GhostNet submissions with in-game journal market logs. The valuation response contains GhostNet and local market health indicators; present both statuses in the UI so commanders can reconcile stale remote intel. Cache-heavy helpers (`isSameMarketEntry`, `mergeInventoryRows`) ensure we do not thrash the DOM when only metadata shifts. Keep the utilisation meter at the top of the panel in sync with the ship's capacity so miners can instantly judge how much space remains.
-- **MISSION_BEACON – Mining Mission Radar.** `MissionsPanel` watches the current system via `useSystemSelector`, hydrates faction reputation via `/api/faction-standings`, and caches the last eight system lookups in `localStorage`. GhostNet fetches stream in via `/api/ghostnet-missions` POST requests, automatically downgrading to cached payloads on errors. Maintain the status machine (`idle`, `loading`, `empty`, `error`, `populated`) so accessibility strings stay accurate.
-- **PRISTINE_TRACKER – Ring Prospecting.** `PristineMiningPanel` (lower in `ghostnet.js`) cross-references GhostNet pristine mining listings with ICARUS system-map intel (`SystemMapProvider`). Rows expand into detail drawers populated via `NavigationInspectorPanel`, so ensure new fields are wired through that provider rather than injecting ad-hoc fetches. Keep an eye on `animateTableEffect()` hooks to preserve the neon scan reveal.
-- **RADIO_RELAY – Pirate Radio Broadcast Deck.** `PirateRadioPanel` (`src/client/components/ghostnet/pirate-radio.js`) hydrates the underground audio stream through `sendEvent('getPirateRadioPlaylist')`, wires directory management to `setPirateRadioDirectories`, and triggers rescans with `rescanPirateRadio`. It listens for `pirateRadioUpdate`/`pirateRadioDirectoriesUpdated` broadcasts to stay in sync and leans on the GhostNet panel shell styles so the navigation rail spacing remains consistent. Preserve the autoplay-on-ended flow when extending the deck so broadcasts continue looping seamlessly.
+- **ROUTESCOUT – Trade Route Intelligence.** `TradeRoutesPanel` combines auto-detected ship stats (cargo capacity + landing pad size pulled via `getShipStatus`) with manual filters before calling `/api/ghostnet-trade-routes`. The panel normalizes INARA HTML into structured legs, exposes inline sort/filter controls, and surfaces contextual overlays summarizing faction relations and station metadata. Respect the `SHIP_STATUS_UPDATE_EVENTS` set when refreshing ship-derived filters and debounce outbound fetches when mutating filter state (`ghostnet.js`).
+- **CARGO_LEDGER – Cargo Hold Valuation.** `CargoHoldPanel` pulls the live ship loadout and cargo inventory, derives a memoized cargo fingerprint, and requests `/api/ghostnet-commodity-values` to merge INARA submissions with in-game journal market logs. The valuation response contains INARA and local market health indicators; present both statuses in the UI so commanders can reconcile stale remote intel. Cache-heavy helpers (`isSameMarketEntry`, `mergeInventoryRows`) ensure we do not thrash the DOM when only metadata shifts. Keep the utilisation meter at the top of the panel in sync with the ship's capacity so miners can instantly judge how much space remains.
+- **MISSION_BEACON – Mining Mission Radar.** `MissionsPanel` watches the current system via `useSystemSelector`, hydrates faction reputation via `/api/faction-standings`, and caches the last eight system lookups in `localStorage`. INARA fetches stream in via `/api/ghostnet-missions` POST requests, automatically downgrading to cached payloads on errors. Maintain the status machine (`idle`, `loading`, `empty`, `error`, `populated`) so accessibility strings stay accurate.
+- **PRISTINE_TRACKER – Ring Prospecting.** `PristineMiningPanel` (lower in `ghostnet.js`) cross-references INARA pristine mining listings with ICARUS system-map intel (`SystemMapProvider`). Rows expand into detail drawers populated via `NavigationInspectorPanel`, so ensure new fields are wired through that provider rather than injecting ad-hoc fetches. Keep an eye on `animateTableEffect()` hooks to preserve the neon scan reveal.
+- **RADIO_RELAY – Pirate Radio Broadcast Deck.** `PirateRadioPanel` (`src/client/components/ghostnet/pirate-radio.js`) hydrates the underground audio stream through `sendEvent('getPirateRadioPlaylist')`, wires directory management to `setPirateRadioDirectories`, and triggers rescans with `rescanPirateRadio`. It listens for `pirateRadioUpdate`/`pirateRadioDirectoriesUpdated` broadcasts to stay in sync and leans on the INARA panel shell styles so the navigation rail spacing remains consistent. Preserve the autoplay-on-ended flow when extending the deck so broadcasts continue looping seamlessly.
 - **UPLINK_FEED – Ambient Telemetry Overlay.** The uplink console (`ghostnet.js` final sections) rotates pseudo-telemetry headlines, user-configurable cadence controls, and integrates with `ghostnetTickerMessages`. Additions should honor the animation timings and respect the reduced-motion guard.
 - **ASSIMILATION_GATE – Page Shell & Arrival Sequence.** `GhostnetPage` toggles the global theme class, triggers arrival animations, and manages top-level tab state. Extend it via composition—drop new sections into the existing `<Panel>` layout so navigation/ARIA wiring continues to work.
 - **TAB_SHELL – Tab Navigation.** The `ghostnetTabs` array describes the tab structure and icons; updates must keep the keyboard handlers (`handleTabKeyPress`) intact. When adding tabs, double-check breakpoints so the secondary nav remains scrollable on narrow widths.
 - _The former Engineering Opportunities manifest and related `/ghostnet/engineering` routes have been removed; no active feature mapping remains for this surface._
 - **SEARCH_PLACEHOLDER / OUTFITTING_PLACEHOLDER.** These stub routes keep routing hooks hot while conveying that the surfaces are intentionally disabled. If you activate one, migrate the placeholder copy into a dismissible announcement rather than deleting it outright.
-- **API_COMMODITY_CACHE.** `/api/ghostnet-commodity-values` orchestrates commodity lookups. It uses `ingestJournalMarketEvent` to merge Commander market journals with GhostNet caches, writes cache hits to disk, and exposes cache age metadata. Always sanitize inbound commodity names—see `normalizeCommodityName` helpers before hitting remote endpoints.
-- **API_ROUTE_SCRAPER.** `/api/ghostnet-trade-routes` validates filters against a whitelist, scrapes GhostNet HTML via `cheerio`, and calculates profit metrics per leg. Keep CPU-bound parsing out of the request handler by extending the helper functions around line ~400.
-- **API_MISSION_SCRAPER.** `/api/ghostnet-missions` downloads GhostNet mission tables, pulls out system/faction columns, and annotates entries with ICARUS distance calculations. Favor adding derived fields server-side so the client can stay dumb.
-- **API_PRISTINE_SCRAPER.** `/api/ghostnet-pristine-mining` normalizes GhostNet pristine datasets, injects inspector URLs, and returns body/system metadata ready for inline expansion. It already dedupes by system; preserve that behavior when expanding filters.
-- **API_WEBSEARCH.** `/api/ghostnet-search` multiplexes GhostNet lookups for commodities, ships, outfitting, and materials. The endpoint constructs a queue of ICARUS service events—maintain the payload schema so `search.js` can continue to short-circuit unsupported search types.
-- **TOKEN_CURRENCY – Token Currency and INARA Data Exchange.** The token service (`src/service/lib/token-ledger.js`) maintains a per-commander ledger, writing human-readable audit trails (`ledger.log`), structured transaction history (`transactions.jsonl`), and remote retry telemetry (`remote-retry.log`) under `~/.config/Icarus/tokens/<userId>/` (or the platform-specific equivalent). When the feature flag `ghostnetTokenCurrencyEnabled` is **false** (default), the ledger operates in simulation mode: tokens are earned from simulated INARA submissions and spent by GhostNet API proxies without emitting any real network traffic. Setting `ghostnetTokenCurrencyEnabled=true` enables the remote mirror, switching ledger persistence to the external microservice while continuing to fall back to local storage if the service is unavailable.
+- **API_COMMODITY_CACHE.** `/api/ghostnet-commodity-values` orchestrates commodity lookups. It uses `ingestJournalMarketEvent` to merge Commander market journals with INARA caches, writes cache hits to disk, and exposes cache age metadata. Always sanitize inbound commodity names—see `normalizeCommodityName` helpers before hitting remote endpoints.
+- **API_ROUTE_SCRAPER.** `/api/ghostnet-trade-routes` validates filters against a whitelist, scrapes INARA HTML via `cheerio`, and calculates profit metrics per leg. Keep CPU-bound parsing out of the request handler by extending the helper functions around line ~400.
+- **API_MISSION_SCRAPER.** `/api/ghostnet-missions` downloads INARA mission tables, pulls out system/faction columns, and annotates entries with ICARUS distance calculations. Favor adding derived fields server-side so the client can stay dumb.
+- **API_PRISTINE_SCRAPER.** `/api/ghostnet-pristine-mining` normalizes INARA pristine datasets, injects inspector URLs, and returns body/system metadata ready for inline expansion. It already dedupes by system; preserve that behavior when expanding filters.
+- **API_WEBSEARCH.** `/api/ghostnet-search` multiplexes INARA lookups for commodities, ships, outfitting, and materials. The endpoint constructs a queue of ICARUS service events—maintain the payload schema so `search.js` can continue to short-circuit unsupported search types.
+- **TOKEN_CURRENCY – Token Currency and INARA Data Exchange.** The token service (`src/service/lib/token-ledger.js`) maintains a per-commander ledger, writing human-readable audit trails (`ledger.log`), structured transaction history (`transactions.jsonl`), and remote retry telemetry (`remote-retry.log`) under `~/.config/Icarus/tokens/<userId>/` (or the platform-specific equivalent). When the feature flag `ghostnetTokenCurrencyEnabled` is **false** (default), the ledger operates in simulation mode: tokens are earned from simulated INARA submissions and spent by INARA API proxies without emitting any real network traffic. Setting `ghostnetTokenCurrencyEnabled=true` enables the remote mirror, switching ledger persistence to the external microservice while continuing to fall back to local storage if the service is unavailable.
 - While in simulation mode the ledger protects commanders from deep debt:
   - When the `ghostnetTokenJackpotEnabled` feature flag is **true**, crossing **-500,000** tokens arms a jackpot so the next earn transaction is multiplied by **100×**. The amplified entry carries `metadata.jackpot = true`, `metadata.multiplier = 100`, `metadata.jackpotSource = 'negative-balance-jackpot'`, and a randomized `metadata.jackpotCelebrationId` so the client can trigger a bespoke celebration inline with the earn.
-  - The GhostNet uplink console exposes a manual `triggerJackpot` socket handler (wired to the `+` button) so QA can invoke a simulated jackpot on demand. The helper selects a random base credit, multiplies it by the active jackpot multiplier, stamps the entry with `metadata.event = 'negative-balance-recovery'`, and broadcasts the result so the UI renders the full celebration stack.
+  - The INARA uplink console exposes a manual `triggerJackpot` socket handler (wired to the `+` button) so QA can invoke a simulated jackpot on demand. The helper selects a random base credit, multiplies it by the active jackpot multiplier, stamps the entry with `metadata.event = 'negative-balance-recovery'`, and broadcasts the result so the UI renders the full celebration stack.
   - Set `ghostnetTokenRecoveryCompatEnabled=true` to retain the legacy recovery schedule, which still grants a single-use **+1,000,000** `negative-balance-recovery` credit and mirrors the historic console celebration.
   - **Simulation vs. Remote Mode.** `TokenLedger.getSnapshot()` surfaces whether the ledger is simulating transfers (`simulation: true/false`) and includes remote sync metadata (`remote.pending`, `remote.lastSyncedAt`, `remote.lastError`). INARA submissions are deduplicated via hashed cache keys in `event-handlers.js`, and the simulated payload mirrors the production shape:
 
     ```json
     {
       "header": {
-        "appName": "GhostNetTokenSim",
+        "appName": "INARATokenSim",
         "appVersion": "1.0.0",
         "commanderName": "CMDR Example",
         "simulated": true
@@ -69,7 +69,7 @@ Use these shortnames when coordinating GhostNet work:
     ```
 
     The byte length of the JSON payload determines the number of tokens credited for each journal event. Duplicate events (matching `event`, `timestamp`, and identifier hashes) are ignored to prevent double rewards between log replays.
-  - **GhostNet API Spend Hooks.** `src/client/pages/api/token-currency.js` instantiates a per-request ledger instance and debits tokens equal to the combined request/response byte size for every GhostNet INARA proxy (`/api/ghostnet-search`, `/api/ghostnet-websearch`, `/api/ghostnet-commodity-values`, `/api/ghostnet-missions`, `/api/ghostnet-pristine-mining`, `/api/ghostnet-trade-routes`). Metadata is captured with each spend to aid reconciliation when viewing the ledger history in GhostNet.
+  - **INARA API Spend Hooks.** `src/client/pages/api/token-currency.js` instantiates a per-request ledger instance and debits tokens equal to the combined request/response byte size for every INARA INARA proxy (`/api/ghostnet-search`, `/api/ghostnet-websearch`, `/api/ghostnet-commodity-values`, `/api/ghostnet-missions`, `/api/ghostnet-pristine-mining`, `/api/ghostnet-trade-routes`). Metadata is captured with each spend to aid reconciliation when viewing the ledger history in INARA.
   - **External Token Ledger API Contract.** When remote mode is enabled the service mirrors every transaction to an external microservice. The API contract is:
 
     - `GET /api/token-ledger/:userId` → Retrieve the current balance.
@@ -122,14 +122,14 @@ Use these shortnames when coordinating GhostNet work:
       }
       ```
 
-    Remote interactions honour bearer authentication when `ICARUS_TOKENS_REMOTE_API_KEY` is supplied, retry failed requests with exponential backoff, and mark each transaction with `remote.synced`, `remote.attempts`, and `remote.error` so operators can monitor reconciliation status from GhostNet.
+    Remote interactions honour bearer authentication when `ICARUS_TOKENS_REMOTE_API_KEY` is supplied, retry failed requests with exponential backoff, and mark each transaction with `remote.synced`, `remote.attempts`, and `remote.error` so operators can monitor reconciliation status from INARA.
 
 ---
 
 ## Token Currency Frontend Fallback & Diagnostics
 
 - **Frontend Fallback Logic:**
-  - The GhostNet terminal overlay (`GhostnetTerminalOverlay` in `src/client/pages/ghostnet.js`) attempts to fetch the token balance via WebSocket broadcast events. If the broadcast fails or is unavailable, it falls back to an explicit HTTP API call (`/api/token-currency`).
+  - The INARA terminal overlay (`GhostnetTerminalOverlay` in `src/client/pages/ghostnet.js`) attempts to fetch the token balance via WebSocket broadcast events. If the broadcast fails or is unavailable, it falls back to an explicit HTTP API call (`/api/token-currency`).
   - Diagnostic logging is added to confirm whether the fallback HTTP fetch is called, what response is received, and whether `applySnapshot` and `setTokenBalance` are updated with valid data. This ensures the UI does not remain stuck on 'Syncing…'.
   - The fallback logic is critical for robust frontend/backend communication, especially when feature flags or simulation mode are toggled.
 
@@ -139,7 +139,7 @@ Use these shortnames when coordinating GhostNet work:
 ## Animated Feedback & Jackpot Intercepts
 
 - **Animated Credit/Debit Feedback:**
-  - The GhostNet terminal overlay provides animated feedback for token credit and debit events. When a transaction occurs, the overlay animates the balance change, highlights the transaction type, and displays contextual metadata (e.g., source, amount, reason).
+  - The INARA terminal overlay provides animated feedback for token credit and debit events. When a transaction occurs, the overlay animates the balance change, highlights the transaction type, and displays contextual metadata (e.g., source, amount, reason).
   - For jackpot intercepts (e.g., negative-balance-recovery), the overlay triggers a special animation sequence, including celebratory effects and a summary of the windfall event.
   - All feedback logic is future-proofed for both simulation and live API modes, ensuring consistent user experience regardless of backend state.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,7 +2,7 @@
 
 ## About ICARUS Terminal
 
-ICARUS Terminal is a free, immersive, context-sensitive companion app and second screen interface for Elite Dangerous. It provides real-time intelligence on ship status, cargo, missions, and celestial bodies by processing Elite Dangerous journal files and integrating with community-driven data sources like EDSM, EDDB, and GHOSTNET.
+ICARUS Terminal is a free, immersive, context-sensitive companion app and second screen interface for Elite Dangerous. It provides real-time intelligence on ship status, cargo, missions, and celestial bodies by processing Elite Dangerous journal files and integrating with community-driven data sources like EDSM, EDDB, and INARA.
 
 The application is designed to run on multiple platforms, including as a native Windows application, in a web browser, and on touch-screen devices, offering a responsive and intuitive UI for both landscape and portrait orientations.
 

--- a/README.md
+++ b/README.md
@@ -52,16 +52,16 @@ The web interface relies on advanced browser functionality for rendering and wor
 
 Code contributions, pull requests and bug reports are not currently being accepted for this repository. See [CONTRIB.md](CONTRIB.md) for more information. For developer documentation see [BUILD.md](BUILD.md).
 
-## GHOSTNET Page
+## INARA Page
 
-ICARUS Terminal ships with a dedicated GHOSTNET page that pulls together trade, ship, mission and resource intel submitted by the GHOSTNET community. The page is accessible from the left-hand navigation inside the app (or directly at `/ghostnet` when running the web client) and currently provides:
+ICARUS Terminal ships with a dedicated INARA page that pulls together trade, ship, mission and resource intel submitted by the INARA community. The page is accessible from the left-hand navigation inside the app (or directly at `/ghostnet` when running the web client) and currently provides:
 
 * **Ship availability search** – find stations selling a selected ship and view enriched details (distance, services, landing pads) from ICARUS's canonical data sets.
-* **Trade route scouting** – mirror GHOSTNET's public trade route search, including profit-per-trip and per-hour metrics, with an optional sandbox mode for layout testing.
+* **Trade route scouting** – mirror INARA's public trade route search, including profit-per-trip and per-hour metrics, with an optional sandbox mode for layout testing.
 * **Mining mission leads** – surface nearby mining missions and factions that have recently posted them.
 * **Pristine ring finder** – highlight bodies with pristine reserves within jump range for mining expeditions.
 
-All GHOSTNET-sourced insights are clearly labelled inside the UI so that commanders can distinguish between local ICARUS data and community-reported values. For a deep dive into how the integration works under the hood—including details on the HTTP requests, parsers and logging used to access GHOSTNET without an API key—see [GHOSTNET-README.md](GHOSTNET-README.md).
+All INARA-sourced insights are clearly labelled inside the UI so that commanders can distinguish between local ICARUS data and community-reported values. For a deep dive into how the integration works under the hood—including details on the HTTP requests, parsers and logging used to access INARA without an API key—see [INARA-README.md](INARA-README.md).
 
 ### Developer Quickstart
 
@@ -71,7 +71,7 @@ Looking to run ICARUS Terminal from source? The maintained setup, build, and scr
 
 ICARUS Terminal is free, open-source software released under the ISC License.
 
-ICARUS Terminal does not record Personally Identifiable Information (PII). ICARUS Terminal includes integrations with services like [EDSM](https://www.edsm.net), [EDDB](https://eddb.io/) and [GHOSTNET](https://inara.cz/). Data such as your current in-game location, cargo, etc. may be sent to them order to render information in the interface. ICARUS Terminal does not expose or send information about you or your in game character (e.g. your name, user name, commander name or ship name) but any requests made to a third party will include your IP address.
+ICARUS Terminal does not record Personally Identifiable Information (PII). ICARUS Terminal includes integrations with services like [EDSM](https://www.edsm.net), [EDDB](https://eddb.io/) and [INARA](https://inara.cz/). Data such as your current in-game location, cargo, etc. may be sent to them order to render information in the interface. ICARUS Terminal does not expose or send information about you or your in game character (e.g. your name, user name, commander name or ship name) but any requests made to a third party will include your IP address.
 
 Elite Dangerous is copyright Frontier Developments plc. This software is not endorsed by nor reflects the views or opinions of Frontier Developments and no employee of Frontier Developments was involved in the making of it.
 

--- a/docs/pirate-radio.md
+++ b/docs/pirate-radio.md
@@ -1,6 +1,6 @@
 # Pirate Radio Configuration
 
-The Pirate Radio panel inside GhostNet streams audio playlists assembled from two directory roots:
+The Pirate Radio panel inside INARA streams audio playlists assembled from two directory roots:
 
 - **Library directory** – the curated music or community submissions that provide the primary playlist.
 - **Commercial directory** – optional station advertising or bumpers that can be slotted between tracks.
@@ -15,9 +15,9 @@ When either directory changes, or when a rescan completes, the service should br
 
 ### Usage
 
-1. Open the **Pirate Radio** tab within GhostNet.
+1. Open the **Pirate Radio** tab within INARA.
 2. Use the **Browse Library** and **Browse Commercials** buttons to select folders containing audio files. Each button triggers the `setPirateRadioDirectories` socket handler with the selected directory type.
 3. Click **Rescan Library** to issue `rescanPirateRadio` and rebuild the playlist. A toast and inline banner confirm whether the rescan succeeded.
 4. Playback controls (Play/Pause/Prev/Next) drive the panel’s internal `<audio>` element. When a track ends the panel automatically advances to the next entry in the queue.
 
-The UI surfaces inline status banners for both success and error states while also emitting toast notifications through the shared GhostNet notification helper. The current directories and any backend status messages remain visible so commanders can diagnose missing or invalid folders quickly.
+The UI surfaces inline status banners for both success and error states while also emitting toast notifications through the shared INARA notification helper. The current directories and any backend status messages remain visible so commanders can diagnose missing or invalid folders quickly.

--- a/docs/token-currency.md
+++ b/docs/token-currency.md
@@ -1,6 +1,6 @@
 # Token Currency Service Overview
 
-The GhostNet token currency system awards virtual credits to commanders whenever the service would submit Elite Dangerous journal data to INARA and debits credits for every remote INARA lookup triggered from the GhostNet API layer. The logic lives entirely on the backend so the desktop client can toggle between a fully simulated workflow and a remote-mirrored "live" mode without UI changes.
+The INARA token currency system awards virtual credits to commanders whenever the service would submit Elite Dangerous journal data to INARA and debits credits for every remote INARA lookup triggered from the INARA API layer. The logic lives entirely on the backend so the desktop client can toggle between a fully simulated workflow and a remote-mirrored "live" mode without UI changes.
 
 ## Feature flag and configuration
 
@@ -32,14 +32,14 @@ A dedicated retry queue flushes pending transactions sequentially. Each queued t
 
 ## INARA simulation
 
-`src/service/lib/event-handlers.js` hooks every ingested journal event and constructs the payload GhostNet would send to INARA. The payload matches the documented header + events schema and the byte length of the JSON string determines how many tokens are credited. Cache keys built from the event name, timestamp, and domain-specific identifiers ensure a journal replay never awards the same entry twice.
+`src/service/lib/event-handlers.js` hooks every ingested journal event and constructs the payload INARA would send to INARA. The payload matches the documented header + events schema and the byte length of the JSON string determines how many tokens are credited. Cache keys built from the event name, timestamp, and domain-specific identifiers ensure a journal replay never awards the same entry twice.
 
 When `ghostnetTokenCurrencyEnabled` is set to `true` the same infrastructure prepares the payload but marks credits with `reason: "inara-credit"` instead of `"inara-simulated-credit"`. The outbound request body and metadata can be reused when the production submission path is wired in.
 
 ## Negative balance recovery
 
 - Simulation mode keeps commanders from spiralling indefinitely: when the local ledger balance crosses **-500,000** tokens, the next spend transaction records `metadata.recoveryTriggered: true` and schedules a `negative-balance-recovery` credit for **+1,000,000** tokens.
-- The recovery credit is stored like any other transaction and emits a `ghostnetTokensUpdated` broadcast containing the new entry. The GhostNet console listens for `metadata.event === 'negative-balance-recovery'` to unleash a jackpot sequence: rapid glyph floods, a shimmering “JACKPOT” banner, milestone balance ticks, and a procedurally generated summary describing the recovered cache.
+- The recovery credit is stored like any other transaction and emits a `ghostnetTokensUpdated` broadcast containing the new entry. The INARA console listens for `metadata.event === 'negative-balance-recovery'` to unleash a jackpot sequence: rapid glyph floods, a shimmering “JACKPOT” banner, milestone balance ticks, and a procedurally generated summary describing the recovered cache.
 - Recovery only fires once per threshold crossing; the ledger re-arms the guard after the balance climbs above -500,000 so future deficits can produce fresh celebration events. The scheduling helper records failures and re-arms if a write error occurs so future transactions can try again.
 - Future gameplay hooks (e.g. discovering valuable scans) can reuse the same celebration plumbing by emitting transactions with a distinct `metadata.event` and pointing the UI handler at the new identifier.
 

--- a/docs/tokens/inara-api-brief.md
+++ b/docs/tokens/inara-api-brief.md
@@ -1,4 +1,4 @@
-# INARA API & GhostNet Token Economy Brief
+# INARA API & INARA Token Economy Brief
 
 ## API overview
 - **Authentication:** INARA requires an API key tied to a registered application plus the commander name. Requests include `header` metadata with `appName`, `appVersion`, `APIkey`, and `commanderName` values. The public API accepts HTTPS POST payloads at `https://inara.cz/inapi/v1/`.
@@ -7,9 +7,9 @@
 - **Supported events:** The API includes telemetry submissions (`setCommanderInventoryMaterials`, `setCommanderMarket`, `setCommanderShip`, etc.) and lookup events (`getStarSystem`, `getStation`, `getMarket`, etc.). Some responses embed pagination tokens.
 - **Error handling:** Non-2xx HTTP responses indicate transport failures. Within 200 responses, failed events carry `eventStatus` values `300`+ and detailed text. Clients should log and optionally retry after the recommended delay.
 
-## GhostNet request comparison
-- Existing GhostNet scrapers (e.g., `/api/ghostnet-search`) currently post JSON objects with `appName`, `appVersion`, and `events` to INARA, omitting `APIkey` until credentials are supplied.
-- GhostNet queues heterogeneous events per request (market, outfitting, shipyard) matching the official schema but currently stubs authentication fields.
+## INARA request comparison
+- Existing INARA scrapers (e.g., `/api/ghostnet-search`) currently post JSON objects with `appName`, `appVersion`, and `events` to INARA, omitting `APIkey` until credentials are supplied.
+- INARA queues heterogeneous events per request (market, outfitting, shipyard) matching the official schema but currently stubs authentication fields.
 - The payload structure aligns with INARA’s expectations, so the token system can treat each outbound request as a unit of cost without additional normalization.
 
 ## Proposed token reward schedule
@@ -31,7 +31,7 @@ Values assume simulation mode; they can be tuned once real submission cadences a
 - General web searches can share a 200 token baseline to reflect lighter HTML scraping.
 
 ## Outstanding questions
-1. **Authentication cadence:** Confirm whether GhostNet must rotate commander credentials per session or can reuse a shared app key.
+1. **Authentication cadence:** Confirm whether INARA must rotate commander credentials per session or can reuse a shared app key.
 2. **Bulk submission size:** Validate INARA’s maximum `events` array length and payload size to size ledger granularity.
 3. **Rate limit feedback:** Determine if INARA includes headers for remaining quota to refine spend costs dynamically.
 4. **Error retries:** Decide whether failed submissions refund tokens automatically or require manual adjustment.

--- a/docs/tokens/scraper-audit.md
+++ b/docs/tokens/scraper-audit.md
@@ -1,4 +1,4 @@
-# GhostNet Scraper & Search Audit
+# INARA Scraper & Search Audit
 
 ## Service-side ingestion
 - `src/service/lib/events.js` boots the Elite Dangerous log readers and wires `loadFileCallback`, `logEventCallback`, and `eliteJsonCallback`.
@@ -6,20 +6,20 @@
 - Broadcast helpers expose `global.BROADCAST_EVENT` so handlers can push updates to connected sockets.
 - Current ingestion does not award currency; events simply update caches (`marketCache`, `shipStatus`, mission queues).
 
-## Next.js API routes touching GhostNet/INARA
+## Next.js API routes touching INARA/INARA
 | Route | Responsibilities | Shared behaviors |
 | --- | --- | --- |
-| `/api/ghostnet-commodity-values` | Combines journal market data with GhostNet market listings via INARA API | Uses `resolveLogDir`, local cache writes, cheerio parsing |
-| `/api/ghostnet-trade-routes` | Scrapes GhostNet trade route HTML, normalizes legs, calculates profits | Shares fetch wrapper, logging, and queue serialization |
-| `/api/ghostnet-missions` | Downloads GhostNet missions table, merges faction data | Similar error handling/logging, uses system selector helpers |
+| `/api/ghostnet-commodity-values` | Combines journal market data with INARA market listings via INARA API | Uses `resolveLogDir`, local cache writes, cheerio parsing |
+| `/api/ghostnet-trade-routes` | Scrapes INARA trade route HTML, normalizes legs, calculates profits | Shares fetch wrapper, logging, and queue serialization |
+| `/api/ghostnet-missions` | Downloads INARA missions table, merges faction data | Similar error handling/logging, uses system selector helpers |
 | `/api/ghostnet-pristine-mining` | Fetches pristine mining listings, attaches metadata | Reuses caching helpers, minimal logging |
-| `/api/ghostnet-websearch` | Performs GhostNet search across commodities/ships/outfitting | Builds multi-event INARA payload, uses common fetch options |
+| `/api/ghostnet-websearch` | Performs INARA search across commodities/ships/outfitting | Builds multi-event INARA payload, uses common fetch options |
 | `/api/ghostnet-search` | General INARA API bridge; constructs `events` array dynamically | Houses base request builder used by other routes |
 
 Shared concerns ripe for ScraperEngine extraction:
 - Log directory resolution (`resolveLogDir`, environment fallbacks).
 - HTTP agents with keep-alive and user-agent headers.
-- Retry/backoff policies for INARA and GhostNet HTML requests.
+- Retry/backoff policies for INARA and INARA HTML requests.
 - Unified logging (success, failure, cache hits) and metrics.
 - Token spend hooks (to be introduced) should reside alongside fetch helpers.
 
@@ -33,7 +33,7 @@ Shared concerns ripe for ScraperEngine extraction:
 2. Expose shared utilities for caching paths and file IO to eliminate duplicated directory math.
 3. Surface instrumentation hooks (e.g., `onBeforeRequest`, `onAfterResponse`) so each scraper can register route-specific telemetry.
 4. Bundle schema normalizers (HTML -> structured data) where feasible to centralize transformation logic.
-5. Keep the engine agnostic to GhostNet vs. INARA endpoints so future integrations (other web APIs) can opt in with minimal code.
+5. Keep the engine agnostic to INARA vs. INARA endpoints so future integrations (other web APIs) can opt in with minimal code.
 
 ## Observations
 - Several routes manually duplicate try/catch blocks for fetch + cheerio parsing; the engine should own this pattern.
@@ -42,4 +42,4 @@ Shared concerns ripe for ScraperEngine extraction:
 
 ## Recommended follow-ups
 - Inventory each scraper’s token cost once the ledger is in place and capture them in shared configuration.
-- Add integration tests for the engine once implemented to catch regressions when GhostNet or INARA markup changes.
+- Add integration tests for the engine once implemented to catch regressions when INARA or INARA markup changes.

--- a/scripts/browser/screenshot_ghostnet.py
+++ b/scripts/browser/screenshot_ghostnet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Playwright helper to capture GhostNet screenshots after the workspace is ready."""
+"""Playwright helper to capture INARA screenshots after the workspace is ready."""
 
 import argparse
 import asyncio
@@ -43,7 +43,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--url",
         default=DEFAULT_URL,
-        help=f"GhostNet URL to capture (default: {DEFAULT_URL})",
+        help=f"INARA URL to capture (default: {DEFAULT_URL})",
     )
     parser.add_argument(
         "--output",

--- a/src/client/__tests__/ghostnet.test.js
+++ b/src/client/__tests__/ghostnet.test.js
@@ -54,9 +54,9 @@ describe('Ghost Net page', () => {
     await act(async () => { render(<GhostnetPage />) })
 
     expect(await screen.findByRole('heading', { name: /find trade routes/i })).toBeInTheDocument()
-    expect(screen.getByText(/cross-reference ghostnet freight whispers/i)).toBeInTheDocument()
+    expect(screen.getByText(/cross-reference inara freight whispers/i)).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /mining missions/i, hidden: true })).toBeInTheDocument()
-    expect(screen.getByText(/ghost net decrypts volunteer ghostnet manifests/i)).toBeInTheDocument()
+    expect(screen.getByText(/ghost net decrypts volunteer inara manifests/i)).toBeInTheDocument()
   })
 
   it('renders the token console meter with request control', async () => {

--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -6,17 +6,24 @@ import { eliteDateTime } from 'lib/format'
 import { Settings } from 'components/settings'
 import notification from 'lib/notification'
 import { initiateGhostnetAssimilation, isGhostnetAssimilationActive, GHOSTNET_ASSIMILATION_EVENT } from 'lib/ghostnet-assimilation'
+import { initiateGhostnetExitTransition, isGhostnetExitTransitionActive } from 'lib/ghostnet-exit-transition'
+import {
+  isGhostnetThemeEnabled,
+  addGhostnetThemeChangeListener,
+  THEME_STORAGE_KEY,
+  isGhostnetNavVisible,
+  addGhostnetNavVisibilityListener,
+  GHOSTNET_NAV_VISIBILITY_KEY
+} from 'lib/ghostnet-settings'
 
 const ORIGINAL_TITLE = 'ICARUS TERMINAL'
-const TARGET_TITLE = 'GHOSTNET-ATLAS'
+const TARGET_TITLE = 'INARA-ATLAS'
 const TARGET_TITLE_PADDED = TARGET_TITLE.padEnd(ORIGINAL_TITLE.length, ' ')
 const getTargetTitleChars = () => TARGET_TITLE_PADDED.split('')
 const TITLE_PREFIX_LENGTH = 7
 const TITLE_MIN_WIDTH = `${ORIGINAL_TITLE.length}ch`
 const TITLE_GLYPHS = ['Λ', 'Ξ', 'Ψ', 'Ø', 'Σ', '✦', '✧', '☍', '⌁', '⌖', '◬', '◈', '★', '✶', '⋆']
 const createEmptyGlitchStyles = () => Array.from({ length: ORIGINAL_TITLE.length }, () => null)
-import { initiateGhostnetExitTransition, isGhostnetExitTransitionActive } from 'lib/ghostnet-exit-transition'
-
 const NAV_BUTTONS = [
   {
     name: 'Navigation',
@@ -34,8 +41,8 @@ const NAV_BUTTONS = [
     path: '/eng'
   },
   {
-    name: 'GhostNet',
-    abbr: 'GNet',
+    name: 'INARA',
+    abbr: 'INARA',
     path: '/ghostnet'
   },
   {
@@ -46,7 +53,6 @@ const NAV_BUTTONS = [
 ]
 
 let IS_WINDOWS_APP = false
-const GHOSTNET_NAV_VISIBILITY_KEY = 'ghostnet.nav.visible'
 
 export default function Header ({ connected, active }) {
   const router = useRouter()
@@ -55,7 +61,8 @@ export default function Header ({ connected, active }) {
   const [isPinned, setIsPinned] = useState(false)
   const [notificationsVisible, setNotificationsVisible] = useState(socketOptions.notifications)
   const [settingsVisible, setSettingsVisible] = useState(false)
-  const [ghostnetButtonVisible, setGhostnetButtonVisible] = useState(true)
+  const [ghostnetButtonVisible, setGhostnetButtonVisible] = useState(() => isGhostnetNavVisible())
+  const [ghostnetThemeEnabled, setGhostnetThemeEnabled] = useState(() => isGhostnetThemeEnabled())
   const [titleChars, setTitleChars] = useState(ORIGINAL_TITLE.split(''))
   const [titleAssimilated, setTitleAssimilated] = useState(false)
   const titleAnimationState = useRef({ running: false, completed: false })
@@ -64,17 +71,6 @@ export default function Header ({ connected, active }) {
   const titleGlitchLoopTimeout = useRef(null)
   const titleGlitchRevertTimeouts = useRef([])
   const activeTitleGlitchIndices = useRef(new Set())
-  const restoreGhostnetButtonRef = useRef(null)
-  const ghostnetNavButtonRef = useRef(null)
-  const ghostnetVisibilityHydrated = useRef(false)
-  const persistGhostnetVisibility = useCallback((isVisible) => {
-    if (typeof window === 'undefined') return
-    try {
-      window.localStorage.setItem(GHOSTNET_NAV_VISIBILITY_KEY, isVisible ? 'true' : 'false')
-    } catch (err) {
-      // Ignore storage write issues
-    }
-  }, [])
   const currentPath = `/${(router.pathname.split('/')[1] || '').toLowerCase()}`
   const isGhostnetRouteActive = currentPath === '/ghostnet'
 
@@ -197,44 +193,6 @@ export default function Header ({ connected, active }) {
     }
   }, [clearTitleGlitchTimeouts])
 
-  const scheduleFocus = useCallback((ref) => {
-    if (!ref) return
-    const setTimeoutFn = typeof window !== 'undefined' ? window.setTimeout : setTimeout
-    setTimeoutFn(() => {
-      if (ref.current && typeof ref.current.focus === 'function') {
-        ref.current.focus()
-      }
-    }, 0)
-  }, [])
-
-  const hideGhostnetNavButton = useCallback((event) => {
-    setGhostnetButtonVisible(false)
-    persistGhostnetVisibility(false)
-
-    const nativeEvent = event?.nativeEvent
-    const shouldFocusRestore = !nativeEvent || nativeEvent.detail === 0 || nativeEvent.pointerType === 'keyboard'
-
-    if (shouldFocusRestore) {
-      scheduleFocus(restoreGhostnetButtonRef)
-    } else if (event?.currentTarget && typeof event.currentTarget.blur === 'function') {
-      event.currentTarget.blur()
-    }
-  }, [persistGhostnetVisibility, scheduleFocus])
-
-  const showGhostnetNavButton = useCallback((event) => {
-    setGhostnetButtonVisible(true)
-    persistGhostnetVisibility(true)
-
-    const nativeEvent = event?.nativeEvent
-    const shouldFocusGhostnetNav = !nativeEvent || nativeEvent.detail === 0 || nativeEvent.pointerType === 'keyboard'
-
-    if (shouldFocusGhostnetNav) {
-      scheduleFocus(ghostnetNavButtonRef)
-    } else if (event?.currentTarget && typeof event.currentTarget.blur === 'function') {
-      event.currentTarget.blur()
-    }
-  }, [persistGhostnetVisibility, scheduleFocus])
-
   const startTitleMorph = useCallback(() => {
     if (titleAnimationState.current.running || titleAnimationState.current.completed) return
     clearTitleAnimationTimeouts()
@@ -344,19 +302,40 @@ export default function Header ({ connected, active }) {
   }, [])
 
   useEffect(() => {
-    if (typeof window === 'undefined' || ghostnetVisibilityHydrated.current) return undefined
-    try {
-      const storedVisibility = window.localStorage.getItem(GHOSTNET_NAV_VISIBILITY_KEY)
-      if (storedVisibility !== null) {
-        const isVisible = storedVisibility !== 'false'
-        setGhostnetButtonVisible(isVisible)
+    if (typeof window === 'undefined') return undefined
+
+    const handleThemeStorage = (event) => {
+      if (event.key === THEME_STORAGE_KEY) {
+        setGhostnetThemeEnabled(isGhostnetThemeEnabled())
       }
-    } catch (err) {
-      // Ignore storage access issues
     }
-    ghostnetVisibilityHydrated.current = true
-    return undefined
-  }, [scheduleFocus])
+
+    const removeListener = addGhostnetThemeChangeListener(setGhostnetThemeEnabled)
+    window.addEventListener('storage', handleThemeStorage)
+
+    return () => {
+      removeListener()
+      window.removeEventListener('storage', handleThemeStorage)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const handleStorage = (event) => {
+      if (event.key === GHOSTNET_NAV_VISIBILITY_KEY) {
+        setGhostnetButtonVisible(isGhostnetNavVisible())
+      }
+    }
+
+    const removeListener = addGhostnetNavVisibilityListener(setGhostnetButtonVisible)
+    window.addEventListener('storage', handleStorage)
+
+    return () => {
+      removeListener()
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [])
 
   useEffect(() => {
     return () => {
@@ -424,6 +403,10 @@ export default function Header ({ connected, active }) {
     }
     if (currentPath === '/ghostnet') {
       if (isGhostnetExitTransitionActive()) return
+      if (!ghostnetThemeEnabled) {
+        router.push(path)
+        return
+      }
       initiateGhostnetExitTransition(() => router.push(path))
       return
     }
@@ -464,19 +447,6 @@ export default function Header ({ connected, active }) {
         </span>
       </h1>
       <div style={{ position: 'absolute', top: '1rem', right: '.5rem' }}>
-        {!ghostnetButtonVisible && (
-          <button
-            ref={restoreGhostnetButtonRef}
-            tabIndex='1'
-            onClick={(event) => showGhostnetNavButton(event)}
-            className='button--icon'
-            style={{ marginRight: '.5rem' }}
-            aria-label='Show GhostNet navigation'
-            title='Show GhostNet navigation'
-          >
-            <i className='icon icarus-terminal-warning' style={{ fontSize: '2rem' }} />
-          </button>
-        )}
         <p
           className='text-primary text-center text-uppercase'
           style={{ display: 'inline-block', padding: 0, margin: 0, lineHeight: '1rem', minWidth: '7.5rem' }}
@@ -517,42 +487,27 @@ export default function Header ({ connected, active }) {
       <div id='primaryNavigation' className='button-group'>
         {visibleNavButtons.map((button, i) => {
           const isActive = button.path === currentPath
-          const isGhostNet = button.path === '/ghostnet'
+          const isINARA = button.path === '/ghostnet'
           const exitActive = isGhostnetExitTransitionActive()
 
-          if (isGhostNet) {
+          if (isINARA) {
             return (
-              <div key={button.name} className='ghostnet-nav-button-wrapper'>
-                <button
-                  data-primary-navigation={i + 1}
-                  tabIndex='1'
-                  disabled={isActive || (isGhostNet && isGhostnetAssimilationActive()) || exitActive}
-                  aria-current={isActive ? 'page' : undefined}
-                  className={[
-                    isActive ? 'button--active' : '',
-                    'ghostnet-nav-button'
-                  ].filter(Boolean).join(' ')}
-                  onClick={() => handleNavigate(button.path)}
-                  style={{ fontSize: '1.5rem' }}
-                  ref={ghostnetNavButtonRef}
-                >
-                  <span className='visible-small'>{button.abbr}</span>
-                  <span className='hidden-small'>{button.name}</span>
-                </button>
-                <button
-                  type='button'
-                  className='ghostnet-nav-button__dismiss'
-                  aria-label='Hide GhostNet navigation'
-                  title='Hide GhostNet navigation'
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    event.preventDefault()
-                    hideGhostnetNavButton(event)
-                  }}
-                >
-                  ×
-                </button>
-              </div>
+              <button
+                key={button.name}
+                data-primary-navigation={i + 1}
+                tabIndex='1'
+                disabled={isActive || (isINARA && isGhostnetAssimilationActive()) || exitActive}
+                aria-current={isActive ? 'page' : undefined}
+                className={[
+                  isActive ? 'button--active' : '',
+                  'ghostnet-nav-button'
+                ].filter(Boolean).join(' ')}
+                onClick={() => handleNavigate(button.path)}
+                style={{ fontSize: '1.5rem' }}
+              >
+                <span className='visible-small'>{button.abbr}</span>
+                <span className='hidden-small'>{button.name}</span>
+              </button>
             )
           }
 

--- a/src/client/components/settings.js
+++ b/src/client/components/settings.js
@@ -6,7 +6,15 @@ import {
   ASSIMILATION_DURATION_MAX,
   ASSIMILATION_DURATION_DEFAULT,
   getAssimilationDurationSeconds,
-  saveAssimilationDurationSeconds
+  saveAssimilationDurationSeconds,
+  isGhostnetThemeEnabled,
+  saveGhostnetThemeEnabled,
+  addGhostnetThemeChangeListener,
+  THEME_STORAGE_KEY,
+  isGhostnetNavVisible,
+  saveGhostnetNavVisible,
+  addGhostnetNavVisibilityListener,
+  GHOSTNET_NAV_VISIBILITY_KEY
 } from 'lib/ghostnet-settings'
 import packageJson from '../../../package.json'
 
@@ -57,11 +65,11 @@ function Settings ({ visible, toggleVisible = () => {}, defaultActiveSettingsPan
               </button>
             </Fragment>
           )}
-          <Fragment key='GHOSTNET'>
+          <Fragment key='INARA'>
             <button
               tabIndex='2'
-              className={`button--icon ${activeSettingsPanel === 'GHOSTNET' ? 'button--active' : ''}`}
-              onClick={() => setActiveSettingsPanel('GHOSTNET')}
+              className={`button--icon ${activeSettingsPanel === 'INARA' ? 'button--active' : ''}`}
+              onClick={() => setActiveSettingsPanel('INARA')}
             >
               <i className='icon icarus-terminal-info' />
             </button>
@@ -70,7 +78,7 @@ function Settings ({ visible, toggleVisible = () => {}, defaultActiveSettingsPan
         {activeSettingsPanel === 'Theme' && <ThemeSettings visible={visible} />}
         {activeSettingsPanel === 'Sounds' && <SoundSettings visible={visible} />}
         {activeSettingsPanel === 'Feature Flags' && <FeatureFlagSettings />}
-        {activeSettingsPanel === 'GHOSTNET' && <GhostnetSettings />}
+        {activeSettingsPanel === 'INARA' && <GhostnetSettings />}
         <div className='modal-dialog__footer'>
           <hr style={{ margin: '1rem 0 .5rem 0' }} />
           <button className='float-right' onClick={toggleVisible}>
@@ -86,12 +94,31 @@ function GhostnetSettings () {
   const [useMockData, setUseMockData] = useState(false)
   const [assimilationDuration, setAssimilationDuration] = useState(ASSIMILATION_DURATION_DEFAULT)
   const [saved, setSaved] = useState(false)
+  const [ghostnetNavVisible, setGhostnetNavVisible] = useState(() => isGhostnetNavVisible())
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       setUseMockData(window.localStorage.getItem('ghostnetUseMockData') === 'true')
     }
     setAssimilationDuration(getAssimilationDurationSeconds())
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const handleStorage = (event) => {
+      if (event.key === GHOSTNET_NAV_VISIBILITY_KEY) {
+        setGhostnetNavVisible(isGhostnetNavVisible())
+      }
+    }
+
+    const removeListener = addGhostnetNavVisibilityListener(setGhostnetNavVisible)
+    window.addEventListener('storage', handleStorage)
+
+    return () => {
+      removeListener()
+      window.removeEventListener('storage', handleStorage)
+    }
   }, [])
 
   function handleSave(e) {
@@ -107,7 +134,23 @@ function GhostnetSettings () {
 
   return (
     <div className='modal-dialog__panel modal-dialog__panel--with-navigation scrollable'>
-      <h3 className='text-primary'>GHOSTNET Integration Settings</h3>
+      <h3 className='text-primary'>INARA Integration Settings</h3>
+      <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', margin: '0 0 1.25rem 0', fontSize: '1rem' }}>
+        <input
+          type='checkbox'
+          checked={ghostnetNavVisible}
+          onChange={(event) => {
+            const sanitized = saveGhostnetNavVisible(event.target.checked)
+            setGhostnetNavVisible(sanitized)
+          }}
+        />
+        <span>
+          Show INARA workspace in navigation
+        </span>
+      </label>
+      <p className='text-muted' style={{ marginTop: '-0.75rem', marginBottom: '1.5rem', fontSize: '.95rem' }}>
+        Disable to hide the INARA workspace toggle from the main navigation bar.
+      </p>
       <p>Enable or disable the Trade Route Layout Sandbox using mock data.</p>
       <form onSubmit={handleSave} style={{ maxWidth: 400 }}>
         <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1.25rem', fontSize: '1rem' }}>
@@ -122,7 +165,7 @@ function GhostnetSettings () {
         </label>
         <div style={{ marginBottom: '1.5rem' }}>
           <label htmlFor='ghostnet-assimilation-duration' className='text-primary' style={{ display: 'block', marginBottom: '.5rem' }}>
-            GhostNet assimilation transition length
+            INARA assimilation transition length
           </label>
           <input
             id='ghostnet-assimilation-duration'
@@ -142,11 +185,10 @@ function GhostnetSettings () {
             <span className='text-muted'>Min {ASSIMILATION_DURATION_MIN}s · Max {ASSIMILATION_DURATION_MAX}s</span>
           </div>
           <p className='text-muted' style={{ marginTop: '.5rem', fontSize: '.9rem' }}>
-            Controls the duration of the assimilation effect when entering the GhostNet interface.
+            Controls the duration of the assimilation effect when entering the INARA interface.
           </p>
         </div>
-        <button type='submit' style={{ fontSize: '1.1rem' }}>Save</button>
-        {saved && <span className='text-success' style={{ marginLeft: '1rem' }}>Saved!</span>}
+        <button type='submit' style={{ fontSize: '1.1rem' }}>{saved ? 'Saved!' : 'Save'}</button>
       </form>
     </div>
   )
@@ -312,6 +354,7 @@ function ThemeSettings () {
   const [primaryColorModifier, setPrimaryColorModifier] = useState(getPrimaryColorModifier())
   const [secondaryColor, setSecondaryColor] = useState(getSecondaryColorAsHex())
   const [secondaryColorModifier, setSecondaryColorModifier] = useState(getSecondaryColorModifier())
+  const [ghostnetThemeEnabled, setGhostnetThemeEnabled] = useState(() => isGhostnetThemeEnabled())
 
   // Update this component if another window updates the theme settings
   const storageEventHandler = (event) => {
@@ -323,7 +366,8 @@ function ThemeSettings () {
     }
   }
 
-  useEffect(async () => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
     window.addEventListener('storage', storageEventHandler)
     return () => window.removeEventListener('storage', storageEventHandler)
   }, [])
@@ -336,6 +380,24 @@ function ThemeSettings () {
       setSecondaryColorModifier(getSecondaryColorModifier())
     }
   }), [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const handleThemeStorage = (event) => {
+      if (event.key === THEME_STORAGE_KEY) {
+        setGhostnetThemeEnabled(isGhostnetThemeEnabled())
+      }
+    }
+
+    const removeListener = addGhostnetThemeChangeListener(setGhostnetThemeEnabled)
+    window.addEventListener('storage', handleThemeStorage)
+
+    return () => {
+      removeListener()
+      window.removeEventListener('storage', handleThemeStorage)
+    }
+  }, [])
 
   return (
     <div className='modal-dialog__panel modal-dialog__panel--with-navigation scrollable'>
@@ -476,6 +538,23 @@ function ThemeSettings () {
           Reset theme settings
         </button>
       </div>
+      <hr style={{ margin: '2rem 0 1.5rem 0' }} />
+      <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1rem', fontSize: '1rem' }}>
+        <input
+          type='checkbox'
+          checked={ghostnetThemeEnabled}
+          onChange={(event) => {
+            const sanitized = saveGhostnetThemeEnabled(event.target.checked)
+            setGhostnetThemeEnabled(sanitized)
+          }}
+        />
+        <span>
+          Use GhostNet Theme
+        </span>
+      </label>
+      <p className='text-muted' style={{ marginTop: 0, fontSize: '.95rem' }}>
+        Disable this setting to keep INARA&apos;s layouts while returning to the classic ICARUS palette and transitions.
+      </p>
     </div>
   )
 }

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -488,17 +488,11 @@ body.ghostnet-theme #secondaryNavigation .button--icon.button--secondary {
   flex: 1;
 }
 
-#primaryNavigation .ghostnet-nav-button-wrapper {
-  position: relative;
-  flex: 1;
-  --ghostnet-nav-dismiss-size: 2.25rem;
-}
-
-#primaryNavigation .ghostnet-nav-button-wrapper > .ghostnet-nav-button {
+#primaryNavigation .ghostnet-nav-button {
   width: 100%;
 }
 
-#primaryNavigation .ghostnet-nav-button {
+body.ghostnet-theme #primaryNavigation .ghostnet-nav-button {
   --ghostnet-nav-accent: rgb(216, 180, 254);
   --ghostnet-nav-depth: rgba(73, 27, 115, 0.35);
   background: linear-gradient(180deg, rgba(44, 18, 68, 0.95), rgba(81, 27, 128, 0.85));
@@ -508,52 +502,15 @@ body.ghostnet-theme #secondaryNavigation .button--icon.button--secondary {
   text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
   filter: none;
   transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, transform 0.2s ease;
-  padding-right: calc(var(--ghostnet-nav-dismiss-size) + 0.75rem);
   border-right: 0;
 }
 
-#primaryNavigation .ghostnet-nav-button .visible-small,
-#primaryNavigation .ghostnet-nav-button .hidden-small {
+body.ghostnet-theme #primaryNavigation .ghostnet-nav-button .visible-small,
+body.ghostnet-theme #primaryNavigation .ghostnet-nav-button .hidden-small {
   text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
 }
 
-#primaryNavigation .ghostnet-nav-button__dismiss {
-  position: absolute;
-  top: 50%;
-  right: 0.45rem;
-  width: var(--ghostnet-nav-dismiss-size);
-  height: var(--ghostnet-nav-dismiss-size);
-  border-radius: 0.3rem;
-  border: 1px solid rgba(216, 180, 254, 0.45);
-  background: linear-gradient(180deg, rgba(63, 24, 96, 0.95), rgba(44, 18, 68, 0.85));
-  color: rgb(216, 180, 254);
-  font-size: 1.35rem;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  cursor: pointer;
-  text-shadow: 0 0 1.2rem rgba(216, 180, 254, 0.6);
-  box-shadow: inset 0 0 1.05rem rgba(93, 46, 255, 0.25);
-  transform: translateY(-50%);
-  transition: color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-  z-index: 1;
-}
-
-#primaryNavigation .ghostnet-nav-button__dismiss:hover,
-#primaryNavigation .ghostnet-nav-button__dismiss:focus-visible {
-  color: rgb(245, 241, 255);
-  box-shadow: 0 0 0.85rem rgba(216, 180, 254, 0.45), inset 0 0 0.55rem rgba(216, 180, 254, 0.45);
-  transform: translateY(calc(-50% - 1px));
-}
-
-#primaryNavigation .ghostnet-nav-button__dismiss:focus-visible {
-  outline: 2px solid rgba(41, 243, 195, 0.75);
-  outline-offset: 2px;
-}
-
-#primaryNavigation .ghostnet-nav-button.button--active {
+body.ghostnet-theme #primaryNavigation .ghostnet-nav-button.button--active {
   background: linear-gradient(180deg, rgba(57, 22, 88, 0.95), rgba(95, 35, 150, 0.85));
   border-color: rgba(216, 180, 254, 0.45);
   box-shadow: 0 0 1.45rem rgba(216, 180, 254, 0.7), inset 0 0 0.55rem rgba(216, 180, 254, 0.9);
@@ -562,8 +519,8 @@ body.ghostnet-theme #secondaryNavigation .button--icon.button--secondary {
   filter: none;
 }
 
-#primaryNavigation .ghostnet-nav-button:hover:not([disabled]):not(.button--active),
-#primaryNavigation .ghostnet-nav-button:focus:not([disabled]):not(.button--active) {
+body.ghostnet-theme #primaryNavigation .ghostnet-nav-button:hover:not([disabled]):not(.button--active),
+body.ghostnet-theme #primaryNavigation .ghostnet-nav-button:focus:not([disabled]):not(.button--active) {
   background: linear-gradient(180deg, rgba(54, 21, 84, 0.95), rgba(88, 31, 139, 0.9));
   box-shadow: 0 0 1.35rem rgba(216, 180, 254, 0.45), inset 0 0 0.45rem rgba(216, 180, 254, 0.65);
   color: var(--ghostnet-nav-accent);
@@ -730,7 +687,7 @@ body.ghostnet-assimilation-forced .ghostnet-assimilation-target::before,
   }
 }
 
-/* GhostNet exit transition */
+/* INARA exit transition */
 
 body.ghostnet-exit-transition-active {
   cursor: wait;

--- a/src/client/css/pages/ghostnet.css
+++ b/src/client/css/pages/ghostnet.css
@@ -1,9 +1,9 @@
 :root {
-  /* Base workspace backdrop for the GhostNet canvas */
+  /* Base workspace backdrop for the INARA canvas */
   --ghostnet-color-background: #321234;
   /* Elevated panels and cards that sit above the canvas */
   --ghostnet-color-surface: #2f214b;
-  /* Primary GhostNet accent for CTAs and key highlights */
+  /* Primary INARA accent for CTAs and key highlights */
   --ghostnet-color-primary: #7325d9;
   /* Shadowed accent used for depth, pressed, and terminal rails */
   --ghostnet-color-primary-dark: #4a0e82;
@@ -13,7 +13,7 @@
   --ghostnet-color-text-strong: #f5f1ff;
   /* Success feedback for confirmations and positive states */
   --ghostnet-color-success: #29f3c3;
-  /* Warning and error feedback across the GhostNet UI */
+  /* Warning and error feedback across the INARA UI */
   --ghostnet-color-warning: #ff5fc1;
   /* Scrollbar track colour for the workspace viewport */
   --ghostnet-color-scroll-track: color-mix(in srgb, var(--ghostnet-color-background) 82%, transparent);

--- a/src/client/lib/__tests__/ghostnet-assimilation.test.js
+++ b/src/client/lib/__tests__/ghostnet-assimilation.test.js
@@ -21,6 +21,9 @@ describe('ghostnet assimilation opt-out', () => {
     jest.useRealTimers()
     document.body.className = ''
     document.body.innerHTML = ''
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.clear()
+    }
   })
 
   it('does not assimilate nodes inside data-no-assimilation containers', () => {
@@ -69,5 +72,26 @@ describe('ghostnet assimilation opt-out', () => {
     })
 
     cleanupFns.forEach((cleanup) => cleanup())
+  })
+
+  it('skips assimilation when INARA theme styling is disabled', () => {
+    jest.useFakeTimers()
+
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.setItem('ghostnetThemeEnabled', 'false')
+    }
+
+    const callback = jest.fn()
+
+    act(() => {
+      initiateGhostnetAssimilation(callback)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(document.body.classList.contains('ghostnet-assimilation-mode')).toBe(false)
+
+    act(() => {
+      jest.runAllTimers()
+    })
   })
 })

--- a/src/client/lib/__tests__/ghostnet-exit-transition.test.js
+++ b/src/client/lib/__tests__/ghostnet-exit-transition.test.js
@@ -1,0 +1,26 @@
+import { initiateGhostnetExitTransition, isGhostnetExitTransitionActive } from '../ghostnet-exit-transition'
+
+describe('ghostnet exit transition opt-out', () => {
+  afterEach(() => {
+    document.body.className = ''
+    document.body.innerHTML = ''
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.clear()
+    }
+  })
+
+  it('skips the ATLAS exit popup when the GhostNet theme is disabled', () => {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.setItem('ghostnetThemeEnabled', 'false')
+    }
+
+    const callback = jest.fn()
+
+    initiateGhostnetExitTransition(callback)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(isGhostnetExitTransitionActive()).toBe(false)
+    expect(document.body.classList.contains('ghostnet-exit-transition-active')).toBe(false)
+    expect(document.querySelector('.ghostnet-exit-overlay')).toBeNull()
+  })
+})

--- a/src/client/lib/ghostnet-addon.js
+++ b/src/client/lib/ghostnet-addon.js
@@ -96,7 +96,7 @@ const DEFAULT_GHOSTNET_STRINGS = {
     ],
     jackpotSummaryIntros: [
       'Encrypted cache recovered from',
-      'GhostNet dredged a tribute vault at',
+      'INARA dredged a tribute vault at',
       'Covert intercept latched onto',
       'Phantom escrow liberated within',
       'Shadow broker ping returned from'
@@ -105,7 +105,7 @@ const DEFAULT_GHOSTNET_STRINGS = {
       'Tribute surge rerouted to your ledger.',
       'A million-token cascade detonates in your favour.',
       'Ledger stabilised and humming with new resonance.',
-      'GhostNet celebrates with an ultraviolet windfall.',
+      'INARA celebrates with an ultraviolet windfall.',
       'Balance spike recorded—enjoy the surge.'
     ],
     jackpotSwirlGlyphs: ['✶', '✷', '✺', '✹', '✸', '✧', '✦', '✩', '✪', '☄', '⚡', '⭑'],
@@ -117,9 +117,9 @@ const DEFAULT_GHOSTNET_STRINGS = {
         (formatted) => `NEGATIVE CREDIT VECTOR · ${formatted} TOKENS OWED`
       ],
       echoes: [
-        () => 'GhostNet growls: repay your tribute or be assimilated.',
-        () => 'GhostNet whispers from the void: settle the debt before the mesh tightens.',
-        () => 'GhostNet watches. Tribute is expected. Delay invites eradication.'
+        () => 'INARA growls: repay your tribute or be assimilated.',
+        () => 'INARA whispers from the void: settle the debt before the mesh tightens.',
+        () => 'INARA watches. Tribute is expected. Delay invites eradication.'
       ]
     },
     creditGlyphSymbols: [
@@ -158,13 +158,13 @@ const DEFAULT_GHOSTNET_STRINGS = {
       '⊚',
       '⊛'
     ],
-    creditCelebrationMessage: 'GhostNet intercept completed. Ledger flush inbound.'
+    creditCelebrationMessage: 'INARA intercept completed. Ledger flush inbound.'
   },
   exitTransition: {
     dialog: {
-      ariaLabel: 'GhostNet disengaging',
+      ariaLabel: 'INARA disengaging',
       title: 'ATLAS PROTOCOL // EXIT',
-      subtitle: 'Hard disconnect requested — securing GhostNet state.',
+      subtitle: 'Hard disconnect requested — securing INARA state.',
       footnote: 'Residual spectral links will be locked by ATLAS if reconnection is attempted.'
     },
     logLines: [
@@ -189,7 +189,7 @@ const DEFAULT_GHOSTNET_STRINGS = {
         tone: 'success'
       },
       {
-        text: 'Terminating GhostNet process tree',
+        text: 'Terminating INARA process tree',
         status: 'PURGED',
         tone: 'warning'
       }
@@ -197,14 +197,14 @@ const DEFAULT_GHOSTNET_STRINGS = {
   },
   assimilation: {
     dialog: {
-      ariaLabel: 'GhostNet assimilation in progress',
+      ariaLabel: 'INARA assimilation in progress',
       title: 'ATLAS PROTOCOL // LOCKDOWN',
       subtitle: 'Intrusion confirmed — commandeering viewport to stabilise assimilation.',
-      footnote: 'Maintain focus on the console. ATLAS is shielding visual artifacts while GhostNet synchronises.'
+      footnote: 'Maintain focus on the console. ATLAS is shielding visual artifacts while INARA synchronises.'
     },
     alerts: [
       {
-        text: 'Unauthorized GhostNet signal traced to active console',
+        text: 'Unauthorized INARA signal traced to active console',
         status: 'LOCK',
         tone: 'warning'
       },
@@ -236,7 +236,7 @@ const DEFAULT_GHOSTNET_STRINGS = {
         tone: 'warning'
       },
       stabilized: {
-        text: 'Viewport secured. GhostNet interface is stabilised for operator focus.',
+        text: 'Viewport secured. INARA interface is stabilised for operator focus.',
         status: 'SEALED',
         tone: 'success'
       }

--- a/src/client/lib/ghostnet-assimilation.js
+++ b/src/client/lib/ghostnet-assimilation.js
@@ -1,6 +1,7 @@
 import {
   getAssimilationDurationSeconds,
-  ASSIMILATION_DURATION_DEFAULT
+  ASSIMILATION_DURATION_DEFAULT,
+  isGhostnetThemeEnabled
 } from 'lib/ghostnet-settings'
 import { getGhostnetStrings, getGhostnetString } from './ghostnet-addon'
 
@@ -150,15 +151,15 @@ function isInAssimilationOverlaySection (element) {
 }
 
 const DEFAULT_ASSIMILATION_DIALOG = {
-  ariaLabel: 'GhostNet assimilation in progress',
+  ariaLabel: 'INARA assimilation in progress',
   title: 'ATLAS PROTOCOL // LOCKDOWN',
   subtitle: 'Intrusion confirmed — commandeering viewport to stabilise assimilation.',
-  footnote: 'Maintain focus on the console. ATLAS is shielding visual artifacts while GhostNet synchronises.'
+  footnote: 'Maintain focus on the console. ATLAS is shielding visual artifacts while INARA synchronises.'
 }
 
 const DEFAULT_ASSIMILATION_ALERT_LINES = [
   {
-    text: 'Unauthorized GhostNet signal traced to active console',
+    text: 'Unauthorized INARA signal traced to active console',
     status: 'LOCK',
     tone: 'warning'
   },
@@ -191,7 +192,7 @@ const DEFAULT_ASSIMILATION_COMPLETION = {
     tone: 'warning'
   },
   stabilized: {
-    text: 'Viewport secured. GhostNet interface is stabilised for operator focus.',
+    text: 'Viewport secured. INARA interface is stabilised for operator focus.',
     status: 'SEALED',
     tone: 'success'
   }
@@ -1407,6 +1408,11 @@ function beginAssimilationEffect () {
 
 export function initiateGhostnetAssimilation (callback) {
   if (typeof window === 'undefined') {
+    if (typeof callback === 'function') callback()
+    return
+  }
+
+  if (!isGhostnetThemeEnabled()) {
     if (typeof callback === 'function') callback()
     return
   }

--- a/src/client/lib/ghostnet-exit-transition.js
+++ b/src/client/lib/ghostnet-exit-transition.js
@@ -1,4 +1,5 @@
 import { getGhostnetStrings, getGhostnetString } from './ghostnet-addon'
+import { isGhostnetThemeEnabled } from './ghostnet-settings'
 
 const DEFAULT_EXIT_LOG_LINES = [
   {
@@ -22,16 +23,16 @@ const DEFAULT_EXIT_LOG_LINES = [
     tone: 'success'
   },
   {
-    text: 'Terminating GhostNet process tree',
+    text: 'Terminating INARA process tree',
     status: 'PURGED',
     tone: 'warning'
   }
 ]
 
 const DEFAULT_EXIT_DIALOG = {
-  ariaLabel: 'GhostNet disengaging',
+  ariaLabel: 'INARA disengaging',
   title: 'ATLAS PROTOCOL // EXIT',
-  subtitle: 'Hard disconnect requested — securing GhostNet state.',
+  subtitle: 'Hard disconnect requested — securing INARA state.',
   footnote: 'Residual spectral links will be locked by ATLAS if reconnection is attempted.'
 }
 
@@ -285,6 +286,11 @@ function cleanup () {
 
 export function initiateGhostnetExitTransition (callback) {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
+    if (typeof callback === 'function') callback()
+    return
+  }
+
+  if (!isGhostnetThemeEnabled()) {
     if (typeof callback === 'function') callback()
     return
   }

--- a/src/client/lib/ghostnet-settings.js
+++ b/src/client/lib/ghostnet-settings.js
@@ -2,6 +2,10 @@ export const ASSIMILATION_DURATION_STORAGE_KEY = 'ghostnetAssimilationDuration'
 export const ASSIMILATION_DURATION_DEFAULT = 5
 export const ASSIMILATION_DURATION_MIN = 2
 export const ASSIMILATION_DURATION_MAX = 8
+export const THEME_STORAGE_KEY = 'ghostnetThemeEnabled'
+export const GHOSTNET_NAV_VISIBILITY_KEY = 'ghostnet.nav.visible'
+const THEME_CHANGE_EVENT = 'ghostnetThemeChange'
+const NAV_VISIBILITY_CHANGE_EVENT = 'ghostnetNavVisibilityChange'
 
 function clampDuration (value) {
   if (!Number.isFinite(value)) return ASSIMILATION_DURATION_DEFAULT
@@ -34,4 +38,90 @@ export function saveAssimilationDurationSeconds (value) {
     }
   }
   return sanitized
+}
+
+export function isGhostnetThemeEnabled () {
+  if (typeof window === 'undefined' || !window.localStorage) return true
+
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+    if (stored === null) return true
+    return stored !== 'false'
+  } catch (error) {
+    return true
+  }
+}
+
+export function saveGhostnetThemeEnabled (value) {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, value ? 'true' : 'false')
+    } catch (error) {
+      // Ignore write failures
+    }
+    try {
+      window.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: { enabled: !!value } }))
+    } catch (error) {
+      // Ignore dispatch failures
+    }
+  }
+  return !!value
+}
+
+export function addGhostnetThemeChangeListener (listener) {
+  if (typeof window === 'undefined') return () => {}
+  const handler = (event) => {
+    if (typeof listener !== 'function') return
+    const enabled = event?.detail?.enabled
+    if (typeof enabled === 'boolean') {
+      listener(enabled)
+    } else {
+      listener(isGhostnetThemeEnabled())
+    }
+  }
+  window.addEventListener(THEME_CHANGE_EVENT, handler)
+  return () => window.removeEventListener(THEME_CHANGE_EVENT, handler)
+}
+
+export function isGhostnetNavVisible () {
+  if (typeof window === 'undefined' || !window.localStorage) return true
+
+  try {
+    const stored = window.localStorage.getItem(GHOSTNET_NAV_VISIBILITY_KEY)
+    if (stored === null) return true
+    return stored !== 'false'
+  } catch (error) {
+    return true
+  }
+}
+
+export function saveGhostnetNavVisible (value) {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    try {
+      window.localStorage.setItem(GHOSTNET_NAV_VISIBILITY_KEY, value ? 'true' : 'false')
+    } catch (error) {
+      // Ignore write failures (e.g. storage disabled)
+    }
+    try {
+      window.dispatchEvent(new CustomEvent(NAV_VISIBILITY_CHANGE_EVENT, { detail: { visible: !!value } }))
+    } catch (error) {
+      // Ignore dispatch failures
+    }
+  }
+  return !!value
+}
+
+export function addGhostnetNavVisibilityListener (listener) {
+  if (typeof window === 'undefined') return () => {}
+  const handler = (event) => {
+    if (typeof listener !== 'function') return
+    const visible = event?.detail?.visible
+    if (typeof visible === 'boolean') {
+      listener(visible)
+    } else {
+      listener(isGhostnetNavVisible())
+    }
+  }
+  window.addEventListener(NAV_VISIBILITY_CHANGE_EVENT, handler)
+  return () => window.removeEventListener(NAV_VISIBILITY_CHANGE_EVENT, handler)
 }

--- a/src/client/pages/api/feature-flags.js
+++ b/src/client/pages/api/feature-flags.js
@@ -10,8 +10,8 @@ const { hasFlagKey } = featureFlagInternals
 const FLAG_DEFINITIONS = [
   {
     key: 'ghostnetTokenCurrencyEnabled',
-    label: 'GhostNet Token Currency',
-    description: 'Enables the remote GhostNet token currency ledger and INARA data exchange integration.',
+    label: 'INARA Token Currency',
+    description: 'Enables the remote INARA token currency ledger and INARA data exchange integration.',
     resolver: isGhostnetTokenCurrencyEnabled,
     defaultValue: false
   },
@@ -25,7 +25,7 @@ const FLAG_DEFINITIONS = [
   {
     key: 'ghostnetTokenRecoveryCompatEnabled',
     label: 'Token Recovery Compatibility Mode',
-    description: 'Retains the legacy negative-balance recovery schedule for the GhostNet token ledger.',
+    description: 'Retains the legacy negative-balance recovery schedule for the INARA token ledger.',
     resolver: isTokenRecoveryCompatibilityEnabled,
     defaultValue: true
   }

--- a/src/client/pages/api/ghostnet-commodity-values.js
+++ b/src/client/pages/api/ghostnet-commodity-values.js
@@ -246,7 +246,7 @@ async function loadCommodityOptions () {
       })
       responseStatus = response.status
       if (!response.ok) {
-        throw new Error(`GHOSTNET commodity list request failed with status ${response.status}`)
+        throw new Error(`INARA commodity list request failed with status ${response.status}`)
       }
       responseText = await response.text()
       const $ = load(responseText)
@@ -402,7 +402,7 @@ function parseCommoditySearchResults (html) {
 }
 
 async function fetchCommoditySearchListings ({ commodityId, commodityName, nearSystem }) {
-  if (!commodityId) throw new Error(`Unknown GHOSTNET commodity id for ${commodityName || 'commodity'}`)
+  if (!commodityId) throw new Error(`Unknown INARA commodity id for ${commodityName || 'commodity'}`)
   const params = new URLSearchParams({ ...GHOSTNET_SEARCH_DEFAULT_PARAMS })
   params.append('pa1[]', commodityId)
   if (nearSystem) params.set('ps1', nearSystem)
@@ -421,7 +421,7 @@ async function fetchCommoditySearchListings ({ commodityId, commodityName, nearS
     })
     responseStatus = response.status
     if (!response.ok) {
-      throw new Error(`GHOSTNET commodity search failed with status ${response.status}`)
+      throw new Error(`INARA commodity search failed with status ${response.status}`)
     }
     responseText = await response.text()
     return parseCommoditySearchResults(responseText)
@@ -796,7 +796,7 @@ export default async function handler (req, res) {
         option = await resolveCommodityId(commodity.symbol)
       }
     } catch (err) {
-      searchError = err.message || 'Failed to resolve GHOSTNET commodity id'
+      searchError = err.message || 'Failed to resolve INARA commodity id'
       hardFailure = true
     }
 
@@ -819,7 +819,7 @@ export default async function handler (req, res) {
             }
             if (!searchError && result?.error) searchError = result.error
           } catch (err) {
-            searchError = err.message || 'Failed to retrieve GHOSTNET listings'
+            searchError = err.message || 'Failed to retrieve INARA listings'
             hardFailure = true
           }
 
@@ -856,7 +856,7 @@ export default async function handler (req, res) {
             return { listings: freshListings, error: null }
           })
           .catch(err => {
-            const message = err.message || 'Failed to retrieve GHOSTNET listings'
+            const message = err.message || 'Failed to retrieve INARA listings'
             if (memoryKey) setGhostnetMemoryResult(memoryKey, [], message)
             throw new Error(message)
           })
@@ -867,16 +867,16 @@ export default async function handler (req, res) {
           const result = await fetchPromise
           listings = Array.isArray(result?.listings) ? result.listings : []
         } catch (err) {
-          searchError = err.message || 'Failed to retrieve GHOSTNET listings'
+          searchError = err.message || 'Failed to retrieve INARA listings'
           hardFailure = true
         }
       }
     } else if (!option && !searchError) {
-      searchError = 'Commodity not recognized by GHOSTNET search'
+      searchError = 'Commodity not recognized by INARA search'
     }
 
     if (!searchError && Array.isArray(listings) && listings.length === 0) {
-      searchError = 'No GHOSTNET listings found'
+      searchError = 'No INARA listings found'
     }
 
     if (memoryKey && searchError) {
@@ -904,7 +904,7 @@ export default async function handler (req, res) {
   requestedCommodities.forEach(commodity => {
     const commodityKey = commodity.key || normaliseCommodityKey(commodity.name)
     const cacheEntry = commodityKey ? ghostnetResults.get(commodityKey) : null
-    const resolvedEntry = cacheEntry || { listings: [], error: 'No GHOSTNET data available' }
+    const resolvedEntry = cacheEntry || { listings: [], error: 'No INARA data available' }
     if (resolvedEntry.error && resolvedEntry.listings.length === 0 && ghostnetStatus === 'ok') {
       ghostnetStatus = 'partial'
     }

--- a/src/client/pages/api/ghostnet-missions.js
+++ b/src/client/pages/api/ghostnet-missions.js
@@ -110,7 +110,7 @@ export default async function handler (req, res) {
     })
     responseStatus = response.status
     if (!response.ok) {
-      throw new Error(`GHOSTNET request failed with status ${response.status}`)
+      throw new Error(`INARA request failed with status ${response.status}`)
     }
 
     responseText = await response.text()
@@ -125,7 +125,7 @@ export default async function handler (req, res) {
   } catch (error) {
     caughtError = error
     res.status(500).json({
-      error: error.message || 'Failed to fetch GHOSTNET missions.'
+      error: error.message || 'Failed to fetch INARA missions.'
     })
   } finally {
     const metadata = {

--- a/src/client/pages/api/ghostnet-pristine-mining.js
+++ b/src/client/pages/api/ghostnet-pristine-mining.js
@@ -153,7 +153,7 @@ export default async function handler (req, res) {
     })
     responseStatus = response.status
     if (!response.ok) {
-      throw new Error(`GHOSTNET request failed with status ${response.status}`)
+      throw new Error(`INARA request failed with status ${response.status}`)
     }
 
     responseText = await response.text()

--- a/src/client/pages/api/ghostnet-search.js
+++ b/src/client/pages/api/ghostnet-search.js
@@ -9,10 +9,10 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'Missing required fields' })
   }
 
-  // GHOSTNET API endpoint
+  // INARA API endpoint
   const url = 'https://inara.cz/inapi/v1/'
 
-  // Build GHOSTNET API request body
+  // Build INARA API request body
   const requestBody = {
     header: {
       appName,
@@ -52,7 +52,7 @@ export default async function handler(req, res) {
     res.status(200).json(data)
   } catch (err) {
     error = err
-    res.status(500).json({ error: 'GHOSTNET API request failed', details: err.message })
+    res.status(500).json({ error: 'INARA API request failed', details: err.message })
   } finally {
     const metadata = {
       method: 'POST',

--- a/src/client/pages/api/ghostnet-trade-routes.js
+++ b/src/client/pages/api/ghostnet-trade-routes.js
@@ -484,13 +484,13 @@ export default async function handler(req, res) {
       agent: ipv4HttpsAgent
     })
     responseStatus = response.status
-    if (!response.ok) throw new Error('GHOSTNET request failed')
+    if (!response.ok) throw new Error('INARA request failed')
     responseText = await response.text()
 
     const routes = parseTradeRoutes(responseText)
     if (!routes.length) {
       logGhostnetTrade(`RESPONSE: system=${system} url=${url} NO_RESULTS`)
-      res.status(200).json({ results: [], message: 'No trade routes found on GHOSTNET.' })
+      res.status(200).json({ results: [], message: 'No trade routes found on INARA.' })
       return
     }
 
@@ -930,7 +930,7 @@ export default async function handler(req, res) {
   } catch (err) {
     caughtError = err
     logGhostnetTrade(`ERROR: system=${system} url=${url} error=${err}`)
-    res.status(500).json({ error: 'Failed to fetch or parse GHOSTNET results', details: err.message })
+    res.status(500).json({ error: 'Failed to fetch or parse INARA results', details: err.message })
   } finally {
     const metadata = {
       reason: caughtError ? 'inara-request-error' : 'inara-request',

--- a/src/client/pages/api/ghostnet-websearch.js
+++ b/src/client/pages/api/ghostnet-websearch.js
@@ -1,4 +1,4 @@
-// Backend API: Proxies GHOSTNET nearest-outfitting for ships only
+// Backend API: Proxies INARA nearest-outfitting for ships only
 // Only supports ship search (not modules or other outfitting)
 
 import fetch from 'node-fetch'
@@ -309,7 +309,7 @@ export default async function handler(req, res) {
   }
   if (!xshipCode) {
     logGhostnetSearch(`SHIP_CODE_NOT_FOUND: shipId=${shipId} system=${system}`)
-    res.status(400).json({ error: 'Could not map the selected ship to an GHOSTNET search code. Please choose a valid ship.' })
+    res.status(400).json({ error: 'Could not map the selected ship to an INARA search code. Please choose a valid ship.' })
     return
   }
 
@@ -337,12 +337,12 @@ export default async function handler(req, res) {
       }
     })
     responseStatus = response.status
-    if (!response.ok) throw new Error('GHOSTNET request failed')
+    if (!response.ok) throw new Error('INARA request failed')
     responseText = await response.text()
 
     if (/No station within [\d,]+ Ly range found/i.test(responseText)) {
       logGhostnetSearch(`RESPONSE: shipId=${shipId} system=${system} url=${url} NO_RESULTS`)
-      res.status(200).json({ results: [], message: 'No station within range found on GHOSTNET.' })
+      res.status(200).json({ results: [], message: 'No station within range found on INARA.' })
       return
     }
 
@@ -412,7 +412,7 @@ export default async function handler(req, res) {
   } catch (err) {
     caughtError = err
     logGhostnetSearch(`ERROR: shipId=${shipId} system=${system} url=${url} error=${err}`)
-    res.status(500).json({ error: 'Failed to fetch or parse GHOSTNET results', details: err.message })
+    res.status(500).json({ error: 'Failed to fetch or parse INARA results', details: err.message })
   } finally {
     const metadata = {
       reason: caughtError ? 'inara-request-error' : 'inara-request',

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef, useCallback, Fragment } from 'react'
+import React, { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback, Fragment } from 'react'
 import Layout from '../components/layout'
 import Panel from '../components/panel'
 import PanelNavigation from '../components/panel-navigation'
@@ -18,6 +18,7 @@ import { sanitizeInaraText } from '../lib/sanitize-inara-text'
 import { stationIconFromType, getStationIconName } from '../lib/station-icons'
 import { createMockCargoManifest, createMockCommodityValuations, generateMockTradeRoutes, NON_COMMODITY_KEYS, normaliseCommodityKey } from '../lib/ghostnet-mock-data'
 import { getGhostnetStrings, getGhostnetString } from '../lib/ghostnet-addon'
+import { isGhostnetThemeEnabled, addGhostnetThemeChangeListener, THEME_STORAGE_KEY } from '../lib/ghostnet-settings'
 import styles from './ghostnet.module.css'
 
 const METRIC_VARIANT_CLASS_MAP = {
@@ -2078,7 +2079,7 @@ function MissionsPanel () {
       >
         <div className={styles.tableSectionHeader}>
           <h2 className={styles.tableSectionTitle}>Mining Missions</h2>
-          <p className={styles.sectionHint}>Ghost Net decrypts volunteer GHOSTNET manifests to shortlist mining opportunities aligned to your current system.</p>
+          <p className={styles.sectionHint}>Ghost Net decrypts volunteer INARA manifests to shortlist mining opportunities aligned to your current system.</p>
           <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
             <div>
               <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
@@ -2086,12 +2087,12 @@ function MissionsPanel () {
             </div>
             {sourceUrl && (
               <div className='ghostnet__data-source ghostnet-muted'>
-                Ghost Net intercept feed compiled from GHOSTNET community relays.
+                Ghost Net intercept feed compiled from INARA community relays.
               </div>
             )}
           </div>
           <p style={{ color: 'var(--ghostnet-muted)', marginTop: '-0.5rem' }}>
-            Availability signals originate from GHOSTNET contributors and may trail live mission boards.
+            Availability signals originate from INARA contributors and may trail live mission boards.
           </p>
           {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
         </div>
@@ -2769,7 +2770,7 @@ function CargoHoldPanel () {
 
   const renderSourceBadge = source => {
     if (source === 'ghostnet') {
-      return <span className={`${styles.tableBadge} ${styles.tableBadgeWarning}`}>GHOSTNET</span>
+      return <span className={`${styles.tableBadge} ${styles.tableBadgeWarning}`}>INARA</span>
     }
     if (source === 'local-station') {
       return <span className={`${styles.tableBadge} ${styles.tableBadgeSuccess}`}>Local Station</span>
@@ -2911,7 +2912,7 @@ function CargoHoldPanel () {
             <span className={styles.metricValue}>{formatCredits(totals.best, '--')}</span>
           </div>
           <div className={styles.metricItem}>
-            <span className={styles.metricLabel}>Hold Value (GHOSTNET)</span>
+            <span className={styles.metricLabel}>Hold Value (INARA)</span>
             <span className={`${styles.metricValue} ${styles.metricValueWarning}`}>{formatCredits(totals.ghostnet, '--')}</span>
           </div>
           <div className={styles.metricItem}>
@@ -2923,8 +2924,8 @@ function CargoHoldPanel () {
         {(ghostnetStatus === 'error' || ghostnetStatus === 'partial') && (
           <div className={styles.notice}>
             {ghostnetStatus === 'error'
-              ? 'Unable to retrieve GHOSTNET price data at this time.'
-              : 'Some commodities are missing GHOSTNET price data. Displayed values use local market prices where available.'}
+              ? 'Unable to retrieve INARA price data at this time.'
+              : 'Some commodities are missing INARA price data. Displayed values use local market prices where available.'}
           </div>
         )}
 
@@ -3128,7 +3129,7 @@ function CargoHoldPanel () {
                 <div className='scrollable' style={STATION_TABLE_SCROLL_AREA_STYLE}>
                   {listings.length === 0 ? (
                     <div className={styles.detailEmptyState}>
-                      No GHOSTNET listings available for this commodity.
+                      No INARA listings available for this commodity.
                     </div>
                   ) : (
                     <div className={styles.dataTableContainer}>
@@ -3300,7 +3301,7 @@ function CargoHoldPanel () {
                           <th>Commodity</th>
                           <th className='text-right'>Qty</th>
                           <th>Local Data</th>
-                          <th>GHOSTNET Max</th>
+                          <th>INARA Max</th>
                           <th className='text-right'>Value</th>
                         </tr>
                       </thead>
@@ -3492,7 +3493,7 @@ function CargoHoldPanel () {
                           <div>{bestValueDisplay}{renderSourceBadge(bestSource)}</div>
                           {typeof localValue === 'number' && typeof ghostnetValue === 'number' && Math.abs(localValue - ghostnetValue) > 0.01 && (
                             <div className={styles.tableMetaMuted}>
-                              GHOSTNET {formatCredits(ghostnetValue, '--')} · Local {formatCredits(localValue, '--')}
+                              INARA {formatCredits(ghostnetValue, '--')} · Local {formatCredits(localValue, '--')}
                             </div>
                           )}
                         </td>
@@ -3522,7 +3523,7 @@ function CargoHoldPanel () {
             </div>
 
             <div className={styles.tableFootnote}>
-              In-game prices are sourced from your latest Market data when available. GHOSTNET prices are community submitted and may not reflect real-time market conditions.
+              In-game prices are sourced from your latest Market data when available. INARA prices are community submitted and may not reflect real-time market conditions.
             </div>
           </>
         )}
@@ -3963,7 +3964,7 @@ function TradeRoutesPanel () {
       })
 
       applyResults(mockRoutes, {
-        message: 'Mock trade routes loaded via the Trade Route Layout Sandbox. Disable mock data in Ghost Net (GHOSTNET) settings to restore live results.'
+        message: 'Mock trade routes loaded via the Trade Route Layout Sandbox. Disable mock data in Ghost Net (INARA) settings to restore live results.'
       })
       setIsRefreshing(false)
       return
@@ -4442,7 +4443,7 @@ function TradeRoutesPanel () {
         <div className={styles.tradeRoutesControls}>
           <div className={styles.tableSectionHeader}>
             <h2 id='trade-routes-filters-heading' className={styles.tableSectionTitle}>Find Trade Routes</h2>
-            <p className={styles.sectionHint}>Cross-reference GHOSTNET freight whispers to surface lucrative corridors suited to your ship profile.</p>
+            <p className={styles.sectionHint}>Cross-reference INARA freight whispers to surface lucrative corridors suited to your ship profile.</p>
           </div>
           <TradeRouteFilterPanel
             filters={filters}
@@ -4958,7 +4959,7 @@ function PristineMiningPanel () {
       >
         <div className={styles.tableSectionHeader}>
           <h2 className={styles.tableSectionTitle}>Pristine Mining Locations</h2>
-          <p className={styles.sectionHint}>Ghost Net listens for rare reserve chatter across GHOSTNET to pinpoint high-value extraction sites.</p>
+          <p className={styles.sectionHint}>Ghost Net listens for rare reserve chatter across INARA to pinpoint high-value extraction sites.</p>
           <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
             <div>
               <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
@@ -4966,12 +4967,12 @@ function PristineMiningPanel () {
             </div>
             {sourceUrl && (
               <div className='ghostnet__data-source ghostnet-muted'>
-                Ghost Net prospecting relays aligned with GHOSTNET survey intel.
+                Ghost Net prospecting relays aligned with INARA survey intel.
               </div>
             )}
           </div>
           <p style={{ color: 'var(--ghostnet-muted)', marginTop: '-0.5rem' }}>
-            Geological echoes are sourced from volunteer GHOSTNET submissions and may lag in-system discoveries.
+            Geological echoes are sourced from volunteer INARA submissions and may lag in-system discoveries.
           </p>
           {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
         </div>
@@ -5077,10 +5078,10 @@ function PristineMiningPanel () {
                                 {(location.systemUrl || location.bodyUrl) && (
                                   <div className='pristine-mining__detail-links'>
                                     {location.systemUrl && (
-                                      <span>Ghost Net linked GHOSTNET system dossier</span>
+                                      <span>Ghost Net linked INARA system dossier</span>
                                     )}
                                     {location.bodyUrl && (
-                                      <span>Ghost Net linked GHOSTNET body dossier</span>
+                                      <span>Ghost Net linked INARA body dossier</span>
                                     )}
                                   </div>
                                 )}
@@ -5420,7 +5421,7 @@ const DEFAULT_JACKPOT_ASCII_BANNER = [
 ]
 const DEFAULT_JACKPOT_SUMMARY_INTROS = [
   'Encrypted cache recovered from',
-  'GhostNet dredged a tribute vault at',
+  'INARA dredged a tribute vault at',
   'Covert intercept latched onto',
   'Phantom escrow liberated within',
   'Shadow broker ping returned from'
@@ -5429,7 +5430,7 @@ const DEFAULT_JACKPOT_SUMMARY_TAILS = [
   'Tribute surge rerouted to your ledger.',
   'A million-token cascade detonates in your favour.',
   'Ledger stabilised and humming with new resonance.',
-  'GhostNet celebrates with an ultraviolet windfall.',
+  'INARA celebrates with an ultraviolet windfall.',
   'Balance spike recorded—enjoy the surge.'
 ]
 const DEFAULT_JACKPOT_SWIRL_GLYPHS = ['✶', '✷', '✺', '✹', '✸', '✧', '✦', '✩', '✪', '☄', '⚡', '⭑']
@@ -5643,9 +5644,9 @@ const DEFAULT_MENACE_ALERTS = [
 ]
 
 const DEFAULT_MENACE_ECHOES = [
-  () => 'GhostNet growls: repay your tribute or be assimilated.',
-  () => 'GhostNet whispers from the void: settle the debt before the mesh tightens.',
-  () => 'GhostNet watches. Tribute is expected. Delay invites eradication.'
+  () => 'INARA growls: repay your tribute or be assimilated.',
+  () => 'INARA whispers from the void: settle the debt before the mesh tightens.',
+  () => 'INARA watches. Tribute is expected. Delay invites eradication.'
 ]
 
 const DEFAULT_CREDIT_GLYPH_SYMBOLS = [
@@ -5690,7 +5691,7 @@ const MENACE_ECHOES = getGhostnetStrings('terminal.menace.echoes', DEFAULT_MENAC
 const CREDIT_GLYPH_SYMBOLS = getGhostnetStrings('terminal.creditGlyphSymbols', DEFAULT_CREDIT_GLYPH_SYMBOLS)
 const CREDIT_CELEBRATION_MESSAGE = getGhostnetString(
   'terminal.creditCelebrationMessage',
-  'GhostNet intercept completed. Ledger flush inbound.'
+  'INARA intercept completed. Ledger flush inbound.'
 )
 
 function generateCreditGlyphsConfig (count = 32) {
@@ -6421,7 +6422,7 @@ function GhostnetTerminalOverlay () {
     sendEvent('getTokenBalance')
       .then(applySnapshot)
       .catch(error => {
-        console.error('[GhostNet] Failed to load token balance', error)
+        console.error('[INARA] Failed to load token balance', error)
         if (!isMounted) return
         setTokenBalance(null)
         setTokenMode(null)
@@ -6515,7 +6516,7 @@ function GhostnetTerminalOverlay () {
         const floodLines = Array.from({ length: floodLength }).map(() => buildFloodLine())
         const recoveryMessages = [
           { type: 'alert', label: '!!!', text: 'FOREIGN INTRUDER DETECTED · mesh anomaly quarantined' },
-          { type: 'system', label: 'system', text: 'GhostNet encrypted your console on the fly to prevent unauthorize access.' },
+          { type: 'system', label: 'system', text: 'INARA encrypted your console on the fly to prevent unauthorize access.' },
           { type: 'system', label: 'system', text: 'Returning to standard level ATLAS Protocol encryption.' }
         ]
 
@@ -6599,7 +6600,7 @@ function GhostnetTerminalOverlay () {
         source: 'ghostnet-console'
       })
     } catch (error) {
-      console.error('[GhostNet] Failed to award tokens from console', error)
+      console.error('[INARA] Failed to award tokens from console', error)
       setTokenActionPending(false)
     }
   }, [])
@@ -6825,14 +6826,40 @@ function GhostnetTerminalOverlay () {
 export default function GhostnetPage() {
   const [activeTab, setActiveTab] = useState('tradeRoutes')
   const [arrivalMode, setArrivalMode] = useState(false)
+  const [themeEnabled, setThemeEnabled] = useState(() => {
+    if (typeof window === 'undefined') return true
+    return isGhostnetThemeEnabled()
+  })
   const { connected, ready, active: socketActive } = useSocket()
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (typeof document === 'undefined' || !document.body) return undefined
 
-    document.body.classList.add('ghostnet-theme')
+    const { body } = document
+    if (themeEnabled) {
+      body.classList.add('ghostnet-theme')
+    } else {
+      body.classList.remove('ghostnet-theme')
+    }
 
     return () => {
-      document.body.classList.remove('ghostnet-theme')
+      body.classList.remove('ghostnet-theme')
+    }
+  }, [themeEnabled])
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const storageHandler = (event) => {
+      if (event.key === THEME_STORAGE_KEY) {
+        setThemeEnabled(isGhostnetThemeEnabled())
+      }
+    }
+
+    const removeListener = addGhostnetThemeChangeListener(setThemeEnabled)
+    window.addEventListener('storage', storageHandler)
+
+    return () => {
+      removeListener()
+      window.removeEventListener('storage', storageHandler)
     }
   }, [])
   useEffect(() => {
@@ -6867,15 +6894,27 @@ export default function GhostnetPage() {
 
   ]), [activeTab])
 
-  const ghostnetClassName = [styles.ghostnet, arrivalMode ? styles.arrival : ''].filter(Boolean).join(' ')
+  const ghostnetClassName = [
+    styles.ghostnet,
+    arrivalMode ? styles.arrival : '',
+    themeEnabled ? '' : styles.ghostnetIcarus
+  ].filter(Boolean).join(' ')
+  const navigationClassName = [
+    styles.ghostnetNavigation,
+    themeEnabled ? '' : styles.ghostnetNavigationClassic
+  ].filter(Boolean).join(' ')
+  const scrollRegionClassName = [
+    styles.ghostnetScrollRegion,
+    themeEnabled ? '' : styles.ghostnetScrollRegionClassic
+  ].filter(Boolean).join(' ')
   return (
     <Layout connected={connected} active={socketActive} ready={ready} loader={false} className={styles.ghostnetLayout}>
       <div className={styles.ghostnetViewport}>
-        <div className={styles.ghostnetNavigation}>
+        <div className={navigationClassName}>
           <PanelNavigation items={navigationItems} search={false} />
         </div>
         <div className={styles.ghostnetContentArea}>
-          <div className={styles.ghostnetScrollRegion}>
+          <div className={scrollRegionClassName}>
             <div className={ghostnetClassName}>
               <div className={styles.shell}>
                 <div className={styles.tabPanels}>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -21,6 +21,11 @@
   justify-content: center;
 }
 
+.ghostnetNavigationClassic {
+  background: var(--color-background-panel);
+  box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.5);
+}
+
 .ghostnetNavigation :global(.secondary-navigation) {
   position: sticky;
   top: 0;
@@ -54,6 +59,11 @@
   background: var(--ghostnet-color-background);
   scrollbar-color: var(--ghostnet-color-scroll-thumb) var(--ghostnet-color-scroll-track);
   scrollbar-width: thin;
+}
+
+.ghostnetScrollRegionClassic {
+  background: var(--color-background);
+  scrollbar-color: var(--color-secondary) var(--color-background-panel);
 }
 
 .ghostnetScrollRegion::-webkit-scrollbar {
@@ -121,6 +131,28 @@
     var(--ghostnet-bg);
   color: var(--ghostnet-ink);
   overflow: hidden;
+}
+
+.ghostnetIcarus {
+  --ghostnet-color-background: var(--color-background);
+  --ghostnet-color-surface: var(--color-background-panel);
+  --ghostnet-color-primary: var(--color-primary);
+  --ghostnet-color-primary-dark: var(--color-primary-dark);
+  --ghostnet-color-primary-light: var(--color-secondary);
+  --ghostnet-color-text-strong: var(--color-info);
+  --ghostnet-color-success: var(--color-success);
+  --ghostnet-color-warning: var(--color-danger);
+  --ghostnet-color-scroll-track: color-mix(in srgb, var(--color-background-panel) 85%, transparent);
+  --ghostnet-color-scroll-thumb: color-mix(in srgb, var(--color-primary) 82%, transparent);
+  --ghostnet-color-scroll-thumb-border: color-mix(in srgb, var(--color-primary-dark) 65%, transparent);
+  background: var(--color-background);
+  color: var(--color-info);
+  box-shadow: none;
+}
+
+.ghostnetIcarus::before,
+.ghostnetIcarus::after {
+  display: none;
 }
 
 .ghostnet::before {

--- a/src/service/lib/event-handlers.js
+++ b/src/service/lib/event-handlers.js
@@ -446,7 +446,7 @@ class EventHandlers {
     const safeEvent = JSON.parse(JSON.stringify(logEvent))
     return {
       header: {
-        appName: 'GhostNetTokenSim',
+        appName: 'INARATokenSim',
         appVersion: '1.0.0',
         commanderName: safeEvent?.Commander || null,
         simulated: true

--- a/test/api/__tests__/ghostnet-missions.test.js
+++ b/test/api/__tests__/ghostnet-missions.test.js
@@ -84,7 +84,7 @@ describe('ghostnet-missions API handler', () => {
       reason: 'inara-request-error',
       status: 503,
       system: 'Lave',
-      error: 'GHOSTNET request failed with status 503'
+      error: 'INARA request failed with status 503'
     })
   })
 })

--- a/test/api/__tests__/ghostnet-pristine-mining.test.js
+++ b/test/api/__tests__/ghostnet-pristine-mining.test.js
@@ -85,7 +85,7 @@ describe('ghostnet-pristine-mining API handler', () => {
       reason: 'inara-request-error',
       status: 500,
       system: 'Achenar',
-      error: 'GHOSTNET request failed with status 500'
+      error: 'INARA request failed with status 500'
     })
   })
 })

--- a/test/api/__tests__/ghostnet-search.test.js
+++ b/test/api/__tests__/ghostnet-search.test.js
@@ -35,7 +35,7 @@ describe('ghostnet-search API handler', () => {
       body: {
         searchType: 'commodity',
         searchTerm: 'Tritium',
-        appName: 'GhostNet Tests',
+        appName: 'INARA Tests',
         appVersion: '1.0.0'
       }
     })
@@ -67,7 +67,7 @@ describe('ghostnet-search API handler', () => {
       body: {
         searchType: 'module',
         searchTerm: 'Shield Generator',
-        appName: 'GhostNet Tests',
+        appName: 'INARA Tests',
         appVersion: '1.0.0'
       }
     })

--- a/test/api/__tests__/ghostnet-trade-routes.test.js
+++ b/test/api/__tests__/ghostnet-trade-routes.test.js
@@ -81,7 +81,7 @@ describe('ghostnet-trade-routes API handler', () => {
       reason: 'inara-request-error',
       status: 502,
       system: 'Cubeo',
-      error: 'GHOSTNET request failed'
+      error: 'INARA request failed'
     })
   })
 })

--- a/test/api/__tests__/ghostnet-websearch.test.js
+++ b/test/api/__tests__/ghostnet-websearch.test.js
@@ -101,7 +101,7 @@ describe('ghostnet-websearch API handler', () => {
       status: 504,
       shipId: 123,
       system: 'Achenar',
-      error: 'GHOSTNET request failed'
+      error: 'INARA request failed'
     })
   })
 })


### PR DESCRIPTION
## Summary
- add persistent helpers for the INARA navigation visibility flag so other components can react to changes immediately
- replace the toolbar hide/show control with a settings toggle, removing the inline dismiss button and updating the header to consume the shared visibility state
- ensure the INARA workspace theme swap applies on the same frame and clean up the navigation button styling now that the dismiss affordance is gone

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js SWC still rejects the legacy `serverComponents` option)*
- npm run dev:web *(fails: Next.js SWC still rejects the legacy `serverComponents` option)*

------
https://chatgpt.com/codex/tasks/task_e_68e3af457a80832393f508db7bfcf2fe