### PR TITLE
Add feature flag guard for GhostNet theme toggle

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,15 +4,15 @@
 The INARA workspace supports a dynamic theme switch between the classic ICARUS theme and the GhostNet theme. This allows users to toggle between:
 
 - **ICARUS Theme:** Uses the legacy color palette, transitions, and layout conventions familiar from earlier versions of ICARUS Terminal. The ICARUS theme is characterized by its classic blue/indigo palette, subdued gradients, and minimal animation.
-- **GhostNet Theme:** Applies the new INARA visual identity, including royal purple (`#5D2EFF`) as the primary accent, neon gradients, animated overlays, and a denser, more immersive UI. The GhostNet theme is enabled by default for the INARA workspace and can be toggled in the settings panel.
+- **GhostNet Theme:** Applies the new INARA visual identity, including royal purple (`#5D2EFF`) as the primary accent, neon gradients, animated overlays, and a denser, more immersive UI. The GhostNet theme can be enabled when the deployment exposes the `ghostnetThemeToggleEnabled` feature flag; otherwise the classic ICARUS palette remains active by default.
 
-Theme switching is managed via the settings modal (`ThemeSettings` in `src/client/components/settings.js`). The theme state is stored in localStorage and can be toggled at runtime without a page reload. When the GhostNet theme is enabled, the workspace applies:
+Theme switching is managed via the settings modal (`ThemeSettings` in `src/client/components/settings.js`). The theme state is stored in localStorage and can be toggled at runtime without a page reload when the `ghostnetThemeToggleEnabled` feature flag is active. When the GhostNet theme is enabled, the workspace applies:
 - GhostNet palette tokens from `src/client/css/pages/ghostnet.css`
 - Animated arrival/exit transitions (`ghostnet-assimilation.js`)
 - Neon overlays and signal mesh backgrounds
 - INARA-specific navigation and panel shells
 
-When the GhostNet theme is disabled, the workspace reverts to ICARUS colors, transitions, and navigation. All INARA features remain available, but the visual experience matches the classic ICARUS look.
+When the GhostNet theme is disabled—or when the feature flag is unavailable—the workspace reverts to ICARUS colors, transitions, and navigation. All INARA features remain available, but the visual experience matches the classic ICARUS look.
 
 **Note:** Theme switching is only available in the INARA workspace. Legacy Icarus pages do not support GhostNet theming.
 

