### PR TITLE
Align trade routes spinner and refresh flow

### DIFF
--- a/src/client/css/pages/ghostnet.css
+++ b/src/client/css/pages/ghostnet.css
@@ -42,23 +42,28 @@
   color: color-mix(in srgb, var(--ghostnet-color-text-strong) 70%, transparent);
 }
 
-.ghostnet-spinner__icon {
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 50%;
-  border: 2px solid color-mix(in srgb, var(--ghostnet-color-text-strong) 18%, transparent);
-  border-top-color: var(--ghostnet-color-primary);
-  animation: ghostnet-spinner-rotate 0.85s linear infinite;
+.ghostnet-spinner__graphic {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  transform: scale(0.65);
+  transform-origin: center;
+  filter: drop-shadow(0 0 8px color-mix(in srgb, var(--color-primary) 45%, transparent));
+}
+
+.ghostnet-spinner--inline .ghostnet-spinner__graphic {
+  transform: scale(0.55);
+}
+
+.ghostnet-spinner__row {
+  display: flex;
+  gap: 0.3rem;
+  line-height: 0;
 }
 
 .ghostnet-spinner__label {
   font-size: 0.95rem;
-}
-
-@keyframes ghostnet-spinner-rotate {
-  to {
-    transform: rotate(360deg);
-  }
 }
 
 .pristine-mining__container {

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -90,7 +90,40 @@ function LoadingSpinner ({ label, inline = false }) {
       role='status'
       aria-live='polite'
     >
-      <span className='ghostnet-spinner__icon' aria-hidden='true' />
+      <span className='ghostnet-spinner__graphic' aria-hidden='true'>
+        <span className='ghostnet-spinner__row'>
+          <span className='loader__arrow loader__arrow--outer-18' />
+          <span className='loader__arrow loader__arrow--down loader__arrow--outer-17' />
+          <span className='loader__arrow loader__arrow--outer-16' />
+          <span className='loader__arrow loader__arrow--down loader__arrow--outer-15' />
+          <span className='loader__arrow loader__arrow--outer-14' />
+        </span>
+        <span className='ghostnet-spinner__row'>
+          <span className='loader__arrow loader__arrow--outer-1' />
+          <span className='loader__arrow loader__arrow--down loader__arrow--outer-2' />
+          <span className='loader__arrow loader__arrow--inner-6' />
+          <span className='loader__arrow loader__arrow--down loader__arrow--inner-5' />
+          <span className='loader__arrow loader__arrow--inner-4' />
+          <span className='loader__arrow loader__arrow--down loader__arrow--outer-13' />
+          <span className='loader__arrow loader__arrow--outer-12' />
+        </span>
+        <span className='ghostnet-spinner__row'>
+          <span className='loader__arrow loader__arrow--down loader__arrow--outer-3' />
+          <span className='loader__arrow loader__arrow--outer-4' />
+          <span className='loader__arrow loader__arrow--down loader__arrow--inner-1' />
+          <span className='loader__arrow loader__arrow--inner-2' />
+          <span className='loader__arrow loader__arrow--down loader__arrow--inner-3' />
+          <span className='loader__arrow loader__arrow--outer-11' />
+          <span className='loader__arrow loader__arrow--down loader__arrow--outer-10' />
+        </span>
+        <span className='ghostnet-spinner__row'>
+          <span className='loader__arrow loader__arrow--down loader__arrow--outer-5' />
+          <span className='loader__arrow loader__arrow--outer-6' />
+          <span className='loader__arrow loader__arrow--down loader__arrow--outer-7' />
+          <span className='loader__arrow loader__arrow--outer-8' />
+          <span className='loader__arrow loader__arrow--down loader__arrow--outer-9' />
+        </span>
+      </span>
       {label ? <span className='ghostnet-spinner__label'>{label}</span> : null}
     </div>
   )
@@ -3927,13 +3960,11 @@ function TradeRoutesPanel () {
 
     setError('')
     setMessage('')
-
-    const hasExistingResults = status === 'populated' || status === 'empty'
-    if (hasExistingResults) {
-      setIsRefreshing(true)
-    } else {
-      setStatus('loading')
-    }
+    setIsRefreshing(true)
+    setRoutes([])
+    setRawRoutes([])
+    setStatus('loading')
+    setLastUpdatedAt(null)
 
     const filters = {
       ...(cargoCapacity !== '' ? { cargoCapacity } : {}),
@@ -3996,7 +4027,7 @@ function TradeRoutesPanel () {
       .finally(() => {
         setIsRefreshing(false)
       })
-  }, [applyResults, cargoCapacity, routeDistance, priceAge, padSize, minSupply, minDemand, stationDistance, surfacePreference, sourcePower, targetPower, orderBy, includeRoundTrips, displayPowerplay, status])
+  }, [applyResults, cargoCapacity, routeDistance, priceAge, padSize, minSupply, minDemand, stationDistance, surfacePreference, sourcePower, targetPower, orderBy, includeRoundTrips, displayPowerplay])
 
   useEffect(() => {
     setSelectedRouteContext(null)
@@ -4357,7 +4388,7 @@ function TradeRoutesPanel () {
   }, [])
 
   const renderRoutesTable = () => (
-    <div className={styles.dataTableContainer}>
+    <div className={`${styles.dataTableContainer} fx-fade-in`}>
       <table className={`${styles.dataTable} ${styles.dataTableDense} ${styles.tradeRoutesTable}`}>
         <thead>
           <tr>
@@ -4417,7 +4448,7 @@ function TradeRoutesPanel () {
             </th>
           </tr>
         </thead>
-        <tbody>
+        <tbody className='fx-fade-in'>
           {routes.map((route, index) => (
             <TradeRouteTableRow
               key={`route-${index}`}

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -3302,9 +3302,9 @@ button.terminalStatusPreview:focus-visible {
   color: var(--ghostnet-muted);
 }
 
-.ghostnet :global(.ghostnet-panel-table .ghostnet-spinner__icon) {
-  border-color: var(--ghostnet-accent);
-  border-right-color: transparent;
+.ghostnet :global(.ghostnet-panel-table .ghostnet-spinner__graphic) {
+  filter: drop-shadow(0 0 8px color-mix(in srgb, var(--ghostnet-accent) 55%, transparent));
+  transform: scale(0.6);
 }
 
 .ghostnet :global(.ghostnet-panel-table .button--active) {


### PR DESCRIPTION
## Summary
- replace the trade route loading indicator with the standard ICARUS arrow spinner markup
- update GhostNet spinner styles to scale and align the shared loader graphic
- refresh GhostNet table overrides to tint the inline spinner graphic for panel usage
- clear trade routes and show the spinner while refreshing, then fade in the new results list

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: next-swc transform error about unknown field `serverComponents` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cb3ad060832397573f518a52698a