### PR TITLE
Ensure INARA Icarus theme uses black background

### DIFF
--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -22,7 +22,7 @@
 }
 
 .ghostnetNavigationClassic {
-  background: var(--color-background-panel);
+  background: #000;
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.5);
 }
 
@@ -62,8 +62,8 @@
 }
 
 .ghostnetScrollRegionClassic {
-  background: var(--color-background);
-  scrollbar-color: var(--color-secondary) var(--color-background-panel);
+  background: #000;
+  scrollbar-color: var(--color-secondary) #000;
 }
 
 .ghostnetScrollRegion::-webkit-scrollbar {
@@ -134,7 +134,7 @@
 }
 
 .ghostnetIcarus {
-  --ghostnet-color-background: var(--color-background);
+  --ghostnet-color-background: #000;
   --ghostnet-color-surface: var(--color-background-panel);
   --ghostnet-color-primary: var(--color-primary);
   --ghostnet-color-primary-dark: var(--color-primary-dark);
@@ -142,10 +142,14 @@
   --ghostnet-color-text-strong: var(--color-info);
   --ghostnet-color-success: var(--color-success);
   --ghostnet-color-warning: var(--color-danger);
-  --ghostnet-color-scroll-track: color-mix(in srgb, var(--color-background-panel) 85%, transparent);
-  --ghostnet-color-scroll-thumb: color-mix(in srgb, var(--color-primary) 82%, transparent);
-  --ghostnet-color-scroll-thumb-border: color-mix(in srgb, var(--color-primary-dark) 65%, transparent);
-  background: var(--color-background);
+  --ghostnet-color-scroll-track: #000;
+  --ghostnet-color-scroll-thumb: color-mix(in srgb, var(--color-secondary) 75%, transparent);
+  --ghostnet-color-scroll-thumb-border: color-mix(in srgb, var(--color-secondary) 45%, transparent);
+  --ghostnet-gradient-top: #000;
+  --ghostnet-gradient-mid: #000;
+  --ghostnet-gradient-bottom: #000;
+  --ghostnet-bg: #000;
+  background: #000;
   color: var(--color-info);
   box-shadow: none;
 }


### PR DESCRIPTION
## Summary
- set the INARA navigation rail and content background to true black when the Ghostnet theme is disabled
- update the Icarus theme overrides to flatten gradients and keep scrollbar accents legible on the black backdrop

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js swc transform error `unknown field serverComponents`)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c8434d988323904d3801f1f8ad05