### PR TITLE
Normalize trade routes table header

### DIFF
--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -3867,13 +3867,6 @@ function TradeRoutesPanel () {
     })
   }, [])
 
-  const handleSortKeyDown = useCallback((event, field) => {
-    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
-      event.preventDefault()
-      handleSortChange(field)
-    }
-  }, [handleSortChange])
-
   const renderSortArrow = field => {
     if (sortField !== field) return null
     const arrow = sortDirection === 'asc' ? String.fromCharCode(0x25B2) : String.fromCharCode(0x25BC)
@@ -4363,57 +4356,44 @@ function TradeRoutesPanel () {
           <tr>
             <th aria-hidden='true' className={styles.tableCellCaret} />
             <th
-              className={styles.tableHeaderInteractive}
-              onClick={() => handleSortChange('stationA')}
-              onKeyDown={event => handleSortKeyDown(event, 'stationA')}
-              tabIndex={0}
+              scope='col'
               aria-sort={sortField === 'stationA' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
             >
-              <div className={styles.tradeRoutesHeader}>
-                <div className={styles.tradeRoutesHeaderTitle}>
-                  <span>Station A</span>
-                  {renderSortArrow('stationA')}
-                </div>
-                <span className={styles.tradeRoutesHeaderSubtitle}>Origin Station</span>
-              </div>
+              <button
+                type='button'
+                className={`${styles.tableHeaderButton} ${sortField === 'stationA' ? styles.tableHeaderButtonActive : ''}`}
+                onClick={() => handleSortChange('stationA')}
+              >
+                Station A
+                {renderSortArrow('stationA')}
+              </button>
             </th>
-            <th aria-sort='none'>
-              <div className={styles.tradeRoutesHeader}>
-                <div className={styles.tradeRoutesHeaderTitle}>
-                  <span>Commodities</span>
-                </div>
-                <span className={styles.tradeRoutesHeaderSubtitle}>Outbound &amp; Return</span>
-              </div>
-            </th>
+            <th scope='col' aria-sort='none'>Commodities</th>
             <th
-              className={styles.tableHeaderInteractive}
-              onClick={() => handleSortChange('stationB')}
-              onKeyDown={event => handleSortKeyDown(event, 'stationB')}
-              tabIndex={0}
+              scope='col'
               aria-sort={sortField === 'stationB' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
             >
-              <div className={styles.tradeRoutesHeader}>
-                <div className={styles.tradeRoutesHeaderTitle}>
-                  <span>Station B</span>
-                  {renderSortArrow('stationB')}
-                </div>
-                <span className={styles.tradeRoutesHeaderSubtitle}>Destination Station</span>
-              </div>
+              <button
+                type='button'
+                className={`${styles.tableHeaderButton} ${sortField === 'stationB' ? styles.tableHeaderButtonActive : ''}`}
+                onClick={() => handleSortChange('stationB')}
+              >
+                Station B
+                {renderSortArrow('stationB')}
+              </button>
             </th>
             <th
-              className={styles.tableHeaderInteractive}
-              onClick={() => handleSortChange('profit')}
-              onKeyDown={event => handleSortKeyDown(event, 'profit')}
-              tabIndex={0}
+              scope='col'
               aria-sort={sortField === 'profit' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
             >
-              <div className={styles.tradeRoutesHeader}>
-                <div className={styles.tradeRoutesHeaderTitle}>
-                  <span>Profit</span>
-                  {renderSortArrow('profit')}
-                </div>
-                <span className={styles.tradeRoutesHeaderSubtitle}>Per t, Trip, Hour</span>
-              </div>
+              <button
+                type='button'
+                className={`${styles.tableHeaderButton} ${sortField === 'profit' ? styles.tableHeaderButtonActive : ''}`}
+                onClick={() => handleSortChange('profit')}
+              >
+                Profit
+                {renderSortArrow('profit')}
+              </button>
             </th>
           </tr>
         </thead>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -2375,35 +2375,6 @@ button.terminalStatusPreview:focus-visible {
   border: 0;
 }
 
-.tradeRoutesHeader {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.tradeRoutesHeaderTitle {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--ghostnet-ink);
-  text-transform: none;
-}
-
-.tradeRoutesHeaderSubtitle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.68rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--ghostnet-text-soft);
-  background: color-mix(in srgb, var(--ghostnet-color-primary) 24%, transparent);
-  padding: 0.18rem 0.55rem;
-  border-radius: 999px;
-}
-
 .tradeRoutesQuantityBadge {
   display: inline-flex;
   align-items: center;
@@ -2509,11 +2480,6 @@ button.terminalStatusPreview:focus-visible {
   display: flex;
   align-items: center;
   gap: 0.55rem;
-}
-
-.tableHeaderInteractive {
-  cursor: pointer;
-  user-select: none;
 }
 
 .tableHeaderButton {


### PR DESCRIPTION
## Summary
- replace the trade routes table headers with the shared button-based layout so the sort controls match other tables
- remove the bespoke trade route header styling that is no longer needed after the markup change

## Testing
- npm test -- --runInBand --config jest.config.js *(fails: npm not found in container)*
- npm run build:client *(fails: npm not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c8994238832388beeac4e578ca90