### PR TITLE
Align INARA workspace with shared layout pattern

### DIFF
--- a/src/client/__tests__/inara.test.js
+++ b/src/client/__tests__/inara.test.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import { render, screen, act } from '@testing-library/react'
 import { getMockTokenBalanceSnapshot } from '../lib/inara-mock-data'
-import InaraPage, {
+import InaraStatusPage, {
   createTransactionSequence,
   createJackpotFloodConfig,
   TERMINAL_PROMPT_TYPE_CLASS_MAP,
   TERMINAL_TEXT_TYPE_CLASS_MAP
-} from '../pages/inara'
+} from '../pages/inara/status'
 import styles from '../pages/glitch.module.css'
 
 jest.mock('next/router', () => ({
@@ -43,7 +43,7 @@ describe('INARA page', () => {
   })
 
   it('renders without a hero summary or redundant page title', async () => {
-    await act(async () => { render(<InaraPage />) })
+    await act(async () => { render(<InaraStatusPage />) })
 
     expect(screen.queryByRole('heading', { level: 1, name: /inara operations/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument()
@@ -51,7 +51,7 @@ describe('INARA page', () => {
   })
 
   it('exposes key INARA panels for missions and mining', async () => {
-    await act(async () => { render(<InaraPage />) })
+    await act(async () => { render(<InaraStatusPage />) })
 
     expect(await screen.findByRole('heading', { name: /find trade routes/i })).toBeInTheDocument()
     expect(screen.getByText(/cross-reference inara freight whispers/i)).toBeInTheDocument()
@@ -60,7 +60,7 @@ describe('INARA page', () => {
   })
 
   it('renders the token console meter with request control', async () => {
-    await act(async () => { render(<InaraPage />) })
+    await act(async () => { render(<InaraStatusPage />) })
 
     expect(mockSendEvent).toHaveBeenCalledWith('getTokenBalance')
     expect(await screen.findByText(/tokens/i)).toBeInTheDocument()

--- a/src/client/lib/navigation-items.js
+++ b/src/client/lib/navigation-items.js
@@ -65,6 +65,32 @@ function NavPanelNavItems (activePanel, query) {
   return navigationItems
 }
 
+function InaraPanelNavItems (activePanel) {
+  const navigationItems = [
+    {
+      name: 'Status',
+      icon: 'route',
+      url: '/inara/status'
+    },
+    {
+      name: 'Search',
+      icon: 'search',
+      url: '/inara/search'
+    },
+    {
+      name: 'Outfitting',
+      icon: 'wrench',
+      url: '/inara/outfitting'
+    }
+  ]
+
+  navigationItems.forEach(item => {
+    if (item.name.toLowerCase() === activePanel.toLowerCase()) item.active = true
+  })
+
+  return navigationItems
+}
+
 function EngineeringPanelNavItems (activePanel) {
   const navigationItems = [
     {
@@ -128,6 +154,7 @@ function SettingsNavItems (activePanel) {
 module.exports = {
   ShipPanelNavItems,
   NavPanelNavItems,
+  InaraPanelNavItems,
   EngineeringPanelNavItems,
   SettingsNavItems
 }

--- a/src/client/pages/glitch.module.css
+++ b/src/client/pages/glitch.module.css
@@ -57,33 +57,35 @@
   overflow-y: auto;
   overflow-x: hidden;
   background: var(--glitch-color-background);
-  scrollbar-color: var(--glitch-color-scroll-thumb) var(--glitch-color-scroll-track);
-  scrollbar-width: thin;
 }
 
 .glitchScrollRegionClassic {
   background: #000;
-  scrollbar-color: var(--color-secondary) #000;
 }
 
 .glitchScrollRegion::-webkit-scrollbar {
-  width: 14px;
-  background-color: var(--glitch-color-scroll-track);
+  width: 16px;
 }
 
 .glitchScrollRegion::-webkit-scrollbar-track {
-  background: var(--glitch-color-scroll-track);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-scroll-thumb-border) 40%, transparent);
+  background-image: linear-gradient(
+    90deg,
+    transparent 41.67%,
+    var(--color-primary) 41.67%,
+    var(--color-primary) 50%,
+    transparent 50%,
+    transparent 91.67%,
+    var(--color-primary) 91.67%,
+    var(--color-primary) 100%
+  );
+  background-size: 48px 48px;
+  background-position-x: 10px;
 }
 
 .glitchScrollRegion::-webkit-scrollbar-thumb {
-  background: var(--glitch-color-scroll-thumb);
-  border: 1px solid var(--glitch-color-scroll-thumb-border);
-  box-shadow: 0 0 1.5rem color-mix(in srgb, var(--glitch-color-primary) 28%, transparent);
-}
-
-.glitchScrollRegion::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--glitch-color-scroll-thumb) 70%, var(--glitch-color-primary-light));
+  background: var(--color-primary);
+  min-height: 4rem;
+  box-shadow: 0 0 10px var(--color-primary-dark);
 }
 
 .glitch {
@@ -180,30 +182,31 @@
 .glitchPanel :global(.layout__panel-scroll) {
   padding: 0;
   background: var(--glitch-bg);
-  scrollbar-color: var(--glitch-scrollbar-thumb) var(--glitch-scrollbar-track);
-  scrollbar-width: thin;
 }
 
 .glitchPanel :global(.layout__panel-scroll::-webkit-scrollbar) {
-  width: 14px;
-  background-color: var(--glitch-scrollbar-track);
+  width: 16px;
 }
 
 .glitchPanel :global(.layout__panel-scroll::-webkit-scrollbar-track) {
-  background: var(--glitch-scrollbar-track);
-  border: 1px solid color-mix(in srgb, var(--glitch-scrollbar-thumb-border) 40%, transparent);
-  border-radius: 0;
+  background-image: linear-gradient(
+    90deg,
+    transparent 41.67%,
+    var(--color-primary) 41.67%,
+    var(--color-primary) 50%,
+    transparent 50%,
+    transparent 91.67%,
+    var(--color-primary) 91.67%,
+    var(--color-primary) 100%
+  );
+  background-size: 48px 48px;
+  background-position-x: 10px;
 }
 
 .glitchPanel :global(.layout__panel-scroll::-webkit-scrollbar-thumb) {
-  background: var(--glitch-scrollbar-thumb);
-  border: 1px solid var(--glitch-scrollbar-thumb-border);
-  border-radius: 0;
-  box-shadow: 0 0 1.5rem color-mix(in srgb, var(--glitch-color-primary) 28%, transparent);
-}
-
-.glitchPanel :global(.layout__panel-scroll::-webkit-scrollbar-thumb:hover) {
-  background: color-mix(in srgb, var(--glitch-scrollbar-thumb) 70%, var(--glitch-color-primary-light));
+  background: var(--color-primary);
+  min-height: 4rem;
+  box-shadow: 0 0 10px var(--color-primary-dark);
 }
 
 .arrival {
@@ -1194,28 +1197,31 @@ button.terminalStatusPreview:focus-visible {
   border: 0;
   border-radius: 0;
   box-shadow: none;
-  scrollbar-width: thin;
-  scrollbar-color: var(--glitch-color-scroll-thumb) transparent;
 }
 
 .dataTableContainer::-webkit-scrollbar {
-  height: 12px;
-  background: transparent;
+  height: 16px;
 }
 
 .dataTableContainer::-webkit-scrollbar-track {
-  background: color-mix(in srgb, var(--glitch-color-scroll-track) 80%, transparent);
-  border-radius: 999px;
+  background-image: linear-gradient(
+    90deg,
+    transparent 41.67%,
+    var(--color-primary) 41.67%,
+    var(--color-primary) 50%,
+    transparent 50%,
+    transparent 91.67%,
+    var(--color-primary) 91.67%,
+    var(--color-primary) 100%
+  );
+  background-size: 48px 48px;
+  background-position-x: 10px;
 }
 
 .dataTableContainer::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--glitch-color-scroll-thumb) 88%, transparent);
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--glitch-color-scroll-thumb-border) 60%, transparent);
-}
-
-.dataTableContainer::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--glitch-color-scroll-thumb) 95%, transparent);
+  background: var(--color-primary);
+  min-height: 4rem;
+  box-shadow: 0 0 10px var(--color-primary-dark);
 }
 
 .tradeFiltersForm {
@@ -3180,28 +3186,31 @@ button.terminalStatusPreview:focus-visible {
   background: transparent;
   overflow-x: auto;
   overflow-y: hidden;
-  scrollbar-color: var(--glitch-color-scroll-thumb) transparent;
-  scrollbar-width: thin;
 }
 
 .glitch :global(.glitch-panel-table > .scrollable::-webkit-scrollbar) {
-  height: 12px;
-  background: transparent;
+  height: 16px;
 }
 
 .glitch :global(.glitch-panel-table > .scrollable::-webkit-scrollbar-track) {
-  background: color-mix(in srgb, var(--glitch-color-scroll-track) 80%, transparent);
-  border-radius: 999px;
+  background-image: linear-gradient(
+    90deg,
+    transparent 41.67%,
+    var(--color-primary) 41.67%,
+    var(--color-primary) 50%,
+    transparent 50%,
+    transparent 91.67%,
+    var(--color-primary) 91.67%,
+    var(--color-primary) 100%
+  );
+  background-size: 48px 48px;
+  background-position-x: 10px;
 }
 
 .glitch :global(.glitch-panel-table > .scrollable::-webkit-scrollbar-thumb) {
-  background: color-mix(in srgb, var(--glitch-color-scroll-thumb) 88%, transparent);
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--glitch-color-scroll-thumb-border) 60%, transparent);
-}
-
-.glitch :global(.glitch-panel-table > .scrollable::-webkit-scrollbar-thumb:hover) {
-  background: color-mix(in srgb, var(--glitch-color-scroll-thumb) 95%, transparent);
+  background: var(--color-primary);
+  min-height: 4rem;
+  box-shadow: 0 0 10px var(--color-primary-dark);
 }
 
 .glitch :global(.glitch-panel-table table thead) {

--- a/src/client/pages/inara/index.js
+++ b/src/client/pages/inara/index.js
@@ -1,0 +1,16 @@
+import Router from 'next/router'
+import Layout from 'components/layout'
+import Panel from 'components/panel'
+import { useSocket } from 'lib/socket'
+
+export default function InaraPage () {
+  const { connected, active } = useSocket()
+
+  if (typeof window !== 'undefined') Router.push('/inara/status')
+
+  return (
+    <Layout connected={connected} active={active}>
+      <Panel layout='full-width' scrollable />
+    </Layout>
+  )
+}

--- a/src/client/pages/inara/layout-sandbox.js
+++ b/src/client/pages/inara/layout-sandbox.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import InaraPage from '../inara'
+import InaraStatusPage from './status'
 import {
   generateMockCurrentSystem,
   generateMockFactionStandingsResponse,
@@ -131,6 +131,6 @@ export default function InaraLayoutSandboxPage () {
     }
   }, [])
 
-  return <InaraPage />
+  return <InaraStatusPage />
 }
 

--- a/src/client/pages/inara/outfitting.js
+++ b/src/client/pages/inara/outfitting.js
@@ -1,24 +1,14 @@
 import { useEffect } from 'react'
 import Layout from 'components/layout'
 import Panel from 'components/panel'
+import { useSocket } from 'lib/socket'
+import { InaraPanelNavItems } from 'lib/navigation-items'
 import styles from '../glitch.module.css'
 
-const navItems = [
-  {
-    name: 'Search',
-    icon: 'search',
-    url: '/inara/search',
-    active: false
-  },
-  {
-    name: 'Outfitting',
-    icon: 'wrench',
-    url: '/inara/outfitting',
-    active: true
-  }
-]
-
 export default function InaraOutfittingPage () {
+  const { connected, active } = useSocket()
+  const navItems = InaraPanelNavItems('Outfitting')
+
   useEffect(() => {
     if (typeof document === 'undefined' || !document.body) return undefined
     document.body.classList.add('glitch-theme')
@@ -26,7 +16,7 @@ export default function InaraOutfittingPage () {
   }, [])
 
   return (
-    <Layout>
+    <Layout connected={connected} active={active}>
       <Panel layout='full-width' scrollable navigation={navItems} className={styles.glitchPanel}>
         <div className={styles.glitch}>
           <div className={styles.hero}>

--- a/src/client/pages/inara/search.js
+++ b/src/client/pages/inara/search.js
@@ -1,24 +1,14 @@
 import { useEffect } from 'react'
 import Layout from 'components/layout'
 import Panel from 'components/panel'
+import { useSocket } from 'lib/socket'
+import { InaraPanelNavItems } from 'lib/navigation-items'
 import styles from '../glitch.module.css'
 
-const navItems = [
-  {
-    name: 'Search',
-    icon: 'search',
-    url: '/inara/search',
-    active: true
-  },
-  {
-    name: 'Outfitting',
-    icon: 'wrench',
-    url: '/inara/outfitting',
-    active: false
-  }
-]
-
 export default function InaraSearchPage() {
+  const { connected, active } = useSocket()
+  const navItems = InaraPanelNavItems('Search')
+
   useEffect(() => {
     if (typeof document === 'undefined' || !document.body) return undefined
     document.body.classList.add('glitch-theme')
@@ -26,7 +16,7 @@ export default function InaraSearchPage() {
   }, [])
 
   return (
-    <Layout>
+    <Layout connected={connected} active={active}>
       <Panel layout='full-width' scrollable navigation={navItems} className={styles.glitchPanel}>
         <div className={styles.glitch}>
           <div className={styles.hero}>

--- a/src/client/pages/inara/status.js
+++ b/src/client/pages/inara/status.js
@@ -1,25 +1,25 @@
 import React, { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback, Fragment } from 'react'
-import Layout from '../components/layout'
-import Panel from '../components/panel'
-import PanelNavigation from '../components/panel-navigation'
-import Icons from '../lib/icons'
-import TransferContextSummary from '../components/panels/inara/transfer-context-summary'
-import StationSummary, { StationIcon, DemandIndicator } from '../components/panels/inara/station-summary'
-import CommoditySummary, { CommodityIcon } from '../components/panels/inara/commodity-summary'
-import CopyOnClick from '../components/copy-on-click'
-import PirateRadioPanel from '../components/panels/inara/pirate-radio'
-import NavigationInspectorPanel from '../components/panels/nav/navigation-inspector-panel'
-import animateTableEffect from '../lib/animate-table-effect'
-import { useSocket, sendEvent, eventListener } from '../lib/socket'
-import { getShipLandingPadSize } from '../lib/ship-pad-sizes'
-import { formatCredits, formatRelativeTime, formatStationDistance, formatSystemDistance } from '../lib/inara-formatters'
-import getDistanceSeverityColor from '../lib/distance-colors'
-import { sanitizeInaraText } from '../lib/sanitize-inara-text'
-import { stationIconFromType, getStationIconName } from '../lib/station-icons'
-import { createMockCargoManifest, createMockCommodityValuations, generateMockTradeRoutes, NON_COMMODITY_KEYS, normaliseCommodityKey } from '../lib/inara-mock-data'
-import { getInaraStrings, getInaraString } from '../lib/inara-addon'
-import { isGlitchThemeEnabled, addGlitchThemeChangeListener, THEME_STORAGE_KEY } from '../lib/glitch-settings'
-import styles from './glitch.module.css'
+import Layout from 'components/layout'
+import Panel from 'components/panel'
+import Icons from 'lib/icons'
+import TransferContextSummary from 'components/panels/inara/transfer-context-summary'
+import StationSummary, { StationIcon, DemandIndicator } from 'components/panels/inara/station-summary'
+import CommoditySummary, { CommodityIcon } from 'components/panels/inara/commodity-summary'
+import CopyOnClick from 'components/copy-on-click'
+import PirateRadioPanel from 'components/panels/inara/pirate-radio'
+import NavigationInspectorPanel from 'components/panels/nav/navigation-inspector-panel'
+import animateTableEffect from 'lib/animate-table-effect'
+import { useSocket, sendEvent, eventListener } from 'lib/socket'
+import { getShipLandingPadSize } from 'lib/ship-pad-sizes'
+import { formatCredits, formatRelativeTime, formatStationDistance, formatSystemDistance } from 'lib/inara-formatters'
+import getDistanceSeverityColor from 'lib/distance-colors'
+import { sanitizeInaraText } from 'lib/sanitize-inara-text'
+import { stationIconFromType, getStationIconName } from 'lib/station-icons'
+import { createMockCargoManifest, createMockCommodityValuations, generateMockTradeRoutes, NON_COMMODITY_KEYS, normaliseCommodityKey } from 'lib/inara-mock-data'
+import { getInaraStrings, getInaraString } from 'lib/inara-addon'
+import { isGlitchThemeEnabled, addGlitchThemeChangeListener, THEME_STORAGE_KEY } from 'lib/glitch-settings'
+import { InaraPanelNavItems } from 'lib/navigation-items'
+import styles from '../glitch.module.css'
 
 const METRIC_VARIANT_CLASS_MAP = {
   neutral: styles.metricChipNeutral,
@@ -7017,7 +7017,7 @@ function InaraTerminalOverlay () {
   )
 }
 
-export default function InaraPage() {
+export default function InaraStatusPage () {
   const [activeTab, setActiveTab] = useState('tradeRoutes')
   const [tradeRoutesStatus, setTradeRoutesStatus] = useState('idle')
   const [arrivalMode, setArrivalMode] = useState(false)
@@ -7079,63 +7079,58 @@ export default function InaraPage() {
       }
     }
   }, [])
-  const inaraTabs = useMemo(() => ([
-    { name: 'Trade Routes', icon: 'route', active: activeTab === 'tradeRoutes', onClick: () => setActiveTab('tradeRoutes') },
-    { name: 'Cargo Hold', icon: 'cargo', active: activeTab === 'cargoHold', onClick: () => setActiveTab('cargoHold') },
-    { name: 'Missions', icon: 'asteroid-base', active: activeTab === 'missions', onClick: () => setActiveTab('missions') },
-    { name: 'Pristine Mining Locations', icon: 'planet-ringed', active: activeTab === 'pristineMining', onClick: () => setActiveTab('pristineMining') },
-    { name: 'Pirate Radio', icon: 'signal', active: activeTab === 'pirateRadio', onClick: () => setActiveTab('pirateRadio') },
-    { name: 'Search', icon: 'search', type: 'SEARCH', active: false }
-
-  ]), [activeTab])
+  const inaraTabs = useMemo(() => {
+    const panelItems = [
+      { name: 'Trade Routes', icon: 'route', active: activeTab === 'tradeRoutes', onClick: () => setActiveTab('tradeRoutes') },
+      { name: 'Cargo Hold', icon: 'cargo', active: activeTab === 'cargoHold', onClick: () => setActiveTab('cargoHold') },
+      { name: 'Missions', icon: 'asteroid-base', active: activeTab === 'missions', onClick: () => setActiveTab('missions') },
+      { name: 'Pristine Mining Locations', icon: 'planet-ringed', active: activeTab === 'pristineMining', onClick: () => setActiveTab('pristineMining') },
+      { name: 'Pirate Radio', icon: 'signal', active: activeTab === 'pirateRadio', onClick: () => setActiveTab('pirateRadio') }
+    ]
+    const sharedNavItems = InaraPanelNavItems('Status').filter(item => item.name !== 'Status')
+    return [...panelItems, ...sharedNavItems]
+  }, [activeTab])
 
   const glitchClassName = [
     styles.glitch,
     arrivalMode ? styles.arrival : '',
     themeEnabled ? '' : styles.glitchIcarus
   ].filter(Boolean).join(' ')
-  const navigationClassName = [
-    styles.glitchNavigation,
-    themeEnabled ? '' : styles.glitchNavigationClassic
-  ].filter(Boolean).join(' ')
-  const scrollRegionClassName = [
-    styles.glitchScrollRegion,
-    themeEnabled ? '' : styles.glitchScrollRegionClassic
-  ].filter(Boolean).join(' ')
+
   const loaderVisible = activeTab === 'tradeRoutes' && tradeRoutesStatus === 'loading'
+
   return (
     <Layout connected={connected} active={socketActive} ready={ready} loader={loaderVisible} className={styles.glitchLayout}>
-      <div className={styles.glitchViewport}>
-        <div className={navigationClassName}>
-          <PanelNavigation items={inaraTabs} search={false} />
-        </div>
-        <div className={styles.glitchContentArea}>
-          <div className={scrollRegionClassName}>
-            <div className={glitchClassName}>
-              <div className={styles.shell}>
-                <div className={styles.tabPanels}>
-                  <div style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
-                    <TradeRoutesPanel onStatusChange={setTradeRoutesStatus} />
-                  </div>
-                  <div style={{ display: activeTab === 'cargoHold' ? 'block' : 'none' }}>
-                    <CargoHoldPanel />
-                  </div>
-                  <div style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
-                    <MissionsPanel />
-                  </div>
-                  <div style={{ display: activeTab === 'pristineMining' ? 'block' : 'none' }}>
-                    <PristineMiningPanel />
-                  </div>
-                  <div style={{ display: activeTab === 'pirateRadio' ? 'block' : 'none' }}>
-                    <PirateRadioPanel />
-                  </div>
-                </div>
+      <Panel
+        layout='full-width'
+        scrollable
+        navigation={inaraTabs}
+        search={false}
+        className={styles.glitchPanel}
+      >
+        <div className={glitchClassName}>
+          <div className={styles.shell}>
+            <div className={styles.tabPanels}>
+              <div style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
+                <TradeRoutesPanel onStatusChange={setTradeRoutesStatus} />
               </div>
-              <InaraTerminalOverlay />
+              <div style={{ display: activeTab === 'cargoHold' ? 'block' : 'none' }}>
+                <CargoHoldPanel />
+              </div>
+              <div style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
+                <MissionsPanel />
+              </div>
+              <div style={{ display: activeTab === 'pristineMining' ? 'block' : 'none' }}>
+                <PristineMiningPanel />
+              </div>
+              <div style={{ display: activeTab === 'pirateRadio' ? 'block' : 'none' }}>
+                <PirateRadioPanel />
+              </div>
             </div>
           </div>
+          <InaraTerminalOverlay />
         </div>
-      </div>
+      </Panel>
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary
- add a redirecting entry point for /inara and move the INARA workspace implementation to /inara/status with the shared layout pattern
- centralize INARA navigation items and wire the status, search, and outfitting surfaces to the common navigation helper and socket state
- update the INARA layout sandbox and Jest suite to reference the relocated status page
- refresh the INARA glitch theme scrollbars so they mirror the ICARUS engineering presentation

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: Next.js SWC transform rejects the serverComponents option in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e43b8dcd5483239564edf07252fd79