--- a/src/client/components/settings.js
+++ b/src/client/components/settings.js
@@ -10,6 +10,7 @@ import {
   isGhostnetThemeEnabled,
   saveGhostnetThemeEnabled,
   addGhostnetThemeChangeListener,
+  isGhostnetThemeToggleAvailable,
   THEME_STORAGE_KEY,
   isGhostnetNavVisible,
   saveGhostnetNavVisible,
@@ -355,6 +356,7 @@ function ThemeSettings () {
   const [secondaryColor, setSecondaryColor] = useState(getSecondaryColorAsHex())
   const [secondaryColorModifier, setSecondaryColorModifier] = useState(getSecondaryColorModifier())
   const [ghostnetThemeEnabled, setGhostnetThemeEnabled] = useState(() => isGhostnetThemeEnabled())
+  const [themeToggleAvailable, setThemeToggleAvailable] = useState(() => isGhostnetThemeToggleAvailable())
 
   // Update this component if another window updates the theme settings
   const storageEventHandler = (event) => {
@@ -370,6 +372,10 @@ function ThemeSettings () {
     if (typeof window === 'undefined') return undefined
     window.addEventListener('storage', storageEventHandler)
     return () => window.removeEventListener('storage', storageEventHandler)
+  }, [])
+
+  useEffect(() => {
+    setThemeToggleAvailable(isGhostnetThemeToggleAvailable())
   }, [])
 
   useEffect(() => eventListener('syncMessage', async (event) => {
@@ -543,6 +549,7 @@ function ThemeSettings () {
         <input
           type='checkbox'
           checked={ghostnetThemeEnabled}
+          disabled={!themeToggleAvailable}
           onChange={(event) => {
             const sanitized = saveGhostnetThemeEnabled(event.target.checked)
             setGhostnetThemeEnabled(sanitized)
@@ -555,6 +562,11 @@ function ThemeSettings () {
       <p className='text-muted' style={{ marginTop: 0, fontSize: '.95rem' }}>
         Disable this setting to keep INARA&apos;s layouts while returning to the classic ICARUS palette and transitions.
       </p>
+      {!themeToggleAvailable && (
+        <p className='text-muted' style={{ marginTop: '-0.35rem', fontSize: '.95rem' }}>
+          The GhostNet theme toggle is disabled for this deployment, so the classic ICARUS theme remains active by default.
+        </p>
+      )}
     </div>
   )
 }

--- a/src/client/lib/__tests__/ghostnet-assimilation.test.js
+++ b/src/client/lib/__tests__/ghostnet-assimilation.test.js
@@ -16,6 +16,10 @@ const mockRect = (element, rect) => {
 }
 
 describe('ghostnet assimilation opt-out', () => {
+  beforeEach(() => {
+    document.documentElement.dataset.ghostnetThemeToggleEnabled = 'true'
+  })
+
   afterEach(() => {
     jest.clearAllTimers()
     jest.useRealTimers()
@@ -24,10 +28,15 @@ describe('ghostnet assimilation opt-out', () => {
     if (typeof window !== 'undefined' && window.localStorage) {
       window.localStorage.clear()
     }
+    delete document.documentElement.dataset.ghostnetThemeToggleEnabled
   })
 
   it('does not assimilate nodes inside data-no-assimilation containers', () => {
     jest.useFakeTimers()
+
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.setItem('ghostnetThemeEnabled', 'true')
+    }
 
     render(
       <div>
@@ -79,6 +88,29 @@ describe('ghostnet assimilation opt-out', () => {
 
     if (typeof window !== 'undefined' && window.localStorage) {
       window.localStorage.setItem('ghostnetThemeEnabled', 'false')
+    }
+
+    const callback = jest.fn()
+
+    act(() => {
+      initiateGhostnetAssimilation(callback)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(document.body.classList.contains('ghostnet-assimilation-mode')).toBe(false)
+
+    act(() => {
+      jest.runAllTimers()
+    })
+  })
+
+  it('skips assimilation when the GhostNet theme toggle flag is disabled', () => {
+    jest.useFakeTimers()
+
+    document.documentElement.dataset.ghostnetThemeToggleEnabled = 'false'
+
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.setItem('ghostnetThemeEnabled', 'true')
     }
 
     const callback = jest.fn()

--- a/src/client/lib/__tests__/ghostnet-exit-transition.test.js
+++ b/src/client/lib/__tests__/ghostnet-exit-transition.test.js
@@ -1,17 +1,39 @@
 import { initiateGhostnetExitTransition, isGhostnetExitTransitionActive } from '../ghostnet-exit-transition'
 
 describe('ghostnet exit transition opt-out', () => {
+  beforeEach(() => {
+    document.documentElement.dataset.ghostnetThemeToggleEnabled = 'true'
+  })
+
   afterEach(() => {
     document.body.className = ''
     document.body.innerHTML = ''
     if (typeof window !== 'undefined' && window.localStorage) {
       window.localStorage.clear()
     }
+    delete document.documentElement.dataset.ghostnetThemeToggleEnabled
   })
 
   it('skips the ATLAS exit popup when the GhostNet theme is disabled', () => {
     if (typeof window !== 'undefined' && window.localStorage) {
       window.localStorage.setItem('ghostnetThemeEnabled', 'false')
+    }
+
+    const callback = jest.fn()
+
+    initiateGhostnetExitTransition(callback)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(isGhostnetExitTransitionActive()).toBe(false)
+    expect(document.body.classList.contains('ghostnet-exit-transition-active')).toBe(false)
+    expect(document.querySelector('.ghostnet-exit-overlay')).toBeNull()
+  })
+
+  it('skips the ATLAS exit popup when the GhostNet theme toggle flag is disabled', () => {
+    document.documentElement.dataset.ghostnetThemeToggleEnabled = 'false'
+
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.setItem('ghostnetThemeEnabled', 'true')
     }
 
     const callback = jest.fn()

--- a/src/client/lib/ghostnet-settings.js
+++ b/src/client/lib/ghostnet-settings.js
@@ -6,6 +6,16 @@ export const THEME_STORAGE_KEY = 'ghostnetThemeEnabled'
 export const GHOSTNET_NAV_VISIBILITY_KEY = 'ghostnet.nav.visible'
 const THEME_CHANGE_EVENT = 'ghostnetThemeChange'
 const NAV_VISIBILITY_CHANGE_EVENT = 'ghostnetNavVisibilityChange'
+const THEME_TOGGLE_DATASET_KEY = 'ghostnetThemeToggleEnabled'
+
+export function isGhostnetThemeToggleAvailable () {
+  if (typeof document === 'undefined' || !document?.documentElement) return false
+  const datasetValue = document.documentElement.dataset?.[THEME_TOGGLE_DATASET_KEY]
+  if (typeof datasetValue === 'string') {
+    return datasetValue === 'true'
+  }
+  return false
+}
 
 function clampDuration (value) {
   if (!Number.isFinite(value)) return ASSIMILATION_DURATION_DEFAULT
@@ -41,31 +51,44 @@ export function saveAssimilationDurationSeconds (value) {
 }
 
 export function isGhostnetThemeEnabled () {
-  if (typeof window === 'undefined' || !window.localStorage) return true
+  if (!isGhostnetThemeToggleAvailable()) {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, 'false')
+      } catch (error) {
+        // Ignore storage write failures when enforcing the default theme
+      }
+    }
+    return false
+  }
+
+  if (typeof window === 'undefined' || !window.localStorage) return false
 
   try {
     const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
-    if (stored === null) return true
+    if (stored === null) return false
     return stored !== 'false'
   } catch (error) {
-    return true
+    return false
   }
 }
 
 export function saveGhostnetThemeEnabled (value) {
+  const sanitized = isGhostnetThemeToggleAvailable() && !!value
+
   if (typeof window !== 'undefined' && window.localStorage) {
     try {
-      window.localStorage.setItem(THEME_STORAGE_KEY, value ? 'true' : 'false')
+      window.localStorage.setItem(THEME_STORAGE_KEY, sanitized ? 'true' : 'false')
     } catch (error) {
       // Ignore write failures
     }
     try {
-      window.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: { enabled: !!value } }))
+      window.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: { enabled: sanitized } }))
     } catch (error) {
       // Ignore dispatch failures
     }
   }
-  return !!value
+  return sanitized
 }
 
 export function addGhostnetThemeChangeListener (listener) {

--- a/src/client/pages/_document.js
+++ b/src/client/pages/_document.js
@@ -1,4 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
+import { isGhostnetThemeToggleEnabled } from '../../shared/feature-flags.js'
 
 // Disable onContextMenu, except in development
 const onContextMenu = process.env.NODE_ENV === 'development'
@@ -12,8 +13,15 @@ class MyDocument extends Document {
   }
 
   render () {
+    const themeToggleEnabled = isGhostnetThemeToggleEnabled()
     return (
-      <Html lang='en' data-fx-crt='true' data-fx-crt-text='false' data-fx-crt-text-animated='false'>
+      <Html
+        lang='en'
+        data-fx-crt='true'
+        data-fx-crt-text='false'
+        data-fx-crt-text-animated='false'
+        data-ghostnet-theme-toggle-enabled={themeToggleEnabled ? 'true' : 'false'}
+      >
         <Head>
           <link rel='manifest' href='/manifest.json' />
           <link rel='apple-touch-icon' izes='180x180' href='/icons/icon-180x180.png' />

--- a/src/client/pages/api/feature-flags.js
+++ b/src/client/pages/api/feature-flags.js
@@ -2,6 +2,7 @@ import {
   isGhostnetTokenCurrencyEnabled,
   isTokenJackpotEnabled,
   isTokenRecoveryCompatibilityEnabled,
+  isGhostnetThemeToggleEnabled,
   _private as featureFlagInternals
 } from '../../../shared/feature-flags.js'
 
@@ -28,6 +29,13 @@ const FLAG_DEFINITIONS = [
     description: 'Retains the legacy negative-balance recovery schedule for the INARA token ledger.',
     resolver: isTokenRecoveryCompatibilityEnabled,
     defaultValue: true
+  },
+  {
+    key: 'ghostnetThemeToggleEnabled',
+    label: 'GhostNet Theme Toggle',
+    description: 'Allows commanders to enable the immersive GhostNet visual theme from the settings modal.',
+    resolver: isGhostnetThemeToggleEnabled,
+    defaultValue: false
   }
 ]
 

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -6827,7 +6827,7 @@ export default function GhostnetPage() {
   const [activeTab, setActiveTab] = useState('tradeRoutes')
   const [arrivalMode, setArrivalMode] = useState(false)
   const [themeEnabled, setThemeEnabled] = useState(() => {
-    if (typeof window === 'undefined') return true
+    if (typeof window === 'undefined') return false
     return isGhostnetThemeEnabled()
   })
   const { connected, ready, active: socketActive } = useSocket()

--- a/src/shared/feature-flags.js
+++ b/src/shared/feature-flags.js
@@ -51,9 +51,14 @@ function isTokenRecoveryCompatibilityEnabled (env = process.env) {
   return resolveFlag('ghostnetTokenRecoveryCompatEnabled', env)
 }
 
+function isGhostnetThemeToggleEnabled (env = process.env) {
+  return resolveFlag('ghostnetThemeToggleEnabled', env)
+}
+
 module.exports = {
   isGhostnetTokenCurrencyEnabled,
   isTokenJackpotEnabled,
   isTokenRecoveryCompatibilityEnabled,
+  isGhostnetThemeToggleEnabled,
   _private: { normalizeFlagValue, resolveFlag, hasFlagKey }
 }


### PR DESCRIPTION
## Summary
- add a `ghostnetThemeToggleEnabled` feature flag that defaults the interface to the classic ICARUS theme when unset
- surface the flag state to the client via `_document`, update GhostNet settings to respect the deployment guard, and adjust tests to cover the new behaviour
- document the new default and flag in the feature catalogue

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js swc transform cannot deserialize `serverComponents` field in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c8e983cc832392871d35babb6552