### PR TITLE
Retheme INARA workspace to Icarus

### DIFF
--- a/src/client/__tests__/inara.test.js
+++ b/src/client/__tests__/inara.test.js
@@ -7,7 +7,7 @@ import InaraStatusPage, {
   TERMINAL_PROMPT_TYPE_CLASS_MAP,
   TERMINAL_TEXT_TYPE_CLASS_MAP
 } from '../pages/inara/status'
-import styles from '../pages/glitch.module.css'
+import styles from '../pages/inara-workspace.module.css'
 
 jest.mock('next/router', () => ({
   useRouter: () => ({

--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -41,14 +41,14 @@ const NAV_BUTTONS = [
     path: '/eng'
   },
   {
-    name: 'INARA',
-    abbr: 'INARA',
-    path: '/inara'
-  },
-  {
     name: 'Log',
     abbr: 'Log',
     path: '/log'
+  },
+  {
+    name: 'INARA',
+    abbr: 'INARA',
+    path: '/inara'
   }
 ]
 

--- a/src/client/components/panels/inara/pirate-radio.js
+++ b/src/client/components/panels/inara/pirate-radio.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import notification from 'lib/notification'
 import { sendEvent, eventListener } from 'lib/socket'
 import { formatRelativeTime } from 'lib/inara-formatters'
-import glitchStyles from 'pages/glitch.module.css'
+import inaraStyles from 'pages/inara-workspace.module.css'
 import styles from './pirate-radio.module.css'
 
 const INITIAL_DIRECTORIES = { library: '', commercial: '' }
@@ -306,9 +306,9 @@ export default function PirateRadioPanel () {
   const noTracks = playlist.length === 0
 
   return (
-    <section className={glitchStyles.tableSection}>
-      <div className={glitchStyles.tableSectionHeader}>
-        <h2 className={glitchStyles.tableSectionTitle}>Pirate Radio</h2>
+    <section className={inaraStyles.tableSection}>
+      <div className={inaraStyles.tableSectionHeader}>
+        <h2 className={inaraStyles.tableSectionTitle}>Pirate Radio</h2>
         <p className={styles.subtitle}>
           INARA’s outlaw signal crawler stitches together volunteer library submissions and station commercials
           into a persistent underground broadcast. Configure your directories and let the uplink spin.
@@ -320,7 +320,7 @@ export default function PirateRadioPanel () {
         </div>
       </div>
 
-      <div className={`${glitchStyles.sectionFrame} ${styles.panelShell}`}>
+      <div className={`${inaraStyles.sectionFrame} ${styles.panelShell}`}>
         <div className={styles.panelCard}>
           {(error || playbackError || successMessage) && (
             <div

--- a/src/client/components/panels/inara/pirate-radio.module.css
+++ b/src/client/components/panels/inara/pirate-radio.module.css
@@ -19,18 +19,18 @@
   margin: 0;
   font-size: clamp(1.4rem, 2.4vw, 1.85rem);
   font-weight: 700;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .subtitle {
-  color: color-mix(in srgb, var(--glitch-ink) 68%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 68%, transparent);
   font-size: 0.98rem;
   line-height: 1.45;
 }
 
 .statusMeta {
   font-size: 0.85rem;
-  color: color-mix(in srgb, var(--glitch-ink) 56%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 56%, transparent);
 }
 
 .controlSurface {
@@ -47,7 +47,7 @@
   margin: 0;
   font-size: clamp(1.2rem, 2vw, 1.6rem);
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .trackMeta {
@@ -55,7 +55,7 @@
   flex-wrap: wrap;
   gap: 0.35rem;
   align-items: center;
-  color: color-mix(in srgb, var(--glitch-ink) 62%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 62%, transparent);
   font-size: 0.9rem;
 }
 
@@ -65,7 +65,7 @@
 }
 
 .trackDescription {
-  color: color-mix(in srgb, var(--glitch-ink) 58%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 58%, transparent);
   font-size: 0.92rem;
   line-height: 1.5;
 }
@@ -85,9 +85,9 @@
 
 .controlButton {
   appearance: none;
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 42%, transparent);
-  background: color-mix(in srgb, var(--glitch-color-primary) 26%, transparent);
-  color: var(--glitch-ink);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 42%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 26%, transparent);
+  color: var(--inara-ink);
   border-radius: 999px;
   padding: 0.45rem 0.95rem;
   font-size: 0.95rem;
@@ -96,23 +96,23 @@
   gap: 0.4rem;
   cursor: pointer;
   transition: transform 120ms ease, box-shadow 160ms ease;
-  box-shadow: 0 0.75rem 1.6rem color-mix(in srgb, var(--glitch-color-background) 70%, transparent);
+  box-shadow: 0 0.75rem 1.6rem color-mix(in srgb, var(--inara-color-background) 70%, transparent);
 }
 
 .controlButton:hover {
   transform: translateY(-1px);
-  box-shadow: 0 1rem 2rem color-mix(in srgb, var(--glitch-color-background) 66%, transparent);
+  box-shadow: 0 1rem 2rem color-mix(in srgb, var(--inara-color-background) 66%, transparent);
 }
 
 .controlButton:focus-visible {
-  outline: 2px solid var(--glitch-color-success);
+  outline: 2px solid var(--inara-color-success);
   outline-offset: 2px;
 }
 
 .controlButtonSecondary {
-  border-color: color-mix(in srgb, var(--glitch-color-primary) 24%, transparent);
-  background: color-mix(in srgb, var(--glitch-color-surface) 88%, transparent);
-  color: color-mix(in srgb, var(--glitch-ink) 78%, transparent);
+  border-color: color-mix(in srgb, var(--inara-color-primary) 24%, transparent);
+  background: color-mix(in srgb, var(--inara-color-surface) 88%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 78%, transparent);
 }
 
 .controlButtonIcon {
@@ -129,7 +129,7 @@
   font-size: 0.85rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-ink) 54%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 54%, transparent);
 }
 
 .playlistList {
@@ -146,40 +146,40 @@
   gap: 0.1rem;
   padding: 0.6rem 0.75rem;
   border-radius: 0.75rem;
-  background: color-mix(in srgb, var(--glitch-color-surface) 65%, transparent);
+  background: color-mix(in srgb, var(--inara-color-surface) 65%, transparent);
   border: 1px solid transparent;
   cursor: pointer;
   transition: background 160ms ease, border-color 160ms ease;
 }
 
 .playlistItem:hover {
-  background: color-mix(in srgb, var(--glitch-color-primary) 26%, transparent);
-  border-color: color-mix(in srgb, var(--glitch-color-primary) 42%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 26%, transparent);
+  border-color: color-mix(in srgb, var(--inara-color-primary) 42%, transparent);
 }
 
 .playlistItemActive {
-  background: color-mix(in srgb, var(--glitch-color-primary) 32%, transparent);
-  border-color: color-mix(in srgb, var(--glitch-color-success) 42%, transparent);
-  box-shadow: 0 0.8rem 1.6rem color-mix(in srgb, var(--glitch-color-background) 72%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 32%, transparent);
+  border-color: color-mix(in srgb, var(--inara-color-success) 42%, transparent);
+  box-shadow: 0 0.8rem 1.6rem color-mix(in srgb, var(--inara-color-background) 72%, transparent);
 }
 
 .playlistItemTitle {
   font-size: 0.95rem;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .playlistItemMeta {
   font-size: 0.8rem;
-  color: color-mix(in srgb, var(--glitch-ink) 58%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 58%, transparent);
 }
 
 .emptyState {
   padding: 1.25rem 1.5rem;
   text-align: center;
   border-radius: 0.85rem;
-  border: 1px dashed color-mix(in srgb, var(--glitch-color-primary) 38%, transparent);
-  color: color-mix(in srgb, var(--glitch-ink) 70%, transparent);
-  background: color-mix(in srgb, var(--glitch-color-surface) 72%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--inara-color-primary) 38%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 70%, transparent);
+  background: color-mix(in srgb, var(--inara-color-surface) 72%, transparent);
 }
 
 .banner {
@@ -190,15 +190,15 @@
 }
 
 .bannerError {
-  background: color-mix(in srgb, var(--glitch-color-warning) 18%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-warning) 38%, transparent);
-  color: var(--glitch-ink);
+  background: color-mix(in srgb, var(--inara-color-warning) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-warning) 38%, transparent);
+  color: var(--inara-ink);
 }
 
 .bannerSuccess {
-  background: color-mix(in srgb, var(--glitch-color-success) 14%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-success) 38%, transparent);
-  color: var(--glitch-ink);
+  background: color-mix(in srgb, var(--inara-color-success) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-success) 38%, transparent);
+  color: var(--inara-ink);
 }
 
 .directorySection {
@@ -216,16 +216,16 @@
   font-size: 0.85rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-ink) 56%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 56%, transparent);
 }
 
 .directoryPath {
   padding: 0.75rem 0.9rem;
   border-radius: 0.75rem;
-  background: color-mix(in srgb, var(--glitch-color-surface) 80%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 22%, transparent);
+  background: color-mix(in srgb, var(--inara-color-surface) 80%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 22%, transparent);
   font-size: 0.92rem;
-  color: color-mix(in srgb, var(--glitch-ink) 82%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 82%, transparent);
   word-break: break-all;
 }
 
@@ -241,7 +241,7 @@
 
 .pendingText {
   font-size: 0.85rem;
-  color: color-mix(in srgb, var(--glitch-ink) 58%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 58%, transparent);
 }
 
 @media (max-width: 960px) {

--- a/src/client/components/panels/inara/station-summary.js
+++ b/src/client/components/panels/inara/station-summary.js
@@ -7,7 +7,7 @@ import styles from './station-summary.module.css'
 
 const DEMAND_ARROW_PATTERN = /[▲△▴▵▼▽▾▿↑↓]/g
 
-export function StationIcon ({ icon, size = 26, color = 'var(--glitch-accent)' }) {
+export function StationIcon ({ icon, size = 26, color = 'var(--inara-accent)' }) {
   if (!icon) return null
   const paths = Icons[icon]
   if (!paths) return null
@@ -27,7 +27,7 @@ export function StationIcon ({ icon, size = 26, color = 'var(--glitch-accent)' }
 StationIcon.defaultProps = {
   icon: '',
   size: 26,
-  color: 'var(--glitch-accent)'
+  color: 'var(--inara-accent)'
 }
 
 StationIcon.propTypes = {

--- a/src/client/components/panels/inara/station-summary.module.css
+++ b/src/client/components/panels/inara/station-summary.module.css
@@ -19,19 +19,19 @@
 
 .stationName {
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .stationSystem {
   font-size: 0.78rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .stationMeta {
   font-size: 0.7rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 58%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 58%, transparent);
 }
 
 .stationSelectionTag {
@@ -42,10 +42,10 @@
   font-size: 0.68rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--glitch-color-success);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-success) 60%, transparent);
+  color: var(--inara-color-success);
+  border: 1px solid color-mix(in srgb, var(--inara-color-success) 60%, transparent);
   border-radius: 999px;
-  background: color-mix(in srgb, var(--glitch-color-success) 18%, transparent);
+  background: color-mix(in srgb, var(--inara-color-success) 18%, transparent);
 }
 
 .stationMetrics {
@@ -60,14 +60,14 @@
   align-items: baseline;
   gap: 0.35rem;
   font-size: 0.72rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .stationMetricLabel {
   letter-spacing: 0.14em;
   text-transform: uppercase;
   font-size: 0.66rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 58%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 58%, transparent);
 }
 
 .stationDemand {
@@ -90,9 +90,9 @@
 }
 
 .demandIndicatorArrowHigh {
-  color: var(--glitch-color-success);
+  color: var(--inara-color-success);
 }
 
 .demandIndicatorArrowLow {
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
 }

--- a/src/client/components/panels/inara/trade-route-cells.module.css
+++ b/src/client/components/panels/inara/trade-route-cells.module.css
@@ -11,7 +11,7 @@
   align-items: flex-start;
   justify-content: center;
   padding-top: 0.15rem;
-  color: var(--glitch-accent);
+  color: var(--inara-accent);
 }
 
 .stackedCellBody {
@@ -32,25 +32,25 @@
 .stackedRowPrimary {
   font-size: 1rem;
   line-height: 1.45;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .stackedRowSecondary {
   font-size: 0.95rem;
   line-height: 1.35;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .stackedRowTertiary {
   font-size: 0.85rem;
   line-height: 1.3;
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
 }
 
 .stackedRowQuaternary {
   font-size: 0.8rem;
   line-height: 1.25;
-  color: var(--glitch-text-faint);
+  color: var(--inara-text-faint);
 }
 
 .stackedItem {
@@ -65,7 +65,7 @@
   font-size: 0.64rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
   font-weight: 600;
 }
 
@@ -91,13 +91,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--glitch-accent);
+  color: var(--inara-accent);
 }
 
 .stationName {
   font-weight: 600;
   font-size: 1.05rem;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   line-height: 1.35;
   min-width: 0;
 }
@@ -108,11 +108,11 @@
   gap: 0.45rem;
   align-items: center;
   font-size: 0.85rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .stationSystem {
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .stationStatus {
@@ -120,19 +120,19 @@
 }
 
 .stationType {
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.65rem;
 }
 
 .stationDistance {
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
 }
 
 .stationMetaItem {
   font-size: 0.82rem;
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
 }
 
 .stationMetaEntry {
@@ -146,8 +146,8 @@
   width: 0.35rem;
   height: 0.35rem;
   border-radius: 50%;
-  background: color-mix(in srgb, var(--glitch-color-primary) 68%, transparent);
-  box-shadow: 0 0 0.8rem color-mix(in srgb, var(--glitch-color-primary) 40%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 68%, transparent);
+  box-shadow: 0 0 0.8rem color-mix(in srgb, var(--inara-color-primary) 40%, transparent);
   opacity: 0.6;
 }
 
@@ -172,11 +172,11 @@
 .itemName {
   font-weight: 600;
   font-size: 1.02rem;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .itemPrice {
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
   font-size: 0.9rem;
 }
 
@@ -197,9 +197,9 @@
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
-  color: var(--glitch-accent);
-  box-shadow: 0 0 0.8rem color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
+  color: var(--inara-accent);
+  box-shadow: 0 0 0.8rem color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
 }
 
 .quantityBadgeLabel {
@@ -210,12 +210,12 @@
 }
 
 .quantityBadgeDemand {
-  background: color-mix(in srgb, var(--glitch-color-warning) 12%, transparent);
+  background: color-mix(in srgb, var(--inara-color-warning) 12%, transparent);
   color: #ff5fc1;
 }
 
 .quantityBadgeSupply {
-  background: color-mix(in srgb, var(--glitch-color-success) 12%, transparent);
+  background: color-mix(in srgb, var(--inara-color-success) 12%, transparent);
   color: #29f3c3;
 }
 
@@ -225,7 +225,7 @@
 }
 
 .itemNote {
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
   font-size: 0.82rem;
 }
 
@@ -245,14 +245,14 @@
   align-items: baseline;
   gap: 0.25rem;
   font-weight: 600;
-  color: var(--glitch-accent);
+  color: var(--inara-accent);
 }
 
 .shipMetricLabel {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.65rem;
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
   font-weight: 600;
 }
 
@@ -262,7 +262,7 @@
   gap: 0.5rem;
   align-items: center;
   font-size: 0.85rem;
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
 }
 
 .shipSummary {
@@ -271,11 +271,11 @@
   gap: 0.45rem;
   align-items: center;
   font-size: 0.85rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .shipSummary strong {
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   font-weight: 600;
 }
 
@@ -283,11 +283,11 @@
   text-transform: uppercase;
   letter-spacing: 0.16em;
   font-size: 0.68rem;
-  color: var(--glitch-text-soft);
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
+  color: var(--inara-text-soft);
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
   padding: 0.18rem 0.55rem;
   border-radius: 999px;
-  box-shadow: 0 0 0.8rem color-mix(in srgb, var(--glitch-color-primary) 25%, transparent);
+  box-shadow: 0 0 0.8rem color-mix(in srgb, var(--inara-color-primary) 25%, transparent);
 }
 
 @media (max-width: 1200px) {

--- a/src/client/components/panels/inara/transfer-context-summary.module.css
+++ b/src/client/components/panels/inara/transfer-context-summary.module.css
@@ -7,9 +7,9 @@
   width: 100%;
   padding: 0.75rem 1rem;
   border-radius: 0.8rem;
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 24%, transparent);
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-background) 86%, transparent) 0%, color-mix(in srgb, var(--glitch-color-primary) 8%, transparent) 100%);
-  box-shadow: 0 0.85rem 2rem color-mix(in srgb, var(--glitch-color-background) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 24%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-background) 86%, transparent) 0%, color-mix(in srgb, var(--inara-color-primary) 8%, transparent) 100%);
+  box-shadow: 0 0.85rem 2rem color-mix(in srgb, var(--inara-color-background) 78%, transparent);
 }
 
 .segment {
@@ -44,7 +44,7 @@
 .primary {
   font-size: 0.96rem;
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -59,7 +59,7 @@
 
 .subtext {
   font-size: 0.7rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   white-space: nowrap;
 }
 
@@ -83,12 +83,12 @@
   font-size: 0.6rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 48%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 48%, transparent);
 }
 
 .metricValue {
   font-size: 0.74rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   display: inline-flex;
   align-items: center;
   gap: 0.24rem;
@@ -101,9 +101,9 @@
   justify-content: center;
   padding: 0.2rem 0.5rem;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 32%, transparent);
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
-  color: var(--glitch-ink);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 32%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
+  color: var(--inara-ink);
   font-weight: 600;
   font-size: 0.72rem;
   letter-spacing: 0.02em;
@@ -111,7 +111,7 @@
 
 .commodityPrice {
   font-size: 0.78rem;
-  color: var(--glitch-color-text-strong);
+  color: var(--inara-color-text-strong);
   white-space: nowrap;
 }
 
@@ -122,19 +122,19 @@
 .distanceIcon {
   font-size: 1.25rem;
   line-height: 1;
-  color: var(--glitch-color-accent, var(--glitch-accent));
+  color: var(--inara-color-accent, var(--inara-accent));
 }
 
 .distanceValue {
   font-size: 0.82rem;
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   white-space: nowrap;
 }
 
 .distanceSecondary {
   font-size: 0.72rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   white-space: nowrap;
 }
 
@@ -145,13 +145,13 @@
 .valuePrimary {
   font-size: 0.84rem;
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   white-space: nowrap;
 }
 
 .valueSecondary {
   font-size: 0.72rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   white-space: nowrap;
 }
 

--- a/src/client/lib/animate-table-effect.js
+++ b/src/client/lib/animate-table-effect.js
@@ -14,7 +14,7 @@ module.exports = () => {
       const delay = `${shownItems++ * 0.03}s`
 
       if (target.matches('[data-inara-table-row]')) {
-        target.style.setProperty('--glitch-row-delay', delay)
+        target.style.setProperty('--inara-row-delay', delay)
         target.setAttribute('data-inara-table-row', 'visible')
       } else {
         target.style.animationDelay = delay

--- a/src/client/lib/navigation-items.js
+++ b/src/client/lib/navigation-items.js
@@ -91,6 +91,37 @@ function InaraPanelNavItems (activePanel) {
   return navigationItems
 }
 
+function InaraWorkspaceNavItems (activePanel) {
+  const navigationItems = [
+    {
+      name: 'Trade Routes',
+      icon: 'route',
+      url: '/inara/trade-routes'
+    },
+    {
+      name: 'Cargo',
+      icon: 'cargo',
+      url: '/inara/cargo'
+    },
+    {
+      name: 'Mining Missions',
+      icon: 'asteroid-base',
+      url: '/inara/mining-missions'
+    },
+    {
+      name: 'Mining Locations',
+      icon: 'planet-ringed',
+      url: '/inara/mining-locations'
+    }
+  ]
+
+  navigationItems.forEach(item => {
+    if (item.name.toLowerCase() === activePanel.toLowerCase()) item.active = true
+  })
+
+  return navigationItems
+}
+
 function EngineeringPanelNavItems (activePanel) {
   const navigationItems = [
     {
@@ -155,6 +186,7 @@ module.exports = {
   ShipPanelNavItems,
   NavPanelNavItems,
   InaraPanelNavItems,
+  InaraWorkspaceNavItems,
   EngineeringPanelNavItems,
   SettingsNavItems
 }

--- a/src/client/pages/inara-workspace.module.css
+++ b/src/client/pages/inara-workspace.module.css
@@ -1,11 +1,11 @@
-.glitchLayout {
+.inaraLayout {
   left: 0;
   right: 0;
   bottom: 0;
   padding: 0;
 }
 
-.glitchViewport {
+.inaraViewport {
   position: relative;
   display: grid;
   grid-template-columns: 4.5rem minmax(0, 1fr);
@@ -13,20 +13,20 @@
   height: 100%;
 }
 
-.glitchNavigation {
+.inaraNavigation {
   position: relative;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-primary-dark) 70%, transparent) 0%, color-mix(in srgb, var(--glitch-color-background) 88%, transparent) 100%);
-  box-shadow: inset -1px 0 0 color-mix(in srgb, var(--glitch-color-primary) 35%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-primary-dark) 70%, transparent) 0%, color-mix(in srgb, var(--inara-color-background) 88%, transparent) 100%);
+  box-shadow: inset -1px 0 0 color-mix(in srgb, var(--inara-color-primary) 35%, transparent);
   display: flex;
   justify-content: center;
 }
 
-.glitchNavigationClassic {
+.inaraNavigationClassic {
   background: #000;
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.5);
 }
 
-.glitchNavigation :global(.secondary-navigation) {
+.inaraNavigation :global(.secondary-navigation) {
   position: sticky;
   top: 0;
   left: 0;
@@ -40,34 +40,34 @@
   gap: 0.75rem;
 }
 
-.glitchNavigation :global(.secondary-navigation button.button--icon) {
+.inaraNavigation :global(.secondary-navigation button.button--icon) {
   margin: 0;
 }
 
-.glitchContentArea {
+.inaraContentArea {
   position: relative;
   min-width: 0;
   display: flex;
   flex-direction: column;
 }
 
-.glitchScrollRegion {
+.inaraScrollRegion {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  background: var(--glitch-color-background);
+  background: var(--inara-color-background);
 }
 
-.glitchScrollRegionClassic {
+.inaraScrollRegionClassic {
   background: #000;
 }
 
-.glitchScrollRegion::-webkit-scrollbar {
+.inaraScrollRegion::-webkit-scrollbar {
   width: 16px;
 }
 
-.glitchScrollRegion::-webkit-scrollbar-track {
+.inaraScrollRegion::-webkit-scrollbar-track {
   background-image: linear-gradient(
     90deg,
     transparent 41.67%,
@@ -82,113 +82,113 @@
   background-position-x: 10px;
 }
 
-.glitchScrollRegion::-webkit-scrollbar-thumb {
+.inaraScrollRegion::-webkit-scrollbar-thumb {
   background: var(--color-primary);
   min-height: 4rem;
   box-shadow: 0 0 10px var(--color-primary-dark);
 }
 
-.glitch {
+.inara {
   position: relative;
   min-height: 100%;
-  --glitch-terminal-height: clamp(180px, 18vh, 220px);
-  --glitch-bg: var(--glitch-color-background);
-  --glitch-panel: color-mix(in srgb, var(--glitch-color-background) 88%, transparent);
-  --glitch-border-soft: color-mix(in srgb, var(--glitch-color-primary) 28%, transparent);
-  --glitch-border-regular: color-mix(in srgb, var(--glitch-color-primary) 35%, transparent);
-  --glitch-border-strong: color-mix(in srgb, var(--glitch-color-primary) 55%, transparent);
-  --glitch-border-focus: color-mix(in srgb, var(--glitch-color-primary-light) 45%, transparent);
-  --glitch-panel-border: var(--glitch-border-soft);
-  --glitch-shadow: color-mix(in srgb, var(--glitch-color-background) 55%, transparent);
-  --glitch-shadow-deep: color-mix(in srgb, var(--glitch-color-background) 68%, transparent);
-  --glitch-glow: color-mix(in srgb, var(--glitch-color-primary-light) 36%, transparent);
-  --glitch-divider: color-mix(in srgb, var(--glitch-color-text-strong) 16%, transparent);
-  --glitch-ink: color-mix(in srgb, var(--glitch-color-text-strong) 92%, transparent);
-  --glitch-muted: color-mix(in srgb, var(--glitch-color-text-strong) 70%, transparent);
-  --glitch-subdued: color-mix(in srgb, var(--glitch-color-text-strong) 56%, transparent);
-  --glitch-text-soft: color-mix(in srgb, var(--glitch-color-text-strong) 68%, transparent);
-  --glitch-text-faint: color-mix(in srgb, var(--glitch-color-text-strong) 54%, transparent);
-  --glitch-accent: var(--glitch-color-primary-light);
-  --glitch-highlight: color-mix(in srgb, var(--glitch-color-primary-light) 18%, transparent);
-  --glitch-highlight-strong: color-mix(in srgb, var(--glitch-color-primary) 25%, transparent);
-  --glitch-scrollbar-track: var(--glitch-color-scroll-track);
-  --glitch-scrollbar-thumb: var(--glitch-color-scroll-thumb);
-  --glitch-scrollbar-thumb-border: var(--glitch-color-scroll-thumb-border);
-  --glitch-terminal-jackpot-flood: color-mix(in srgb, var(--glitch-color-success) 88%, transparent);
-  --glitch-terminal-jackpot-flood-shadow: color-mix(in srgb, var(--glitch-color-success) 58%, transparent);
-  --glitch-terminal-jackpot-flood-accent: color-mix(in srgb, var(--glitch-color-primary-light) 28%, transparent);
-  --glitch-terminal-debit: color-mix(in srgb, var(--glitch-color-warning) 92%, transparent);
-  --glitch-terminal-debit-shadow: color-mix(in srgb, var(--glitch-color-warning) 64%, transparent);
-  --glitch-terminal-debit-contrast: color-mix(in srgb, var(--glitch-color-text-strong) 94%, transparent);
-  --glitch-table-header: linear-gradient(
+  --inara-terminal-height: clamp(180px, 18vh, 220px);
+  --inara-bg: var(--inara-color-background);
+  --inara-panel: color-mix(in srgb, var(--inara-color-background) 88%, transparent);
+  --inara-border-soft: color-mix(in srgb, var(--inara-color-primary) 28%, transparent);
+  --inara-border-regular: color-mix(in srgb, var(--inara-color-primary) 35%, transparent);
+  --inara-border-strong: color-mix(in srgb, var(--inara-color-primary) 55%, transparent);
+  --inara-border-focus: color-mix(in srgb, var(--inara-color-primary-light) 45%, transparent);
+  --inara-panel-border: var(--inara-border-soft);
+  --inara-shadow: color-mix(in srgb, var(--inara-color-background) 55%, transparent);
+  --inara-shadow-deep: color-mix(in srgb, var(--inara-color-background) 68%, transparent);
+  --inara-glow: color-mix(in srgb, var(--inara-color-primary-light) 36%, transparent);
+  --inara-divider: color-mix(in srgb, var(--inara-color-text-strong) 16%, transparent);
+  --inara-ink: color-mix(in srgb, var(--inara-color-text-strong) 92%, transparent);
+  --inara-muted: color-mix(in srgb, var(--inara-color-text-strong) 70%, transparent);
+  --inara-subdued: color-mix(in srgb, var(--inara-color-text-strong) 56%, transparent);
+  --inara-text-soft: color-mix(in srgb, var(--inara-color-text-strong) 68%, transparent);
+  --inara-text-faint: color-mix(in srgb, var(--inara-color-text-strong) 54%, transparent);
+  --inara-accent: var(--inara-color-primary-light);
+  --inara-highlight: color-mix(in srgb, var(--inara-color-primary-light) 18%, transparent);
+  --inara-highlight-strong: color-mix(in srgb, var(--inara-color-primary) 25%, transparent);
+  --inara-scrollbar-track: var(--inara-color-scroll-track);
+  --inara-scrollbar-thumb: var(--inara-color-scroll-thumb);
+  --inara-scrollbar-thumb-border: var(--inara-color-scroll-thumb-border);
+  --inara-terminal-jackpot-flood: color-mix(in srgb, var(--inara-color-success) 88%, transparent);
+  --inara-terminal-jackpot-flood-shadow: color-mix(in srgb, var(--inara-color-success) 58%, transparent);
+  --inara-terminal-jackpot-flood-accent: color-mix(in srgb, var(--inara-color-primary-light) 28%, transparent);
+  --inara-terminal-debit: color-mix(in srgb, var(--inara-color-warning) 92%, transparent);
+  --inara-terminal-debit-shadow: color-mix(in srgb, var(--inara-color-warning) 64%, transparent);
+  --inara-terminal-debit-contrast: color-mix(in srgb, var(--inara-color-text-strong) 94%, transparent);
+  --inara-table-header: linear-gradient(
     180deg,
-    color-mix(in srgb, var(--glitch-color-primary) 82%, transparent) 0%,
-    color-mix(in srgb, var(--glitch-color-primary-dark) 78%, transparent) 100%
+    color-mix(in srgb, var(--inara-color-primary) 82%, transparent) 0%,
+    color-mix(in srgb, var(--inara-color-primary-dark) 78%, transparent) 100%
   );
-  --glitch-gradient-top: color-mix(in srgb, var(--glitch-color-surface) 92%, transparent);
-  --glitch-gradient-mid: color-mix(in srgb, var(--glitch-color-primary-dark) 60%, transparent);
-  --glitch-gradient-bottom: color-mix(in srgb, var(--glitch-color-background) 88%, transparent);
-  padding: 0 0 calc(4.25rem + var(--glitch-terminal-height));
-  background: linear-gradient(165deg, var(--glitch-gradient-top) 0%, var(--glitch-gradient-mid) 55%, var(--glitch-gradient-bottom) 100%),
-    var(--glitch-bg);
-  color: var(--glitch-ink);
+  --inara-gradient-top: color-mix(in srgb, var(--inara-color-surface) 92%, transparent);
+  --inara-gradient-mid: color-mix(in srgb, var(--inara-color-primary-dark) 60%, transparent);
+  --inara-gradient-bottom: color-mix(in srgb, var(--inara-color-background) 88%, transparent);
+  padding: 0 0 calc(4.25rem + var(--inara-terminal-height));
+  background: linear-gradient(165deg, var(--inara-gradient-top) 0%, var(--inara-gradient-mid) 55%, var(--inara-gradient-bottom) 100%),
+    var(--inara-bg);
+  color: var(--inara-ink);
   overflow: hidden;
 }
 
-.glitchIcarus {
-  --glitch-color-background: #000;
-  --glitch-color-surface: var(--color-background-panel);
-  --glitch-color-primary: var(--color-primary);
-  --glitch-color-primary-dark: var(--color-primary-dark);
-  --glitch-color-primary-light: var(--color-secondary);
-  --glitch-color-text-strong: var(--color-info);
-  --glitch-color-success: var(--color-success);
-  --glitch-color-warning: var(--color-danger);
-  --glitch-color-scroll-track: #000;
-  --glitch-color-scroll-thumb: color-mix(in srgb, var(--color-secondary) 75%, transparent);
-  --glitch-color-scroll-thumb-border: color-mix(in srgb, var(--color-secondary) 45%, transparent);
-  --glitch-gradient-top: #000;
-  --glitch-gradient-mid: #000;
-  --glitch-gradient-bottom: #000;
-  --glitch-bg: #000;
+.inaraIcarus {
+  --inara-color-background: #000;
+  --inara-color-surface: var(--color-background-panel);
+  --inara-color-primary: var(--color-primary);
+  --inara-color-primary-dark: var(--color-primary-dark);
+  --inara-color-primary-light: var(--color-secondary);
+  --inara-color-text-strong: var(--color-info);
+  --inara-color-success: var(--color-success);
+  --inara-color-warning: var(--color-danger);
+  --inara-color-scroll-track: #000;
+  --inara-color-scroll-thumb: color-mix(in srgb, var(--color-secondary) 75%, transparent);
+  --inara-color-scroll-thumb-border: color-mix(in srgb, var(--color-secondary) 45%, transparent);
+  --inara-gradient-top: #000;
+  --inara-gradient-mid: #000;
+  --inara-gradient-bottom: #000;
+  --inara-bg: #000;
   background: #000;
   color: var(--color-info);
   box-shadow: none;
 }
 
-.glitchIcarus::before,
-.glitchIcarus::after {
+.inaraIcarus::before,
+.inaraIcarus::after {
   display: none;
 }
 
-.glitch::before {
+.inara::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: url('/glitch/signal-mesh.svg') center/cover no-repeat;
+  background: url('/inara/signal-mesh.svg') center/cover no-repeat;
   opacity: 0.24;
   mix-blend-mode: screen;
   pointer-events: none;
 }
 
-.glitch::after {
+.inara::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--glitch-color-background) 90%, transparent) 100%);
+  background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--inara-color-background) 90%, transparent) 100%);
   pointer-events: none;
 }
 
-.glitchPanel :global(.layout__panel-scroll) {
+.inaraPanel :global(.layout__panel-scroll) {
   padding: 0;
-  background: var(--glitch-bg);
+  background: var(--inara-bg);
 }
 
-.glitchPanel :global(.layout__panel-scroll::-webkit-scrollbar) {
+.inaraPanel :global(.layout__panel-scroll::-webkit-scrollbar) {
   width: 16px;
 }
 
-.glitchPanel :global(.layout__panel-scroll::-webkit-scrollbar-track) {
+.inaraPanel :global(.layout__panel-scroll::-webkit-scrollbar-track) {
   background-image: linear-gradient(
     90deg,
     transparent 41.67%,
@@ -203,43 +203,43 @@
   background-position-x: 10px;
 }
 
-.glitchPanel :global(.layout__panel-scroll::-webkit-scrollbar-thumb) {
+.inaraPanel :global(.layout__panel-scroll::-webkit-scrollbar-thumb) {
   background: var(--color-primary);
   min-height: 4rem;
   box-shadow: 0 0 10px var(--color-primary-dark);
 }
 
 .arrival {
-  animation: glitchArrivalSurface 4.2s cubic-bezier(0.45, 0, 0.2, 1) forwards;
+  animation: inaraArrivalSurface 4.2s cubic-bezier(0.45, 0, 0.2, 1) forwards;
 }
 
 .arrival::before {
-  animation: glitchArrivalMesh 4.2s steps(3, end) forwards;
+  animation: inaraArrivalMesh 4.2s steps(3, end) forwards;
 }
 
 .arrival::after {
-  animation: glitchArrivalVignette 4.2s ease-out forwards;
+  animation: inaraArrivalVignette 4.2s ease-out forwards;
 }
 
 .arrival .shell {
-  animation: glitchArrivalShell 4.1s cubic-bezier(0.33, 1, 0.68, 1) forwards;
+  animation: inaraArrivalShell 4.1s cubic-bezier(0.33, 1, 0.68, 1) forwards;
 }
 
 .arrival .sectionHint,
-.arrival .glitchAlert,
-.arrival :global(.glitch-inline-accent),
-.arrival :global(.glitch-muted),
-.arrival :global(.glitch-accent) {
-  animation: glitchArrivalChromatic 4.2s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+.arrival .inaraAlert,
+.arrival :global(.inara-inline-accent),
+.arrival :global(.inara-muted),
+.arrival :global(.inara-accent) {
+  animation: inaraArrivalChromatic 4.2s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
 }
 
 .arrival .sectionFrame,
 .arrival .sectionFrameElevated {
-  animation: glitchArrivalPanel 4.2s cubic-bezier(0.42, 0, 0.25, 1) forwards;
+  animation: inaraArrivalPanel 4.2s cubic-bezier(0.42, 0, 0.25, 1) forwards;
 }
 
 .arrival .badge {
-  animation: glitchArrivalBadge 4.2s cubic-bezier(0.42, 0, 0.25, 1) forwards;
+  animation: inaraArrivalBadge 4.2s cubic-bezier(0.42, 0, 0.25, 1) forwards;
 }
 
 .shell {
@@ -263,7 +263,7 @@
   display: flex;
   justify-content: center;
   align-items: flex-end;
-  height: var(--glitch-terminal-height);
+  height: var(--inara-terminal-height);
   pointer-events: none;
   z-index: 20;
 }
@@ -281,12 +281,12 @@
   width: 100%;
   max-width: none;
   background: linear-gradient(180deg, rgba(6, 6, 12, 0.96) 0%, rgba(2, 2, 6, 0.98) 60%, rgba(0, 0, 0, 0.98) 100%);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-text-strong) 26%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-text-strong) 26%, transparent);
   border-bottom: none;
   border-radius: 1.5rem 1.5rem 0 0;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   pointer-events: auto;
-  box-shadow: 0 -1.5rem 3rem rgba(0, 0, 0, 0.65), 0 0 2rem color-mix(in srgb, var(--glitch-color-primary) 28%, transparent);
+  box-shadow: 0 -1.5rem 3rem rgba(0, 0, 0, 0.65), 0 0 2rem color-mix(in srgb, var(--inara-color-primary) 28%, transparent);
   backdrop-filter: blur(10px);
   display: flex;
   flex-direction: column;
@@ -310,8 +310,8 @@
   pointer-events: none;
   opacity: 0;
   transition: opacity 320ms ease, filter 320ms ease;
-  background: radial-gradient(circle at 50% 15%, color-mix(in srgb, var(--glitch-color-success) 18%, transparent) 0%, transparent 55%),
-    linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-success) 6%, transparent) 0%, transparent 68%);
+  background: radial-gradient(circle at 50% 15%, color-mix(in srgb, var(--inara-color-success) 18%, transparent) 0%, transparent 55%),
+    linear-gradient(180deg, color-mix(in srgb, var(--inara-color-success) 6%, transparent) 0%, transparent 68%);
   mix-blend-mode: screen;
   overflow: hidden;
   z-index: 0;
@@ -334,8 +334,8 @@
 .terminalCelebrationGlyph {
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
   font-size: 1.05rem;
-  color: color-mix(in srgb, var(--glitch-color-success) 95%, transparent);
-  text-shadow: 0 0 1.65rem color-mix(in srgb, var(--glitch-color-success) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-success) 95%, transparent);
+  text-shadow: 0 0 1.65rem color-mix(in srgb, var(--inara-color-success) 60%, transparent);
   --terminal-celebration-skew: 0deg;
   display: inline-block;
   opacity: 0;
@@ -365,7 +365,7 @@
   gap: 1.5rem;
   padding: 1rem 1.5rem 0.75rem 1.5rem;
   background: linear-gradient(180deg, rgba(32, 32, 40, 0.92) 0%, rgba(12, 12, 18, 0.96) 60%, rgba(6, 6, 12, 0.98) 100%);
-  border-bottom: 1px solid color-mix(in srgb, var(--glitch-color-text-strong) 22%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--inara-color-text-strong) 22%, transparent);
   box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.45);
 }
 
@@ -404,7 +404,7 @@
 .terminalHeaderCompressed {
   padding: 0.45rem 0.85rem;
   background: linear-gradient(180deg, rgba(28, 28, 34, 0.94) 0%, rgba(8, 8, 12, 0.98) 100%);
-  border-bottom: 1px solid color-mix(in srgb, var(--glitch-color-text-strong) 18%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--inara-color-text-strong) 18%, transparent);
   gap: 0.85rem;
 }
 
@@ -440,7 +440,7 @@
   gap: 0.35rem;
   padding: 0;
   background: rgba(0, 0, 0, 0.35);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-text-strong) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-text-strong) 16%, transparent);
   border-radius: 6px;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.4);
   min-height: clamp(2.4rem, 2rem + 0.8vw, 3rem);
@@ -455,13 +455,13 @@
   aspect-ratio: 36 / 28;
   min-height: clamp(2.2rem, 1.8rem + 0.8vw, 2.85rem);
   border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--glitch-color-text-strong) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-text-strong) 18%, transparent);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: clamp(0.85rem, 0.75rem + 0.25vw, 1.25rem);
   line-height: 1;
-  color: var(--glitch-color-text-strong);
+  color: var(--inara-color-text-strong);
   background: linear-gradient(180deg, rgba(24, 24, 32, 0.92) 0%, rgba(8, 8, 12, 0.98) 100%);
   cursor: pointer;
   transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease, border-color 180ms ease;
@@ -476,11 +476,11 @@ button.terminalWindowControl:not(:disabled):hover,
 button.terminalWindowControl:focus-visible {
   transform: translateY(-1px);
   background: linear-gradient(180deg, rgba(36, 36, 48, 0.96) 0%, rgba(12, 12, 18, 0.98) 100%);
-  border-color: color-mix(in srgb, var(--glitch-color-text-strong) 28%, transparent);
+  border-color: color-mix(in srgb, var(--inara-color-text-strong) 28%, transparent);
 }
 
 button.terminalWindowControl:focus-visible {
-  outline: 2px solid var(--glitch-border-focus);
+  outline: 2px solid var(--inara-border-focus);
   outline-offset: 2px;
 }
 
@@ -497,51 +497,51 @@ button.terminalWindowControl:disabled {
 }
 
 .terminalWindowControlMinimize {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-warning) 22%, transparent) 0%, rgba(20, 20, 28, 0.98) 100%);
-  border-color: color-mix(in srgb, var(--glitch-color-warning) 26%, transparent);
-  color: color-mix(in srgb, var(--glitch-color-warning) 86%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-warning) 22%, transparent) 0%, rgba(20, 20, 28, 0.98) 100%);
+  border-color: color-mix(in srgb, var(--inara-color-warning) 26%, transparent);
+  color: color-mix(in srgb, var(--inara-color-warning) 86%, transparent);
 }
 
 button.terminalWindowControlMinimize:not(:disabled):hover,
 button.terminalWindowControlMinimize:focus-visible {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-warning) 32%, transparent) 0%, rgba(24, 24, 32, 0.98) 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-warning) 32%, transparent) 0%, rgba(24, 24, 32, 0.98) 100%);
 }
 
 .terminalWindowControlMaximize {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-success) 28%, transparent) 0%, rgba(20, 24, 28, 0.98) 100%);
-  border-color: color-mix(in srgb, var(--glitch-color-success) 32%, transparent);
-  color: color-mix(in srgb, var(--glitch-color-success) 82%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-success) 28%, transparent) 0%, rgba(20, 24, 28, 0.98) 100%);
+  border-color: color-mix(in srgb, var(--inara-color-success) 32%, transparent);
+  color: color-mix(in srgb, var(--inara-color-success) 82%, transparent);
 }
 
 button.terminalWindowControlMaximize:not(:disabled):hover,
 button.terminalWindowControlMaximize:focus-visible {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-success) 38%, transparent) 0%, rgba(26, 30, 34, 0.98) 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-success) 38%, transparent) 0%, rgba(26, 30, 34, 0.98) 100%);
 }
 
 .terminalWindowControlClose {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-primary) 38%, transparent) 0%, rgba(24, 16, 36, 0.98) 100%);
-  border-color: color-mix(in srgb, var(--glitch-color-primary) 36%, transparent);
-  color: color-mix(in srgb, var(--glitch-color-primary) 88%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-primary) 38%, transparent) 0%, rgba(24, 16, 36, 0.98) 100%);
+  border-color: color-mix(in srgb, var(--inara-color-primary) 36%, transparent);
+  color: color-mix(in srgb, var(--inara-color-primary) 88%, transparent);
 }
 
 button.terminalWindowControlClose:not(:disabled):hover,
 button.terminalWindowControlClose:focus-visible {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-primary) 48%, transparent) 0%, rgba(30, 20, 44, 0.98) 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-primary) 48%, transparent) 0%, rgba(30, 20, 44, 0.98) 100%);
 }
 
 .terminalWindowControlToken {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-primary) 60%, transparent) 0%, rgba(26, 18, 44, 0.98) 100%);
-  border-color: color-mix(in srgb, var(--glitch-color-primary) 44%, transparent);
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 94%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-primary) 60%, transparent) 0%, rgba(26, 18, 44, 0.98) 100%);
+  border-color: color-mix(in srgb, var(--inara-color-primary) 44%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 94%, transparent);
 }
 
 button.terminalWindowControlToken:not(:disabled):hover,
 button.terminalWindowControlToken:focus-visible {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-primary) 72%, transparent) 0%, rgba(32, 22, 52, 0.98) 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-primary) 72%, transparent) 0%, rgba(32, 22, 52, 0.98) 100%);
 }
 
 button.terminalWindowControlToken:not(:disabled):active {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-primary-dark) 68%, transparent) 0%, rgba(18, 12, 32, 0.98) 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-primary-dark) 68%, transparent) 0%, rgba(18, 12, 32, 0.98) 100%);
 }
 
 .terminalStatusPreview {
@@ -552,7 +552,7 @@ button.terminalWindowControlToken:not(:disabled):active {
   border: 1px solid transparent;
   border-radius: 999px;
   background: transparent;
-  color: var(--glitch-color-text-strong);
+  color: var(--inara-color-text-strong);
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
   font-size: 0.78rem;
   letter-spacing: 0.08em;
@@ -565,12 +565,12 @@ button.terminalWindowControlToken:not(:disabled):active {
 }
 
 button.terminalStatusPreview:hover {
-  border-color: color-mix(in srgb, var(--glitch-border-soft) 68%, transparent);
-  background: color-mix(in srgb, var(--glitch-color-primary) 16%, transparent);
+  border-color: color-mix(in srgb, var(--inara-border-soft) 68%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 16%, transparent);
 }
 
 button.terminalStatusPreview:focus-visible {
-  outline: 2px solid var(--glitch-border-focus);
+  outline: 2px solid var(--inara-border-focus);
   outline-offset: 2px;
 }
 
@@ -578,14 +578,14 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.68rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 68%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 68%, transparent);
   white-space: nowrap;
 }
 
 .terminalStatusPreviewText {
   font-size: 0.78rem;
   letter-spacing: 0.12em;
-  color: var(--glitch-color-text-strong);
+  color: var(--inara-color-text-strong);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -597,12 +597,12 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.9rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--glitch-color-text-strong);
+  color: var(--inara-color-text-strong);
 }
 
 .terminalStatus {
   font-size: 0.8rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 68%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 68%, transparent);
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
 }
 
@@ -620,21 +620,21 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.72rem;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
 }
 
 .terminalTokenValue {
   font-size: 0.96rem;
   letter-spacing: 0.08em;
-  color: var(--glitch-color-text-strong);
+  color: var(--inara-color-text-strong);
   min-width: 5rem;
   text-align: right;
   white-space: nowrap;
 }
 
 .terminalTokenValueNegative {
-  color: var(--glitch-color-warning);
-  text-shadow: 0 0 0.8rem color-mix(in srgb, var(--glitch-color-warning) 55%, transparent);
+  color: var(--inara-color-warning);
+  text-shadow: 0 0 0.8rem color-mix(in srgb, var(--inara-color-warning) 55%, transparent);
 }
 
 .terminalTokenValueFlashCredit {
@@ -661,7 +661,7 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.65rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 54%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 54%, transparent);
 }
 
 .terminalBody {
@@ -670,7 +670,7 @@ button.terminalStatusPreview:focus-visible {
   background: linear-gradient(180deg, rgba(0, 0, 0, 0.92) 0%, rgba(0, 0, 0, 0.98) 40%, rgba(4, 4, 12, 0.98) 100%);
   overflow: hidden;
   display: flex;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--glitch-color-text-strong) 12%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--inara-color-text-strong) 12%, transparent);
 }
 
 .terminalFeed {
@@ -689,7 +689,7 @@ button.terminalStatusPreview:focus-visible {
   gap: 0.85rem;
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
   font-size: 0.85rem;
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
   opacity: 0;
   animation: terminalLineReveal 320ms ease forwards;
 }
@@ -702,153 +702,153 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .terminalPromptCommand {
-  color: var(--glitch-color-success);
+  color: var(--inara-color-success);
 }
 
 .terminalPromptResponse {
-  color: color-mix(in srgb, var(--glitch-color-primary) 75%, transparent);
+  color: color-mix(in srgb, var(--inara-color-primary) 75%, transparent);
 }
 
 .terminalPromptAlert {
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
 }
 
 .terminalPromptCipher {
-  color: var(--glitch-text-faint);
+  color: var(--inara-text-faint);
 }
 
 .terminalPromptBinary {
-  color: var(--glitch-color-success);
+  color: var(--inara-color-success);
 }
 
 .terminalPromptDecrypt {
-  color: color-mix(in srgb, var(--glitch-color-primary) 95%, transparent);
+  color: color-mix(in srgb, var(--inara-color-primary) 95%, transparent);
 }
 
-.terminalPromptGlitch {
-  color: color-mix(in srgb, var(--glitch-color-primary) 85%, transparent);
-  text-shadow: 0 0 18px color-mix(in srgb, var(--glitch-color-primary) 48%, transparent);
+.terminalPromptInara {
+  color: color-mix(in srgb, var(--inara-color-primary) 85%, transparent);
+  text-shadow: 0 0 18px color-mix(in srgb, var(--inara-color-primary) 48%, transparent);
 }
 
 .terminalPromptSystem {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 72%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 72%, transparent);
 }
 
 .terminalPromptCredit {
-  color: color-mix(in srgb, var(--glitch-color-success) 96%, transparent);
-  text-shadow: 0 0 18px color-mix(in srgb, var(--glitch-color-success) 58%, transparent);
+  color: color-mix(in srgb, var(--inara-color-success) 96%, transparent);
+  text-shadow: 0 0 18px color-mix(in srgb, var(--inara-color-success) 58%, transparent);
 }
 
 .terminalPromptTransaction {
-  color: color-mix(in srgb, var(--glitch-color-success) 88%, transparent);
-  text-shadow: 0 0 14px color-mix(in srgb, var(--glitch-color-success) 40%, transparent);
+  color: color-mix(in srgb, var(--inara-color-success) 88%, transparent);
+  text-shadow: 0 0 14px color-mix(in srgb, var(--inara-color-success) 40%, transparent);
 }
 
 .terminalPromptSimulation {
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
   animation: terminalSimulationPulse 1.4s ease-in-out infinite;
 }
 
 .terminalPromptJackpot {
-  color: var(--glitch-color-primary);
-  text-shadow: 0 0 18px color-mix(in srgb, var(--glitch-color-primary) 65%, transparent);
+  color: var(--inara-color-primary);
+  text-shadow: 0 0 18px color-mix(in srgb, var(--inara-color-primary) 65%, transparent);
 }
 
 .terminalPromptJackpotGlyph {
-  color: color-mix(in srgb, var(--glitch-color-primary-light) 82%, transparent);
+  color: color-mix(in srgb, var(--inara-color-primary-light) 82%, transparent);
 }
 
 .terminalPromptJackpotFloodGlyph {
-  color: var(--glitch-terminal-jackpot-flood);
+  color: var(--inara-terminal-jackpot-flood);
   text-shadow:
-    0 0 18px var(--glitch-terminal-jackpot-flood-shadow),
-    0 0 28px var(--glitch-terminal-jackpot-flood-accent);
+    0 0 18px var(--inara-terminal-jackpot-flood-shadow),
+    0 0 28px var(--inara-terminal-jackpot-flood-accent);
   animation: terminalJackpotFloodPulse 1.6s ease-in-out infinite;
   white-space: nowrap;
 }
 
 .terminalPromptJackpotSummary {
-  color: var(--glitch-color-success);
-  text-shadow: 0 0 12px color-mix(in srgb, var(--glitch-color-success) 48%, transparent);
+  color: var(--inara-color-success);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--inara-color-success) 48%, transparent);
 }
 
 .terminalPromptDebitGlyph {
-  color: var(--glitch-terminal-debit);
-  text-shadow: 0 0 16px var(--glitch-terminal-debit-shadow);
+  color: var(--inara-terminal-debit);
+  text-shadow: 0 0 16px var(--inara-terminal-debit-shadow);
   animation: terminalDebitGlyphPulse 1.8s steps(2, end) infinite;
 }
 
 .terminalText {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 82%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 82%, transparent);
 }
 
 .terminalTextAlert {
-  color: var(--glitch-color-warning);
-  text-shadow: 0 0 12px color-mix(in srgb, var(--glitch-color-warning) 58%, transparent);
+  color: var(--inara-color-warning);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--inara-color-warning) 58%, transparent);
 }
 
 .terminalTextCipher {
-  color: var(--glitch-text-faint);
+  color: var(--inara-text-faint);
   letter-spacing: 0.18em;
 }
 
 .terminalTextBinary {
-  color: color-mix(in srgb, var(--glitch-color-success) 92%, transparent);
-  text-shadow: 0 0 10px color-mix(in srgb, var(--glitch-color-success) 55%, transparent);
+  color: color-mix(in srgb, var(--inara-color-success) 92%, transparent);
+  text-shadow: 0 0 10px color-mix(in srgb, var(--inara-color-success) 55%, transparent);
 }
 
 .terminalTextDecrypt {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 95%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 95%, transparent);
 }
 
-.terminalTextGlitch {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 70%, transparent);
+.terminalTextInara {
+  color: color-mix(in srgb, var(--inara-color-text-strong) 70%, transparent);
   letter-spacing: 0.2em;
-  text-shadow: 0 0 22px color-mix(in srgb, var(--glitch-color-primary) 45%, transparent);
+  text-shadow: 0 0 22px color-mix(in srgb, var(--inara-color-primary) 45%, transparent);
 }
 
 .terminalTextSystem {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 92%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 92%, transparent);
 }
 
 .terminalTextCredit {
-  color: color-mix(in srgb, var(--glitch-color-success) 90%, transparent);
-  text-shadow: 0 0 22px color-mix(in srgb, var(--glitch-color-success) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-success) 90%, transparent);
+  text-shadow: 0 0 22px color-mix(in srgb, var(--inara-color-success) 60%, transparent);
   letter-spacing: 0.2em;
 }
 
 .terminalTextTransaction {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 92%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 92%, transparent);
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .terminalTextSimulation {
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
   letter-spacing: 0.24em;
   text-transform: uppercase;
   animation: terminalSimulationTextPulse 1.4s ease-in-out infinite;
 }
 
 .terminalTextJackpot {
-  color: var(--glitch-color-primary);
+  color: var(--inara-color-primary);
   font-weight: 600;
   letter-spacing: 0.16em;
-  text-shadow: 0 0 22px color-mix(in srgb, var(--glitch-color-primary) 58%, transparent);
+  text-shadow: 0 0 22px color-mix(in srgb, var(--inara-color-primary) 58%, transparent);
   animation: terminalJackpotShimmer 2.2s linear infinite;
 }
 
 .terminalTextJackpotGlyph {
-  color: color-mix(in srgb, var(--glitch-color-primary-light) 88%, transparent);
-  text-shadow: 0 0 14px color-mix(in srgb, var(--glitch-color-primary-light) 55%, transparent);
+  color: color-mix(in srgb, var(--inara-color-primary-light) 88%, transparent);
+  text-shadow: 0 0 14px color-mix(in srgb, var(--inara-color-primary-light) 55%, transparent);
   animation: terminalJackpotGlyph 1.4s ease-in-out infinite;
 }
 
 .terminalTextJackpotFloodGlyph {
-  color: var(--glitch-terminal-jackpot-flood);
+  color: var(--inara-terminal-jackpot-flood);
   text-shadow:
-    0 0 18px var(--glitch-terminal-jackpot-flood-shadow),
-    0 0 36px var(--glitch-terminal-jackpot-flood-accent);
+    0 0 18px var(--inara-terminal-jackpot-flood-shadow),
+    0 0 36px var(--inara-terminal-jackpot-flood-accent);
   letter-spacing: 0.22em;
   display: inline-block;
   max-width: 100%;
@@ -859,18 +859,18 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .terminalTextJackpotSummary {
-  color: var(--glitch-color-success);
+  color: var(--inara-color-success);
   font-weight: 600;
   letter-spacing: 0.18em;
-  text-shadow: 0 0 18px color-mix(in srgb, var(--glitch-color-success) 52%, transparent);
+  text-shadow: 0 0 18px color-mix(in srgb, var(--inara-color-success) 52%, transparent);
 }
 
 .terminalTextDebitGlyph {
-  color: var(--glitch-terminal-debit-contrast);
+  color: var(--inara-terminal-debit-contrast);
   letter-spacing: 0.24em;
   text-shadow:
-    0 0 16px var(--glitch-terminal-debit-shadow),
-    0 0 24px color-mix(in srgb, var(--glitch-color-warning) 46%, transparent);
+    0 0 16px var(--inara-terminal-debit-shadow),
+    0 0 24px color-mix(in srgb, var(--inara-color-warning) 46%, transparent);
   animation: terminalDebitGlyphPulse 1.8s steps(2, end) infinite;
 }
 
@@ -908,37 +908,37 @@ button.terminalStatusPreview:focus-visible {
 
 @keyframes terminalSimulationPulse {
   0% {
-    color: color-mix(in srgb, var(--glitch-color-warning) 72%, transparent);
+    color: color-mix(in srgb, var(--inara-color-warning) 72%, transparent);
   }
   50% {
-    color: color-mix(in srgb, var(--glitch-color-primary-light) 90%, transparent);
+    color: color-mix(in srgb, var(--inara-color-primary-light) 90%, transparent);
   }
   100% {
-    color: color-mix(in srgb, var(--glitch-color-warning) 72%, transparent);
+    color: color-mix(in srgb, var(--inara-color-warning) 72%, transparent);
   }
 }
 
 @keyframes terminalSimulationTextPulse {
   0% {
-    text-shadow: 0 0 12px color-mix(in srgb, var(--glitch-color-warning) 60%, transparent);
+    text-shadow: 0 0 12px color-mix(in srgb, var(--inara-color-warning) 60%, transparent);
   }
   50% {
-    text-shadow: 0 0 18px color-mix(in srgb, var(--glitch-color-primary) 55%, transparent);
+    text-shadow: 0 0 18px color-mix(in srgb, var(--inara-color-primary) 55%, transparent);
   }
   100% {
-    text-shadow: 0 0 12px color-mix(in srgb, var(--glitch-color-warning) 60%, transparent);
+    text-shadow: 0 0 12px color-mix(in srgb, var(--inara-color-warning) 60%, transparent);
   }
 }
 
 @keyframes terminalJackpotShimmer {
   0% {
-    text-shadow: 0 0 16px color-mix(in srgb, var(--glitch-color-primary) 48%, transparent);
+    text-shadow: 0 0 16px color-mix(in srgb, var(--inara-color-primary) 48%, transparent);
   }
   50% {
-    text-shadow: 0 0 28px color-mix(in srgb, var(--glitch-color-primary-light) 70%, transparent);
+    text-shadow: 0 0 28px color-mix(in srgb, var(--inara-color-primary-light) 70%, transparent);
   }
   100% {
-    text-shadow: 0 0 16px color-mix(in srgb, var(--glitch-color-primary) 48%, transparent);
+    text-shadow: 0 0 16px color-mix(in srgb, var(--inara-color-primary) 48%, transparent);
   }
 }
 
@@ -957,18 +957,18 @@ button.terminalStatusPreview:focus-visible {
 @keyframes terminalJackpotFloodGlyphDrift {
   0% {
     text-shadow:
-      0 0 18px var(--glitch-terminal-jackpot-flood-shadow),
-      0 0 26px var(--glitch-terminal-jackpot-flood-accent);
+      0 0 18px var(--inara-terminal-jackpot-flood-shadow),
+      0 0 26px var(--inara-terminal-jackpot-flood-accent);
   }
   50% {
     text-shadow:
-      0 0 22px var(--glitch-terminal-jackpot-flood-shadow),
-      0 0 42px var(--glitch-terminal-jackpot-flood-accent);
+      0 0 22px var(--inara-terminal-jackpot-flood-shadow),
+      0 0 42px var(--inara-terminal-jackpot-flood-accent);
   }
   100% {
     text-shadow:
-      0 0 18px var(--glitch-terminal-jackpot-flood-shadow),
-      0 0 26px var(--glitch-terminal-jackpot-flood-accent);
+      0 0 18px var(--inara-terminal-jackpot-flood-shadow),
+      0 0 26px var(--inara-terminal-jackpot-flood-accent);
   }
 }
 
@@ -976,20 +976,20 @@ button.terminalStatusPreview:focus-visible {
   0% {
     opacity: 0.76;
     text-shadow:
-      0 0 12px var(--glitch-terminal-debit-shadow),
-      0 0 18px color-mix(in srgb, var(--glitch-color-warning) 40%, transparent);
+      0 0 12px var(--inara-terminal-debit-shadow),
+      0 0 18px color-mix(in srgb, var(--inara-color-warning) 40%, transparent);
   }
   50% {
     opacity: 1;
     text-shadow:
-      0 0 22px var(--glitch-terminal-debit-shadow),
-      0 0 32px color-mix(in srgb, var(--glitch-color-warning) 60%, transparent);
+      0 0 22px var(--inara-terminal-debit-shadow),
+      0 0 32px color-mix(in srgb, var(--inara-color-warning) 60%, transparent);
   }
   100% {
     opacity: 0.76;
     text-shadow:
-      0 0 12px var(--glitch-terminal-debit-shadow),
-      0 0 18px color-mix(in srgb, var(--glitch-color-warning) 40%, transparent);
+      0 0 12px var(--inara-terminal-debit-shadow),
+      0 0 18px color-mix(in srgb, var(--inara-color-warning) 40%, transparent);
   }
 }
 
@@ -1010,22 +1010,22 @@ button.terminalStatusPreview:focus-visible {
 
 @keyframes terminalTokenFlashCredit {
   0% {
-    color: var(--glitch-color-success);
-    text-shadow: 0 0 18px color-mix(in srgb, var(--glitch-color-success) 60%, transparent);
+    color: var(--inara-color-success);
+    text-shadow: 0 0 18px color-mix(in srgb, var(--inara-color-success) 60%, transparent);
   }
   100% {
-    color: var(--glitch-color-text-strong);
+    color: var(--inara-color-text-strong);
     text-shadow: none;
   }
 }
 
 @keyframes terminalTokenFlashDebit {
   0% {
-    color: var(--glitch-color-warning);
-    text-shadow: 0 0 18px color-mix(in srgb, var(--glitch-color-warning) 58%, transparent);
+    color: var(--inara-color-warning);
+    text-shadow: 0 0 18px color-mix(in srgb, var(--inara-color-warning) 58%, transparent);
   }
   100% {
-    color: var(--glitch-color-text-strong);
+    color: var(--inara-color-text-strong);
     text-shadow: none;
   }
 }
@@ -1040,15 +1040,15 @@ button.terminalStatusPreview:focus-visible {
   }
 
   .terminalCollapsed {
-    transform: translateY(calc(var(--glitch-terminal-height) - 3rem));
+    transform: translateY(calc(var(--inara-terminal-height) - 3rem));
   }
 }
 
 .sectionFrame {
   border-radius: 0;
-  background: var(--glitch-panel);
-  border: 1px solid var(--glitch-panel-border);
-  box-shadow: 0 1.75rem 3.5rem var(--glitch-shadow);
+  background: var(--inara-panel);
+  border: 1px solid var(--inara-panel-border);
+  box-shadow: 0 1.75rem 3.5rem var(--inara-shadow);
   backdrop-filter: blur(12px);
 }
 
@@ -1066,9 +1066,9 @@ button.terminalStatusPreview:focus-visible {
 
 .tablePanel {
   border-radius: 1.25rem;
-  background: var(--glitch-panel);
-  border: 1px solid var(--glitch-panel-border);
-  box-shadow: 0 1.75rem 3.5rem var(--glitch-shadow);
+  background: var(--inara-panel);
+  border: 1px solid var(--inara-panel-border);
+  box-shadow: 0 1.75rem 3.5rem var(--inara-shadow);
   backdrop-filter: blur(12px);
   padding: clamp(1.75rem, 3vw, 2.25rem) clamp(1.75rem, 3vw, 2.5rem);
 }
@@ -1090,14 +1090,14 @@ button.terminalStatusPreview:focus-visible {
   margin: 0;
   font-size: clamp(1.6rem, 2.4vw, 2rem);
   font-weight: 700;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .sectionFrameElevated {
   border-radius: 0;
-  background: var(--glitch-panel);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 32%, transparent);
-  box-shadow: 0 1.75rem 4rem color-mix(in srgb, var(--glitch-color-background) 85%, transparent);
+  background: var(--inara-panel);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 32%, transparent);
+  box-shadow: 0 1.75rem 4rem color-mix(in srgb, var(--inara-color-background) 85%, transparent);
   backdrop-filter: blur(14px);
 }
 
@@ -1111,7 +1111,7 @@ button.terminalStatusPreview:focus-visible {
 
 .sectionHint {
   margin: 0;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   font-size: 0.95rem;
   line-height: 1.6;
 }
@@ -1128,7 +1128,7 @@ button.terminalStatusPreview:focus-visible {
   align-items: center;
   justify-content: space-between;
   font-size: 0.85rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   text-transform: uppercase;
   letter-spacing: 0.14em;
 }
@@ -1139,7 +1139,7 @@ button.terminalStatusPreview:focus-visible {
 
 .cargoProgressValue {
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   letter-spacing: 0.08em;
 }
 
@@ -1147,8 +1147,8 @@ button.terminalStatusPreview:focus-visible {
   position: relative;
   height: 0.65rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 38%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 38%, transparent);
   overflow: hidden;
 }
 
@@ -1159,8 +1159,8 @@ button.terminalStatusPreview:focus-visible {
   left: 0;
   width: 0;
   border-radius: inherit;
-  background: linear-gradient(90deg, var(--glitch-accent), color-mix(in srgb, var(--glitch-accent) 40%, var(--glitch-color-primary)));
-  box-shadow: 0 0 1rem color-mix(in srgb, var(--glitch-accent) 65%, transparent);
+  background: linear-gradient(90deg, var(--inara-accent), color-mix(in srgb, var(--inara-accent) 40%, var(--inara-color-primary)));
+  box-shadow: 0 0 1rem color-mix(in srgb, var(--inara-accent) 65%, transparent);
   transition: width 240ms ease;
 }
 
@@ -1173,19 +1173,19 @@ button.terminalStatusPreview:focus-visible {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 42%, transparent);
-  background: color-mix(in srgb, var(--glitch-color-primary) 12%, transparent);
-  color: var(--glitch-accent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 42%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 12%, transparent);
+  color: var(--inara-accent);
 }
 
-.glitchAlert {
-  color: var(--glitch-muted);
+.inaraAlert {
+  color: var(--inara-muted);
   font-size: 0.9rem;
   line-height: 1.5;
 }
 
-.glitchAlert strong {
-  color: var(--glitch-ink);
+.inaraAlert strong {
+  color: var(--inara-ink);
 }
 
 .dataTableContainer {
@@ -1228,8 +1228,8 @@ button.terminalStatusPreview:focus-visible {
   margin-top: 1.5rem;
   padding: 1.5rem 1.75rem;
   border-radius: 0;
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 35%, transparent);
-  background: linear-gradient(180deg, color-mix(in srgb, var(--glitch-color-background) 96%, transparent) 0%, color-mix(in srgb, var(--glitch-color-primary-dark) 16%, transparent) 100%);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 35%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--inara-color-background) 96%, transparent) 0%, color-mix(in srgb, var(--inara-color-primary-dark) 16%, transparent) 100%);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -1251,7 +1251,7 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.72rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 74%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 74%, transparent);
 }
 
 .tradeFiltersSystemControls {
@@ -1266,9 +1266,9 @@ button.terminalStatusPreview:focus-visible {
 .tradeFiltersNumberInput {
   appearance: none;
   border-radius: 0.85rem;
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 40%, transparent);
-  background: color-mix(in srgb, var(--glitch-color-background) 90%, transparent);
-  color: var(--glitch-ink);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 40%, transparent);
+  background: color-mix(in srgb, var(--inara-color-background) 90%, transparent);
+  color: var(--inara-ink);
   padding: 0.65rem 0.9rem;
   font-size: 0.95rem;
   min-width: 0;
@@ -1279,7 +1279,7 @@ button.terminalStatusPreview:focus-visible {
 .tradeFiltersSelect:focus,
 .tradeFiltersTextInput:focus,
 .tradeFiltersNumberInput:focus {
-  outline: 2px solid var(--glitch-color-success);
+  outline: 2px solid var(--inara-color-success);
   outline-offset: 2px;
 }
 
@@ -1291,9 +1291,9 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tradeFiltersToggle {
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 35%, transparent);
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
-  color: var(--glitch-accent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 35%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
+  color: var(--inara-accent);
   padding: 0.6rem 1.15rem;
   border-radius: 0;
   font-size: 0.85rem;
@@ -1303,13 +1303,13 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tradeFiltersToggle:hover {
-  background: color-mix(in srgb, var(--glitch-color-primary) 26%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 26%, transparent);
 }
 
 .tradeFiltersSubmit {
   border: none;
   border-radius: 0;
-  background: linear-gradient(90deg, var(--glitch-accent), color-mix(in srgb, var(--glitch-color-primary) 45%, transparent));
+  background: linear-gradient(90deg, var(--inara-accent), color-mix(in srgb, var(--inara-color-primary) 45%, transparent));
   color: #0c061f;
   padding: 0.6rem 1.4rem;
   font-weight: 600;
@@ -1334,14 +1334,14 @@ button.terminalStatusPreview:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .tradeFilterField label {
   font-size: 0.8rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 70%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 70%, transparent);
 }
 
 .tradeFiltersNumberInput::-webkit-outer-spin-button,
@@ -1351,7 +1351,7 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeFilterHint {
   font-size: 0.75rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .tradeFilterFieldToggle {
@@ -1362,13 +1362,13 @@ button.terminalStatusPreview:focus-visible {
   display: flex;
   align-items: center;
   gap: 0.55rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 78%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 78%, transparent);
 }
 
 .tradeFilterToggleRow input[type='checkbox'] {
   width: 1.05rem;
   height: 1.05rem;
-  accent-color: var(--glitch-accent);
+  accent-color: var(--inara-accent);
 }
 
 .dataTable {
@@ -1377,7 +1377,7 @@ button.terminalStatusPreview:focus-visible {
   border-collapse: collapse;
   border-spacing: 0;
   table-layout: auto;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   line-height: 1.45;
   background: transparent;
 }
@@ -1387,13 +1387,13 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .dataTable thead {
-  background: var(--glitch-table-header);
-  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--glitch-color-primary) 38%, transparent);
+  background: var(--inara-table-header);
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--inara-color-primary) 38%, transparent);
 }
 
 .dataTable thead tr {
-  border-bottom: 1px solid color-mix(in srgb, var(--glitch-color-primary) 45%, transparent);
-  background: var(--glitch-table-header);
+  border-bottom: 1px solid color-mix(in srgb, var(--inara-color-primary) 45%, transparent);
+  background: var(--inara-table-header);
 }
 
 .dataTable thead th {
@@ -1401,21 +1401,21 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.72rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 88%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 88%, transparent);
   font-weight: 600;
   text-align: left;
   white-space: nowrap;
 }
 
 .dataTable tbody tr {
-  background: color-mix(in srgb, var(--glitch-color-surface) 85%, var(--glitch-color-background) 15%);
-  border-bottom: 1px solid color-mix(in srgb, var(--glitch-color-primary) 25%, transparent);
+  background: color-mix(in srgb, var(--inara-color-surface) 85%, var(--inara-color-background) 15%);
+  border-bottom: 1px solid color-mix(in srgb, var(--inara-color-primary) 25%, transparent);
   transition: background 0.25s ease, transform 0.25s ease;
   font-size: 0.95rem;
 }
 
 .dataTable tbody tr:nth-child(even) {
-  background: color-mix(in srgb, var(--glitch-color-primary-dark) 22%, var(--glitch-color-background) 78%);
+  background: color-mix(in srgb, var(--inara-color-primary-dark) 22%, var(--inara-color-background) 78%);
 }
 
 .dataTable tbody tr:last-child {
@@ -1423,19 +1423,19 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .dataTable tbody tr:hover {
-  background: color-mix(in srgb, var(--glitch-color-primary) 24%, var(--glitch-color-surface) 76%);
+  background: color-mix(in srgb, var(--inara-color-primary) 24%, var(--inara-color-surface) 76%);
 }
 
 .dataTable td {
   padding: 0.75rem 1rem;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   text-transform: none !important;
   vertical-align: middle;
   white-space: nowrap;
 }
 
 .nonCommodityRow {
-  background: color-mix(in srgb, var(--glitch-color-primary-dark) 40%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary-dark) 40%, transparent);
   font-size: 0.85rem;
   line-height: 1.2;
 }
@@ -1453,31 +1453,31 @@ button.terminalStatusPreview:focus-visible {
 
 .nonCommodityLabel {
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .nonCommodityTag {
   font-size: 0.7rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 70%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 45%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 70%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 45%, transparent);
   border-radius: 999px;
   padding: 0.1rem 0.6rem;
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
 }
 
 .nonCommodityQuantity {
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
   margin-left: auto;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .dataTable :global([data-inara-table-row]) {
   opacity: 0;
   transform: translateY(14px);
   transition: opacity 0.35s ease, transform 0.35s ease;
-  transition-delay: var(--glitch-row-delay, 0s);
+  transition-delay: var(--inara-row-delay, 0s);
 }
 
 .dataTable :global([data-inara-table-row='visible']) {
@@ -1564,13 +1564,13 @@ button.terminalStatusPreview:focus-visible {
 .tradeRoutesTable thead th {
   position: sticky;
   top: 0;
-  background: color-mix(in srgb, var(--glitch-color-primary-dark) 24%, transparent);
-  border-bottom: 1px solid var(--glitch-border-regular);
+  background: color-mix(in srgb, var(--inara-color-primary-dark) 24%, transparent);
+  border-bottom: 1px solid var(--inara-border-regular);
   text-align: left;
   font-size: 0.92rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   z-index: 1;
 }
 
@@ -1586,9 +1586,9 @@ button.terminalStatusPreview:focus-visible {
   margin: 0;
   padding: 1.25rem clamp(1rem, 4vw, 1.5rem);
   border-radius: 0.75rem;
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 32%, transparent);
-  background: color-mix(in srgb, var(--glitch-color-primary-dark) 26%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--glitch-color-primary) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 32%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary-dark) 26%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--inara-color-primary) 14%, transparent);
 }
 
 .tradeRouteContextTitleRow {
@@ -1602,7 +1602,7 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.95rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .tradeRouteContextProfitRow {
@@ -1618,22 +1618,22 @@ button.terminalStatusPreview:focus-visible {
   gap: 0.35rem;
   padding: clamp(0.8rem, 3vw, 1.1rem);
   border-radius: 0.85rem;
-  background: color-mix(in srgb, var(--glitch-color-primary-dark) 48%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 30%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--glitch-color-primary) 16%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary-dark) 48%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 30%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--inara-color-primary) 16%, transparent);
 }
 
 .tradeRouteContextProfitLabel {
   font-size: 0.75rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
 }
 
 .tradeRouteContextProfitValue {
   font-size: clamp(1.35rem, 2.7vw, 1.85rem);
   font-weight: 700;
-  color: var(--glitch-color-success);
+  color: var(--inara-color-success);
   line-height: 1.1;
 }
 
@@ -1641,7 +1641,7 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.8rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
 }
 
 .tradeRouteContextStations {
@@ -1663,10 +1663,10 @@ button.terminalStatusPreview:focus-visible {
   padding: clamp(1.25rem, 3vw, 1.65rem);
   border-radius: 1rem;
   background: linear-gradient(135deg,
-      color-mix(in srgb, var(--glitch-color-primary) 24%, transparent) 0%,
-      color-mix(in srgb, var(--glitch-color-primary-dark) 62%, transparent) 100%);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 42%, transparent);
-  box-shadow: 0 1.5rem 2.75rem color-mix(in srgb, var(--glitch-color-primary) 22%, transparent);
+      color-mix(in srgb, var(--inara-color-primary) 24%, transparent) 0%,
+      color-mix(in srgb, var(--inara-color-primary-dark) 62%, transparent) 100%);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 42%, transparent);
+  box-shadow: 0 1.5rem 2.75rem color-mix(in srgb, var(--inara-color-primary) 22%, transparent);
   overflow: hidden;
   isolation: isolate;
   min-width: 0;
@@ -1677,7 +1677,7 @@ button.terminalStatusPreview:focus-visible {
   position: absolute;
   inset: 0;
   background: radial-gradient(ellipse at top right,
-      color-mix(in srgb, var(--glitch-color-success) 26%, transparent) 0%,
+      color-mix(in srgb, var(--inara-color-success) 26%, transparent) 0%,
       transparent 55%);
   opacity: 0.35;
   pointer-events: none;
@@ -1689,8 +1689,8 @@ button.terminalStatusPreview:focus-visible {
   inset: 0;
   background: repeating-linear-gradient(
       135deg,
-      color-mix(in srgb, var(--glitch-color-primary-light) 18%, transparent) 0px,
-      color-mix(in srgb, var(--glitch-color-primary-light) 18%, transparent) 2px,
+      color-mix(in srgb, var(--inara-color-primary-light) 18%, transparent) 0px,
+      color-mix(in srgb, var(--inara-color-primary-light) 18%, transparent) 2px,
       transparent 2px,
       transparent 12px);
   opacity: 0.12;
@@ -1699,13 +1699,13 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteContextStationCardOrigin::before {
   background: radial-gradient(circle at 15% 15%,
-      color-mix(in srgb, var(--glitch-color-success) 32%, transparent) 0%,
+      color-mix(in srgb, var(--inara-color-success) 32%, transparent) 0%,
       transparent 60%);
 }
 
 .tradeRouteContextStationCardDestination::before {
   background: radial-gradient(circle at 85% 15%,
-      color-mix(in srgb, var(--glitch-accent) 35%, transparent) 0%,
+      color-mix(in srgb, var(--inara-accent) 35%, transparent) 0%,
       transparent 60%);
 }
 
@@ -1725,15 +1725,15 @@ button.terminalStatusPreview:focus-visible {
   letter-spacing: 0.16em;
   text-transform: uppercase;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--glitch-color-primary) 30%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary-light) 45%, transparent);
-  color: var(--glitch-ink);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--glitch-color-primary-light) 35%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 30%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary-light) 45%, transparent);
+  color: var(--inara-ink);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--inara-color-primary-light) 35%, transparent);
 }
 
 .tradeRouteContextBadgeDetail {
   font-size: 0.8rem;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
   white-space: nowrap;
 }
 
@@ -1767,7 +1767,7 @@ button.terminalStatusPreview:focus-visible {
 .tradeRouteContextStationName {
   font-size: clamp(1.35rem, 4vw, 1.75rem);
   font-weight: 700;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   line-height: 1.15;
   white-space: normal;
   word-break: break-word;
@@ -1775,7 +1775,7 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteContextStationSystem {
   font-size: 1rem;
-  color: color-mix(in srgb, var(--glitch-ink) 88%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 88%, transparent);
   white-space: normal;
   word-break: break-word;
 }
@@ -1784,12 +1784,12 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.85rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-accent) 78%, transparent);
+  color: color-mix(in srgb, var(--inara-accent) 78%, transparent);
 }
 
 .tradeRouteContextStationEconomy {
   font-size: 0.85rem;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
 }
 
 .tradeRouteContextMetrics {
@@ -1809,7 +1809,7 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.7rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
 }
 
 .metricChipContext {
@@ -1839,8 +1839,8 @@ button.terminalStatusPreview:focus-visible {
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 50%;
-  background: color-mix(in srgb, var(--glitch-color-success) 65%, transparent);
-  box-shadow: 0 0 0.95rem color-mix(in srgb, var(--glitch-color-success) 35%, transparent);
+  background: color-mix(in srgb, var(--inara-color-success) 65%, transparent);
+  box-shadow: 0 0 0.95rem color-mix(in srgb, var(--inara-color-success) 35%, transparent);
 }
 
 .tradeRouteContextConnectorLine {
@@ -1849,9 +1849,9 @@ button.terminalStatusPreview:focus-visible {
   min-height: clamp(2.5rem, 5vw, 3.2rem);
   border-radius: 999px;
   background: linear-gradient(90deg,
-      color-mix(in srgb, var(--glitch-color-primary-light) 65%, transparent) 0%,
-      color-mix(in srgb, var(--glitch-color-primary-dark) 55%, transparent) 100%);
-  box-shadow: 0 0 1.6rem color-mix(in srgb, var(--glitch-color-primary) 24%, transparent);
+      color-mix(in srgb, var(--inara-color-primary-light) 65%, transparent) 0%,
+      color-mix(in srgb, var(--inara-color-primary-dark) 55%, transparent) 100%);
+  box-shadow: 0 0 1.6rem color-mix(in srgb, var(--inara-color-primary) 24%, transparent);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1865,7 +1865,7 @@ button.terminalStatusPreview:focus-visible {
   border-radius: inherit;
   background: linear-gradient(90deg,
       transparent 0%,
-      color-mix(in srgb, var(--glitch-color-success) 55%, transparent) 50%,
+      color-mix(in srgb, var(--inara-color-success) 55%, transparent) 50%,
       transparent 100%);
   opacity: 0.7;
   animation: tradeRoutePulse 5s ease-in-out infinite;
@@ -1878,12 +1878,12 @@ button.terminalStatusPreview:focus-visible {
   font-weight: 600;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   padding: 0.25rem 0.85rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--glitch-color-primary-dark) 45%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary-light) 35%, transparent);
-  box-shadow: 0 0 1.1rem color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary-dark) 45%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary-light) 35%, transparent);
+  box-shadow: 0 0 1.1rem color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
 }
 
 .tradeRouteContextConnectorMeta {
@@ -1893,7 +1893,7 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteContextConnectorMetaText {
   font-size: 0.78rem;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -1979,9 +1979,9 @@ button.terminalStatusPreview:focus-visible {
   gap: 0.85rem;
   padding: clamp(1rem, 3vw, 1.35rem);
   border-radius: 0.9rem;
-  background: color-mix(in srgb, var(--glitch-color-primary-dark) 55%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 35%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary-dark) 55%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 35%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
   overflow: hidden;
 }
 
@@ -1991,7 +1991,7 @@ button.terminalStatusPreview:focus-visible {
   inset: 0;
   background: linear-gradient(120deg,
       transparent 0%,
-      color-mix(in srgb, var(--glitch-color-primary-light) 24%, transparent) 55%,
+      color-mix(in srgb, var(--inara-color-primary-light) 24%, transparent) 55%,
       transparent 100%);
   opacity: 0.16;
   pointer-events: none;
@@ -2000,14 +2000,14 @@ button.terminalStatusPreview:focus-visible {
 .tradeRouteContextCommodityOutbound::after {
   background: linear-gradient(120deg,
       transparent 0%,
-      color-mix(in srgb, var(--glitch-color-success) 32%, transparent) 55%,
+      color-mix(in srgb, var(--inara-color-success) 32%, transparent) 55%,
       transparent 100%);
 }
 
 .tradeRouteContextCommodityReturn::after {
   background: linear-gradient(120deg,
       transparent 0%,
-      color-mix(in srgb, var(--glitch-accent) 38%, transparent) 55%,
+      color-mix(in srgb, var(--inara-accent) 38%, transparent) 55%,
       transparent 100%);
 }
 
@@ -2020,7 +2020,7 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteContextCommodityPrice {
   font-size: 0.85rem;
-  color: color-mix(in srgb, var(--glitch-ink) 82%, transparent);
+  color: color-mix(in srgb, var(--inara-ink) 82%, transparent);
   white-space: nowrap;
 }
 
@@ -2037,8 +2037,8 @@ button.terminalStatusPreview:focus-visible {
   width: 2.75rem;
   height: 2.75rem;
   border-radius: 0.8rem;
-  background: color-mix(in srgb, var(--glitch-color-primary) 22%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--glitch-color-primary-light) 45%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 22%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--inara-color-primary-light) 45%, transparent);
   flex-shrink: 0;
 }
 
@@ -2052,7 +2052,7 @@ button.terminalStatusPreview:focus-visible {
 .tradeRouteContextCommodityName {
   font-size: 1.05rem;
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2060,12 +2060,12 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteContextCommodityMeta {
   font-size: 0.85rem;
-  color: color-mix(in srgb, var(--glitch-color-success) 70%, transparent);
+  color: color-mix(in srgb, var(--inara-color-success) 70%, transparent);
 }
 
 .tradeRouteContextCommodityFootnote {
   font-size: 0.75rem;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
 }
 
 @keyframes tradeRoutePulse {
@@ -2090,14 +2090,14 @@ button.terminalStatusPreview:focus-visible {
 .tradeRouteContextEmpty {
   margin-top: 1rem;
   padding: 0.75rem 0;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
   font-style: italic;
 }
 
 .tradeRouteContextRoute {
   margin-top: 1.5rem;
   padding-top: 1rem;
-  border-top: 1px solid color-mix(in srgb, var(--glitch-color-primary) 25%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--inara-color-primary) 25%, transparent);
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
@@ -2116,20 +2116,20 @@ button.terminalStatusPreview:focus-visible {
   justify-content: center;
   padding: 0.4rem 0.75rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--glitch-color-primary) 22%, transparent);
-  color: var(--glitch-ink);
+  background: color-mix(in srgb, var(--inara-color-primary) 22%, transparent);
+  color: var(--inara-ink);
   font-size: 0.85rem;
   font-weight: 600;
   white-space: nowrap;
 }
 
 .tradeRoutePathNodeCurrent {
-  background: color-mix(in srgb, var(--glitch-color-success) 42%, transparent);
-  color: var(--glitch-color-background);
+  background: color-mix(in srgb, var(--inara-color-success) 42%, transparent);
+  color: var(--inara-color-background);
 }
 
 .tradeRoutePathSeparator {
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
   font-size: 0.9rem;
 }
 
@@ -2164,7 +2164,7 @@ button.terminalStatusPreview:focus-visible {
   max-width: 3.2rem;
   height: 100%;
   max-height: 100%;
-  color: var(--glitch-accent);
+  color: var(--inara-accent);
 }
 
 .tradeRouteStationIcon :global(svg) {
@@ -2186,7 +2186,7 @@ button.terminalStatusPreview:focus-visible {
 .tradeRouteStationName {
   font-size: 1.02rem;
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2194,7 +2194,7 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteStationSystem {
   font-size: 0.92rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2283,7 +2283,7 @@ button.terminalStatusPreview:focus-visible {
   grid-column: 1;
   font-size: 1rem;
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   text-align: center;
   white-space: nowrap;
   overflow: hidden;
@@ -2294,14 +2294,14 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteCommodityPrice {
   grid-column: 2;
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
   font-size: 0.9rem;
   white-space: nowrap;
   justify-self: end;
 }
 
 .tradeRoutePlaceholder {
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
   opacity: 0.65;
 }
 
@@ -2335,14 +2335,14 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.64rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
   text-align: right;
 }
 
 .tradeRouteProfitValue {
   font-size: 1.02rem;
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   white-space: nowrap;
   text-align: right;
 }
@@ -2394,19 +2394,19 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.75rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--glitch-accent);
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
-  box-shadow: 0 0 0.75rem color-mix(in srgb, var(--glitch-color-primary) 22%, transparent);
+  color: var(--inara-accent);
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
+  box-shadow: 0 0 0.75rem color-mix(in srgb, var(--inara-color-primary) 22%, transparent);
 }
 
 .tradeRoutesQuantitySupply {
   color: #29f3c3;
-  background: color-mix(in srgb, var(--glitch-color-success) 15%, transparent);
+  background: color-mix(in srgb, var(--inara-color-success) 15%, transparent);
 }
 
 .tradeRoutesQuantityDemand {
   color: #ff5fc1;
-  background: color-mix(in srgb, var(--glitch-color-warning) 15%, transparent);
+  background: color-mix(in srgb, var(--inara-color-warning) 15%, transparent);
 }
 
 .tradeRoutesQuantityBadge span:last-child {
@@ -2415,13 +2415,13 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tradeRoutesQuantityPlaceholder {
-  color: var(--glitch-text-soft);
-  background: color-mix(in srgb, var(--glitch-color-primary) 10%, transparent);
+  color: var(--inara-text-soft);
+  background: color-mix(in srgb, var(--inara-color-primary) 10%, transparent);
   box-shadow: none;
 }
 
 .metricChip {
-  --chip-color: var(--glitch-accent);
+  --chip-color: var(--inara-accent);
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
@@ -2438,26 +2438,26 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .metricChipPlaceholder {
-  color: var(--glitch-text-soft);
-  background: color-mix(in srgb, var(--glitch-color-primary) 10%, transparent);
-  border: 1px dashed color-mix(in srgb, var(--glitch-color-primary) 28%, transparent);
+  color: var(--inara-text-soft);
+  background: color-mix(in srgb, var(--inara-color-primary) 10%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--inara-color-primary) 28%, transparent);
   box-shadow: none;
 }
 
 .metricChipNeutral {
-  --chip-color: var(--glitch-accent);
+  --chip-color: var(--inara-accent);
 }
 
 .metricChipSuccess {
-  --chip-color: var(--glitch-color-success);
+  --chip-color: var(--inara-color-success);
 }
 
 .metricChipCaution {
-  --chip-color: color-mix(in srgb, var(--glitch-color-warning) 55%, var(--glitch-color-primary-light) 45%);
+  --chip-color: color-mix(in srgb, var(--inara-color-warning) 55%, var(--inara-color-primary-light) 45%);
 }
 
 .metricChipWarning {
-  --chip-color: var(--glitch-color-warning);
+  --chip-color: var(--inara-color-warning);
 }
 
 .tableCellTop {
@@ -2476,7 +2476,7 @@ button.terminalStatusPreview:focus-visible {
   padding: 0.6rem 0.35rem;
   text-align: center;
   vertical-align: top;
-  color: var(--glitch-accent);
+  color: var(--inara-accent);
   font-size: 1.1rem;
   line-height: 1;
 }
@@ -2505,17 +2505,17 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tableHeaderButton:focus-visible {
-  outline: 2px solid var(--glitch-color-success);
+  outline: 2px solid var(--inara-color-success);
   outline-offset: 2px;
 }
 
 .tableHeaderButtonActive {
-  color: var(--glitch-accent);
+  color: var(--inara-accent);
 }
 
 .tableSortIndicator {
   font-size: 0.75rem;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
 }
 
 .tableRowInteractive {
@@ -2523,25 +2523,25 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tableRowInteractive:hover {
-  background: color-mix(in srgb, var(--glitch-color-primary) 20%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 20%, transparent);
 }
 
 .tableRowSelected {
-  outline: 2px solid color-mix(in srgb, var(--glitch-color-primary) 55%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--inara-color-primary) 55%, transparent);
   outline-offset: -2px;
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent) !important;
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent) !important;
 }
 
 .tableRowSelected:hover {
-  background: color-mix(in srgb, var(--glitch-color-primary) 24%, transparent) !important;
+  background: color-mix(in srgb, var(--inara-color-primary) 24%, transparent) !important;
 }
 
 .tableRowExpanded {
-  background: color-mix(in srgb, var(--glitch-color-primary) 16%, transparent) !important;
+  background: color-mix(in srgb, var(--inara-color-primary) 16%, transparent) !important;
 }
 
 .tableRowExpanded:hover {
-  background: color-mix(in srgb, var(--glitch-color-primary) 22%, transparent) !important;
+  background: color-mix(in srgb, var(--inara-color-primary) 22%, transparent) !important;
 }
 
 .tableDetailRow {
@@ -2549,8 +2549,8 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tableDetailRow td {
-  background: color-mix(in srgb, var(--glitch-color-background) 88%, transparent);
-  border-top: 1px solid color-mix(in srgb, var(--glitch-color-primary) 25%, transparent);
+  background: color-mix(in srgb, var(--inara-color-background) 88%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--inara-color-primary) 25%, transparent);
   padding: 0 1.5rem 1.5rem;
 }
 
@@ -2559,7 +2559,7 @@ button.terminalStatusPreview:focus-visible {
   flex-direction: column;
   gap: 0.3rem;
   font-size: 0.82rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
 }
 
 .tableDetailSection span {
@@ -2567,64 +2567,64 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tableTextNeutral {
-  color: var(--glitch-accent);
+  color: var(--inara-accent);
 }
 
 .tableTextSuccess {
-  color: var(--glitch-color-success);
+  color: var(--inara-color-success);
 }
 
 .tableTextDanger {
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
 }
 
 .tableMessage {
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   padding: 1.25rem 2rem;
 }
 
 .tableMessageBorder {
-  border-bottom: 1px solid color-mix(in srgb, var(--glitch-color-primary) 25%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--inara-color-primary) 25%, transparent);
 }
 
 .tableIdleState {
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   padding: 2rem;
 }
 
 .tableErrorState {
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
   padding: 2rem;
 }
 
 .tableEmptyState {
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   padding: 2rem;
 }
 
 .tableSubtext {
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   font-size: 0.82rem;
   margin-top: 0.35rem;
   white-space: normal;
 }
 
 .tableMetaMuted {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
   font-size: 0.75rem;
   margin-top: 0.25rem;
   white-space: normal;
 }
 
 .tableWarning {
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
   font-size: 0.78rem;
   margin-top: 0.35rem;
   white-space: normal;
 }
 
 .tableMutedNote {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
   font-size: 0.75rem;
   margin-top: 0.45rem;
   white-space: normal;
@@ -2634,7 +2634,7 @@ button.terminalStatusPreview:focus-visible {
   text-transform: uppercase;
   letter-spacing: 0.32em;
   font-size: 0.68rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 70%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 70%, transparent);
 }
 
 .routeDetailTitle {
@@ -2643,13 +2643,13 @@ button.terminalStatusPreview:focus-visible {
   justify-content: center;
   gap: 0.85rem;
   font-size: 1.65rem;
-  color: var(--glitch-color-text-strong);
-  text-shadow: 0 0 14px color-mix(in srgb, var(--glitch-color-primary) 45%, transparent);
+  color: var(--inara-color-text-strong);
+  text-shadow: 0 0 14px color-mix(in srgb, var(--inara-color-primary) 45%, transparent);
   margin: 0;
 }
 
 .routeDetailDivider {
-  color: var(--glitch-color-success);
+  color: var(--inara-color-success);
   font-size: 1.75rem;
   line-height: 1;
 }
@@ -2660,11 +2660,11 @@ button.terminalStatusPreview:focus-visible {
   gap: 0.65rem;
   margin: 0;
   font-size: 0.92rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 74%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 74%, transparent);
 }
 
 .routeDetailArrow {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
   font-size: 1.1rem;
 }
 
@@ -2675,16 +2675,16 @@ button.terminalStatusPreview:focus-visible {
   min-width: 160px;
   padding: 0.9rem 1.25rem;
   border-radius: 0;
-  background: color-mix(in srgb, var(--glitch-color-primary-dark) 60%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 35%, transparent);
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 78%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary-dark) 60%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 35%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 78%, transparent);
 }
 
 .routeDetailMetaLabel {
   text-transform: uppercase;
   letter-spacing: 0.22em;
   font-size: 0.65rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
 }
 
 .routeDetailSummaryBar {
@@ -2703,21 +2703,21 @@ button.terminalStatusPreview:focus-visible {
   gap: 0.4rem;
   padding: 1.15rem 1.35rem;
   border-radius: 0;
-  background: color-mix(in srgb, var(--glitch-color-background) 92%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 32%, transparent);
-  box-shadow: 0 1.2rem 2.4rem color-mix(in srgb, var(--glitch-color-background) 55%, transparent);
+  background: color-mix(in srgb, var(--inara-color-background) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 32%, transparent);
+  box-shadow: 0 1.2rem 2.4rem color-mix(in srgb, var(--inara-color-background) 55%, transparent);
 }
 
 .routeDetailMetricLabel {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.68rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 62%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 62%, transparent);
 }
 
 .routeDetailMetricValue {
   font-size: 1.05rem;
-  color: var(--glitch-color-text-strong);
+  color: var(--inara-color-text-strong);
   font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
 }
 
@@ -2732,10 +2732,10 @@ button.terminalStatusPreview:focus-visible {
   flex-direction: column;
   gap: 1rem;
   padding: 1.75rem 1.9rem;
-  background: color-mix(in srgb, var(--glitch-color-background) 92%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 32%, transparent);
+  background: color-mix(in srgb, var(--inara-color-background) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 32%, transparent);
   border-radius: 0;
-  box-shadow: 0 1.45rem 2.8rem color-mix(in srgb, var(--glitch-color-background) 55%, transparent);
+  box-shadow: 0 1.45rem 2.8rem color-mix(in srgb, var(--inara-color-background) 55%, transparent);
 }
 
 .routeDetailPanelHeader {
@@ -2749,7 +2749,7 @@ button.terminalStatusPreview:focus-visible {
   text-transform: uppercase;
   letter-spacing: 0.28em;
   font-size: 0.68rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 62%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 62%, transparent);
 }
 
 .routeDetailStation {
@@ -2771,13 +2771,13 @@ button.terminalStatusPreview:focus-visible {
 
 .routeDetailStationName {
   font-size: 1.05rem;
-  color: var(--glitch-color-text-strong);
+  color: var(--inara-color-text-strong);
   font-weight: 600;
 }
 
 .routeDetailSystem {
   font-size: 0.85rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 62%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 62%, transparent);
 }
 
 .routeDetailInfoRow {
@@ -2785,7 +2785,7 @@ button.terminalStatusPreview:focus-visible {
   justify-content: space-between;
   align-items: baseline;
   gap: 1rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 78%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 78%, transparent);
   font-size: 0.92rem;
 }
 
@@ -2793,7 +2793,7 @@ button.terminalStatusPreview:focus-visible {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.7rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 58%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 58%, transparent);
 }
 
 .routeDetailInfoValue {
@@ -2806,7 +2806,7 @@ button.terminalStatusPreview:focus-visible {
 .routeDetailDividerLine {
   height: 1px;
   width: 100%;
-  background: color-mix(in srgb, var(--glitch-color-primary) 25%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 25%, transparent);
   margin: 0.5rem 0 0.75rem;
 }
 
@@ -2814,20 +2814,20 @@ button.terminalStatusPreview:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 84%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 84%, transparent);
 }
 
 .routeDetailCommodityLabel {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.68rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
 }
 
 .routeDetailCommodityValue {
   font-size: 1.05rem;
   font-weight: 600;
-  color: var(--glitch-color-text-strong);
+  color: var(--inara-color-text-strong);
 }
 
 .routeDetailPriceRow {
@@ -2835,7 +2835,7 @@ button.terminalStatusPreview:focus-visible {
   flex-wrap: wrap;
   gap: 0.85rem;
   font-size: 0.88rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 74%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 74%, transparent);
 }
 
 @media (max-width: 1100px) {
@@ -2890,11 +2890,11 @@ button.terminalStatusPreview:focus-visible {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.78rem;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
 }
 
 .tableEntryHighlight {
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   font-weight: 600;
 }
 
@@ -2903,22 +2903,22 @@ button.terminalStatusPreview:focus-visible {
   align-items: baseline;
   gap: 0.4rem;
   font-size: 0.95rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 84%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 84%, transparent);
 }
 
 .tableEntryValueHighlight {
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .tableEntrySource {
   font-size: 0.72rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--glitch-color-success);
+  color: var(--inara-color-success);
 }
 
 .tableEntryLabel {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -2926,13 +2926,13 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tableEntryMeta {
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   font-size: 0.8rem;
   margin-top: 0.25rem;
 }
 
 .tableEntryFootnote {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
   font-size: 0.75rem;
   margin-top: 0.2rem;
 }
@@ -2945,35 +2945,35 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tableBadgeWarning {
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
 }
 
 .tableBadgeSuccess {
-  color: var(--glitch-color-success);
+  color: var(--inara-color-success);
 }
 
 .tableFootnote {
   margin-top: 1.5rem;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
   font-size: 0.85rem;
   line-height: 1.6;
 }
 
 .tableRowContext {
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
 }
 
 .tableRowContext:hover {
-  background: color-mix(in srgb, var(--glitch-color-primary) 26%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 26%, transparent);
 }
 
 .tableContextIndicator {
   margin-top: 0.6rem;
   padding: 0.6rem 0.85rem;
   border-radius: 0.9rem;
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 38%, transparent);
-  box-shadow: 0 0.9rem 1.8rem color-mix(in srgb, var(--glitch-color-background) 76%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 38%, transparent);
+  box-shadow: 0 0.9rem 1.8rem color-mix(in srgb, var(--inara-color-background) 76%, transparent);
   display: inline-flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -2984,18 +2984,18 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.68rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 62%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 62%, transparent);
 }
 
 .tableContextValue {
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
   white-space: normal;
 }
 
 .tableContextFootnote {
   font-size: 0.72rem;
-  color: var(--glitch-muted);
+  color: var(--inara-muted);
   white-space: normal;
 }
 
@@ -3038,21 +3038,21 @@ button.terminalStatusPreview:focus-visible {
 .detailEmptyState {
   padding: 2rem;
   text-align: center;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
   font-size: 0.95rem;
 }
 
 
 .stationRowSelected {
-  background: color-mix(in srgb, var(--glitch-color-primary) 20%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 20%, transparent);
 }
 
 .stationRowSelected:hover {
-  background: color-mix(in srgb, var(--glitch-color-primary) 26%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 26%, transparent);
 }
 
 .stationDemandLow {
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
 }
 
 .commodityCell {
@@ -3068,8 +3068,8 @@ button.terminalStatusPreview:focus-visible {
   width: 2.35rem;
   height: 2.35rem;
   border-radius: 0.85rem;
-  background: color-mix(in srgb, var(--glitch-color-primary) 16%, transparent);
-  box-shadow: 0 1rem 1.8rem color-mix(in srgb, var(--glitch-color-background) 82%, transparent);
+  background: color-mix(in srgb, var(--inara-color-primary) 16%, transparent);
+  box-shadow: 0 1rem 1.8rem color-mix(in srgb, var(--inara-color-background) 82%, transparent);
 }
 
 .commodityCellIcon svg {
@@ -3086,7 +3086,7 @@ button.terminalStatusPreview:focus-visible {
 
 .commodityCellTitle {
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .metricGrid {
@@ -3107,41 +3107,41 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.78rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--glitch-subdued);
+  color: var(--inara-subdued);
 }
 
 .metricValue {
   font-size: 1.1rem;
   font-weight: 600;
-  color: var(--glitch-ink);
+  color: var(--inara-ink);
 }
 
 .metricValueWarning {
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
 }
 
 .metricValueSuccess {
-  color: var(--glitch-color-success);
+  color: var(--inara-color-success);
 }
 
 .notice {
   margin-bottom: 0.75rem;
   font-size: 0.9rem;
-  color: var(--glitch-accent);
+  color: var(--inara-accent);
 }
 
 .noticeMuted {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 50%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 50%, transparent);
 }
 
 .inlineNotice {
   padding: 1rem 0;
-  color: var(--glitch-color-warning);
+  color: var(--inara-color-warning);
 }
 
 .inlineNoticeMuted {
   padding: 1rem 0;
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 50%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 50%, transparent);
 }
 
 .placeholder {
@@ -3149,32 +3149,32 @@ button.terminalStatusPreview:focus-visible {
   max-width: 40rem;
   padding: 2.75rem 3rem;
   text-align: center;
-  color: var(--glitch-text-soft);
+  color: var(--inara-text-soft);
   font-size: 1.1rem;
   line-height: 1.65;
   border-radius: 1rem;
-  border: 1px solid var(--glitch-border-regular);
-  background: color-mix(in srgb, var(--glitch-color-background) 88%, transparent);
-  box-shadow: 0 1.35rem 3.2rem color-mix(in srgb, var(--glitch-shadow) 58%, transparent);
+  border: 1px solid var(--inara-border-regular);
+  background: color-mix(in srgb, var(--inara-color-background) 88%, transparent);
+  box-shadow: 0 1.35rem 3.2rem color-mix(in srgb, var(--inara-shadow) 58%, transparent);
 }
 
-.glitch :global(.glitch-surface) {
+.inara :global(.inara-surface) {
   background: transparent;
 }
 
-.glitch :global(.glitch-panel) {
+.inara :global(.inara-panel) {
   background: transparent;
 }
 
-.glitch :global(.glitch-prompt) {
-  color: var(--glitch-muted);
+.inara :global(.inara-prompt) {
+  color: var(--inara-muted);
 }
 
-.glitch :global(.glitch-highlight) {
-  color: var(--glitch-accent);
+.inara :global(.inara-highlight) {
+  color: var(--inara-accent);
 }
 
-.glitch :global(.glitch-panel-table) {
+.inara :global(.inara-panel-table) {
   width: 100%;
   background: transparent;
   border: 0;
@@ -3182,17 +3182,17 @@ button.terminalStatusPreview:focus-visible {
   box-shadow: none;
 }
 
-.glitch :global(.glitch-panel-table > .scrollable) {
+.inara :global(.inara-panel-table > .scrollable) {
   background: transparent;
   overflow-x: auto;
   overflow-y: hidden;
 }
 
-.glitch :global(.glitch-panel-table > .scrollable::-webkit-scrollbar) {
+.inara :global(.inara-panel-table > .scrollable::-webkit-scrollbar) {
   height: 16px;
 }
 
-.glitch :global(.glitch-panel-table > .scrollable::-webkit-scrollbar-track) {
+.inara :global(.inara-panel-table > .scrollable::-webkit-scrollbar-track) {
   background-image: linear-gradient(
     90deg,
     transparent 41.67%,
@@ -3207,117 +3207,117 @@ button.terminalStatusPreview:focus-visible {
   background-position-x: 10px;
 }
 
-.glitch :global(.glitch-panel-table > .scrollable::-webkit-scrollbar-thumb) {
+.inara :global(.inara-panel-table > .scrollable::-webkit-scrollbar-thumb) {
   background: var(--color-primary);
   min-height: 4rem;
   box-shadow: 0 0 10px var(--color-primary-dark);
 }
 
-.glitch :global(.glitch-panel-table table thead) {
-  background: var(--glitch-table-header);
-  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--glitch-color-primary) 38%, transparent);
+.inara :global(.inara-panel-table table thead) {
+  background: var(--inara-table-header);
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--inara-color-primary) 38%, transparent);
 }
 
-.glitch :global(.glitch-panel-table table thead tr) {
-  background: var(--glitch-table-header) !important;
+.inara :global(.inara-panel-table table thead tr) {
+  background: var(--inara-table-header) !important;
 }
 
-.glitch :global(.glitch-panel-table table thead tr th) {
-  border-bottom: 1px solid color-mix(in srgb, var(--glitch-color-primary) 45%, transparent);
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 88%, transparent);
+.inara :global(.inara-panel-table table thead tr th) {
+  border-bottom: 1px solid color-mix(in srgb, var(--inara-color-primary) 45%, transparent);
+  color: color-mix(in srgb, var(--inara-color-text-strong) 88%, transparent);
 }
 
-.glitch :global(.glitch-panel-table table thead tr th::after) {
-  border-bottom: 0.2rem solid var(--glitch-color-primary);
-  box-shadow: 0 0.03rem 0.5rem color-mix(in srgb, var(--glitch-color-primary) 60%, transparent);
+.inara :global(.inara-panel-table table thead tr th::after) {
+  border-bottom: 0.2rem solid var(--inara-color-primary);
+  box-shadow: 0 0.03rem 0.5rem color-mix(in srgb, var(--inara-color-primary) 60%, transparent);
 }
 
-.glitch :global(.glitch-panel-table tbody tr) {
-  border-bottom: 1px solid color-mix(in srgb, var(--glitch-color-primary) 25%, transparent);
+.inara :global(.inara-panel-table tbody tr) {
+  border-bottom: 1px solid color-mix(in srgb, var(--inara-color-primary) 25%, transparent);
 }
 
-.glitch :global(.glitch-panel-table tbody tr:nth-child(even):not(.glitch-table-detail-row)) {
-  background: color-mix(in srgb, var(--glitch-color-primary-dark) 22%, transparent);
+.inara :global(.inara-panel-table tbody tr:nth-child(even):not(.inara-table-detail-row)) {
+  background: color-mix(in srgb, var(--inara-color-primary-dark) 22%, transparent);
 }
 
-.glitch :global(.glitch-panel-table tbody tr:hover) {
-  background: color-mix(in srgb, var(--glitch-color-primary) 24%, var(--glitch-color-surface) 76%) !important;
+.inara :global(.inara-panel-table tbody tr:hover) {
+  background: color-mix(in srgb, var(--inara-color-primary) 24%, var(--inara-color-surface) 76%) !important;
 }
 
-.glitch :global(.glitch-panel-table .pristine-mining__detail) {
-  background: color-mix(in srgb, var(--glitch-color-background) 85%, transparent);
-  border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 22%, transparent);
+.inara :global(.inara-panel-table .pristine-mining__detail) {
+  background: color-mix(in srgb, var(--inara-color-background) 85%, transparent);
+  border: 1px solid color-mix(in srgb, var(--inara-color-primary) 22%, transparent);
 }
 
-.glitch :global(.glitch-panel-table .pristine-mining__detail-status) {
-  color: var(--glitch-muted);
+.inara :global(.inara-panel-table .pristine-mining__detail-status) {
+  color: var(--inara-muted);
 }
 
-.glitch :global(.glitch-panel-table .pristine-mining__detail-links span) {
-  color: var(--glitch-accent);
+.inara :global(.inara-panel-table .pristine-mining__detail-links span) {
+  color: var(--inara-accent);
 }
 
-.glitch :global(.glitch-panel-table .pristine-mining__detail-status--error) {
-  color: var(--glitch-color-warning);
+.inara :global(.inara-panel-table .pristine-mining__detail-status--error) {
+  color: var(--inara-color-warning);
 }
 
-.glitch :global(.glitch-panel-table .text-primary) {
-  color: var(--glitch-accent);
+.inara :global(.inara-panel-table .text-primary) {
+  color: var(--inara-accent);
 }
 
-.glitch :global(.glitch-panel-table .text-secondary) {
-  color: color-mix(in srgb, var(--glitch-color-text-strong) 85%, transparent);
+.inara :global(.inara-panel-table .text-secondary) {
+  color: color-mix(in srgb, var(--inara-color-text-strong) 85%, transparent);
 }
 
-.glitch :global(.glitch-panel-table .text-muted) {
-  color: var(--glitch-muted);
+.inara :global(.inara-panel-table .text-muted) {
+  color: var(--inara-muted);
 }
 
-.glitch :global(.glitch-panel-table .glitch-spinner__label) {
-  color: var(--glitch-muted);
+.inara :global(.inara-panel-table .inara-spinner__label) {
+  color: var(--inara-muted);
 }
 
-.glitch :global(.glitch-panel-table .glitch-spinner__icon) {
-  border-color: var(--glitch-accent);
+.inara :global(.inara-panel-table .inara-spinner__icon) {
+  border-color: var(--inara-accent);
   border-right-color: transparent;
 }
 
-.glitch :global(.glitch-panel-table .button--active) {
-  background: color-mix(in srgb, var(--glitch-color-primary) 18%, transparent);
-  border-color: color-mix(in srgb, var(--glitch-color-primary) 45%, transparent);
+.inara :global(.inara-panel-table .button--active) {
+  background: color-mix(in srgb, var(--inara-color-primary) 18%, transparent);
+  border-color: color-mix(in srgb, var(--inara-color-primary) 45%, transparent);
 }
 
-.glitch :global(.glitch-panel-table .button--active:hover) {
-  background: color-mix(in srgb, var(--glitch-color-primary) 24%, transparent);
+.inara :global(.inara-panel-table .button--active:hover) {
+  background: color-mix(in srgb, var(--inara-color-primary) 24%, transparent);
 }
 
-.glitch :global(.glitch-panel-table .button--icon) {
-  color: var(--glitch-ink);
+.inara :global(.inara-panel-table .button--icon) {
+  color: var(--inara-ink);
 }
 
-.glitch :global(.glitch-panel-table .button--icon:hover) {
-  background: color-mix(in srgb, var(--glitch-color-primary) 16%, transparent);
+.inara :global(.inara-panel-table .button--icon:hover) {
+  background: color-mix(in srgb, var(--inara-color-primary) 16%, transparent);
 }
 
-.glitch :global(.glitch-panel-table .button--secondary) {
-  color: var(--glitch-accent);
+.inara :global(.inara-panel-table .button--secondary) {
+  color: var(--inara-accent);
 }
 
-.glitch :global(.glitch-panel-table .button--secondary:hover) {
-  background: color-mix(in srgb, var(--glitch-color-primary) 16%, transparent);
+.inara :global(.inara-panel-table .button--secondary:hover) {
+  background: color-mix(in srgb, var(--inara-color-primary) 16%, transparent);
 }
 
-.glitch :global(button),
-.glitch :global(.button) {
+.inara :global(button),
+.inara :global(.button) {
   border-radius: 0;
 }
 
-.glitch :global(.glitch-panel-table .pristine-mining__inspector) {
-  border-left: 1px solid color-mix(in srgb, var(--glitch-color-primary) 22%, transparent);
+.inara :global(.inara-panel-table .pristine-mining__inspector) {
+  border-left: 1px solid color-mix(in srgb, var(--inara-color-primary) 22%, transparent);
 }
 
 @media (max-width: 640px) {
-  .glitch {
+  .inara {
     padding: 2rem 0 2.75rem;
   }
 
@@ -3330,106 +3330,106 @@ button.terminalStatusPreview:focus-visible {
   }
 }
 
-.glitch :global(.glitch-muted) {
-  color: var(--glitch-muted);
+.inara :global(.inara-muted) {
+  color: var(--inara-muted);
 }
 
-.glitch :global(.glitch-accent) {
-  color: var(--glitch-accent);
+.inara :global(.inara-accent) {
+  color: var(--inara-accent);
 }
 
-.glitch :global(.glitch-panel-border) {
-  border-color: var(--glitch-panel-border);
+.inara :global(.inara-panel-border) {
+  border-color: var(--inara-panel-border);
 }
 
-.glitch :global(.glitch-inline-accent) {
-  color: var(--glitch-accent);
+.inara :global(.inara-inline-accent) {
+  color: var(--inara-accent);
   font-weight: 500;
 }
 
-@keyframes glitchArrivalSurface {
+@keyframes inaraArrivalSurface {
   0% {
-    --glitch-bg: var(--glitch-color-background);
-    --glitch-panel: color-mix(in srgb, var(--glitch-color-primary-dark) 82%, transparent);
-    --glitch-panel-border: color-mix(in srgb, var(--glitch-color-warning) 45%, transparent);
-    --glitch-ink: color-mix(in srgb, var(--glitch-color-text-strong) 96%, transparent);
-    --glitch-muted: color-mix(in srgb, var(--glitch-color-warning) 65%, transparent);
-    --glitch-subdued: color-mix(in srgb, var(--glitch-color-warning) 45%, transparent);
-    --glitch-accent: var(--glitch-color-warning);
-    --glitch-highlight: color-mix(in srgb, var(--glitch-color-warning) 28%, transparent);
+    --inara-bg: var(--inara-color-background);
+    --inara-panel: color-mix(in srgb, var(--inara-color-primary-dark) 82%, transparent);
+    --inara-panel-border: color-mix(in srgb, var(--inara-color-warning) 45%, transparent);
+    --inara-ink: color-mix(in srgb, var(--inara-color-text-strong) 96%, transparent);
+    --inara-muted: color-mix(in srgb, var(--inara-color-warning) 65%, transparent);
+    --inara-subdued: color-mix(in srgb, var(--inara-color-warning) 45%, transparent);
+    --inara-accent: var(--inara-color-warning);
+    --inara-highlight: color-mix(in srgb, var(--inara-color-warning) 28%, transparent);
     background: linear-gradient(
         165deg,
-        color-mix(in srgb, var(--glitch-color-warning) 22%, transparent) 0%,
-        color-mix(in srgb, var(--glitch-color-primary) 18%, transparent) 45%,
-        color-mix(in srgb, var(--glitch-color-background) 90%, transparent) 100%
+        color-mix(in srgb, var(--inara-color-warning) 22%, transparent) 0%,
+        color-mix(in srgb, var(--inara-color-primary) 18%, transparent) 45%,
+        color-mix(in srgb, var(--inara-color-background) 90%, transparent) 100%
       ),
-      var(--glitch-bg);
+      var(--inara-bg);
     filter: saturate(1.08) contrast(1.05);
     transform: scale(1.01);
   }
   42% {
-    --glitch-bg: var(--glitch-color-background);
-    --glitch-panel: color-mix(in srgb, var(--glitch-color-surface) 88%, transparent);
-    --glitch-panel-border: color-mix(in srgb, var(--glitch-color-primary) 38%, transparent);
-    --glitch-ink: color-mix(in srgb, var(--glitch-color-text-strong) 94%, transparent);
-    --glitch-muted: color-mix(in srgb, var(--glitch-color-text-strong) 78%, transparent);
-    --glitch-subdued: color-mix(in srgb, var(--glitch-color-text-strong) 60%, transparent);
-    --glitch-accent: var(--glitch-color-primary-light);
-    --glitch-highlight: color-mix(in srgb, var(--glitch-color-primary) 20%, transparent);
+    --inara-bg: var(--inara-color-background);
+    --inara-panel: color-mix(in srgb, var(--inara-color-surface) 88%, transparent);
+    --inara-panel-border: color-mix(in srgb, var(--inara-color-primary) 38%, transparent);
+    --inara-ink: color-mix(in srgb, var(--inara-color-text-strong) 94%, transparent);
+    --inara-muted: color-mix(in srgb, var(--inara-color-text-strong) 78%, transparent);
+    --inara-subdued: color-mix(in srgb, var(--inara-color-text-strong) 60%, transparent);
+    --inara-accent: var(--inara-color-primary-light);
+    --inara-highlight: color-mix(in srgb, var(--inara-color-primary) 20%, transparent);
     background: linear-gradient(
         165deg,
-        color-mix(in srgb, var(--glitch-color-primary) 24%, transparent) 0%,
-        color-mix(in srgb, var(--glitch-color-primary-dark) 32%, transparent) 55%,
-        color-mix(in srgb, var(--glitch-color-background) 88%, transparent) 100%
+        color-mix(in srgb, var(--inara-color-primary) 24%, transparent) 0%,
+        color-mix(in srgb, var(--inara-color-primary-dark) 32%, transparent) 55%,
+        color-mix(in srgb, var(--inara-color-background) 88%, transparent) 100%
       ),
-      var(--glitch-bg);
+      var(--inara-bg);
     filter: saturate(1.05);
     transform: scale(1.006);
   }
   62% {
     background: linear-gradient(
         165deg,
-        color-mix(in srgb, var(--glitch-color-primary) 20%, transparent) 0%,
-        color-mix(in srgb, var(--glitch-color-primary-dark) 28%, transparent) 55%,
-        color-mix(in srgb, var(--glitch-color-background) 86%, transparent) 100%
+        color-mix(in srgb, var(--inara-color-primary) 20%, transparent) 0%,
+        color-mix(in srgb, var(--inara-color-primary-dark) 28%, transparent) 55%,
+        color-mix(in srgb, var(--inara-color-background) 86%, transparent) 100%
       ),
-      var(--glitch-bg);
+      var(--inara-bg);
     filter: saturate(1.02);
     transform: scale(1.004) translate3d(-3px, 1px, 0);
   }
   72% {
     background: linear-gradient(
         165deg,
-        color-mix(in srgb, var(--glitch-color-primary) 16%, transparent) 0%,
-        color-mix(in srgb, var(--glitch-color-primary-dark) 26%, transparent) 55%,
-        color-mix(in srgb, var(--glitch-color-background) 84%, transparent) 100%
+        color-mix(in srgb, var(--inara-color-primary) 16%, transparent) 0%,
+        color-mix(in srgb, var(--inara-color-primary-dark) 26%, transparent) 55%,
+        color-mix(in srgb, var(--inara-color-background) 84%, transparent) 100%
       ),
-      var(--glitch-bg);
+      var(--inara-bg);
     filter: saturate(0.96);
     transform: scale(1.002) translate3d(2px, -1px, 0);
   }
   100% {
-    --glitch-bg: var(--glitch-color-background);
-    --glitch-panel: color-mix(in srgb, var(--glitch-color-background) 88%, transparent);
-    --glitch-panel-border: var(--glitch-border-soft);
-    --glitch-ink: color-mix(in srgb, var(--glitch-color-text-strong) 92%, transparent);
-    --glitch-muted: color-mix(in srgb, var(--glitch-color-text-strong) 70%, transparent);
-    --glitch-subdued: color-mix(in srgb, var(--glitch-color-text-strong) 56%, transparent);
-    --glitch-accent: var(--glitch-color-primary-light);
-    --glitch-highlight: color-mix(in srgb, var(--glitch-color-primary) 12%, transparent);
+    --inara-bg: var(--inara-color-background);
+    --inara-panel: color-mix(in srgb, var(--inara-color-background) 88%, transparent);
+    --inara-panel-border: var(--inara-border-soft);
+    --inara-ink: color-mix(in srgb, var(--inara-color-text-strong) 92%, transparent);
+    --inara-muted: color-mix(in srgb, var(--inara-color-text-strong) 70%, transparent);
+    --inara-subdued: color-mix(in srgb, var(--inara-color-text-strong) 56%, transparent);
+    --inara-accent: var(--inara-color-primary-light);
+    --inara-highlight: color-mix(in srgb, var(--inara-color-primary) 12%, transparent);
     background: linear-gradient(
         165deg,
-        var(--glitch-gradient-top) 0%,
-        var(--glitch-gradient-mid) 55%,
-        var(--glitch-gradient-bottom) 100%
+        var(--inara-gradient-top) 0%,
+        var(--inara-gradient-mid) 55%,
+        var(--inara-gradient-bottom) 100%
       ),
-      var(--glitch-bg);
+      var(--inara-bg);
     filter: none;
     transform: none;
   }
 }
 
-@keyframes glitchArrivalMesh {
+@keyframes inaraArrivalMesh {
   0% {
     opacity: 0.55;
     transform: scale(1.05) skewX(-3deg);
@@ -3452,21 +3452,21 @@ button.terminalStatusPreview:focus-visible {
   }
 }
 
-@keyframes glitchArrivalVignette {
+@keyframes inaraArrivalVignette {
   0% {
     opacity: 0.85;
     background: linear-gradient(
       180deg,
-      color-mix(in srgb, var(--glitch-color-background) 35%, transparent) 0%,
-      color-mix(in srgb, var(--glitch-color-background) 94%, transparent) 100%
+      color-mix(in srgb, var(--inara-color-background) 35%, transparent) 0%,
+      color-mix(in srgb, var(--inara-color-background) 94%, transparent) 100%
     );
   }
   40% {
     opacity: 0.7;
     background: linear-gradient(
       180deg,
-      color-mix(in srgb, var(--glitch-color-primary-dark) 28%, transparent) 0%,
-      color-mix(in srgb, var(--glitch-color-background) 92%, transparent) 100%
+      color-mix(in srgb, var(--inara-color-primary-dark) 28%, transparent) 0%,
+      color-mix(in srgb, var(--inara-color-background) 92%, transparent) 100%
     );
   }
   70% {
@@ -3474,11 +3474,11 @@ button.terminalStatusPreview:focus-visible {
   }
   100% {
     opacity: 1;
-    background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--glitch-color-background) 90%, transparent) 100%);
+    background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--inara-color-background) 90%, transparent) 100%);
   }
 }
 
-@keyframes glitchArrivalShell {
+@keyframes inaraArrivalShell {
   0% {
     opacity: 0.2;
     filter: blur(6px);
@@ -3506,24 +3506,24 @@ button.terminalStatusPreview:focus-visible {
   }
 }
 
-@keyframes glitchArrivalChromatic {
+@keyframes inaraArrivalChromatic {
   0% {
-    color: color-mix(in srgb, var(--glitch-color-warning) 95%, transparent);
-    text-shadow: 0 0 1.35rem color-mix(in srgb, var(--glitch-color-warning) 55%, transparent);
+    color: color-mix(in srgb, var(--inara-color-warning) 95%, transparent);
+    text-shadow: 0 0 1.35rem color-mix(in srgb, var(--inara-color-warning) 55%, transparent);
     transform: translate3d(0, 0, 0);
   }
   35% {
-    color: color-mix(in srgb, var(--glitch-color-warning) 85%, transparent);
-    text-shadow: 0 0 1.15rem color-mix(in srgb, var(--glitch-color-warning) 45%, transparent);
+    color: color-mix(in srgb, var(--inara-color-warning) 85%, transparent);
+    text-shadow: 0 0 1.15rem color-mix(in srgb, var(--inara-color-warning) 45%, transparent);
   }
   55% {
-    color: color-mix(in srgb, var(--glitch-color-success) 90%, transparent);
-    text-shadow: 0 0 1.35rem color-mix(in srgb, var(--glitch-color-success) 55%, transparent);
+    color: color-mix(in srgb, var(--inara-color-success) 90%, transparent);
+    text-shadow: 0 0 1.35rem color-mix(in srgb, var(--inara-color-success) 55%, transparent);
     transform: translate3d(-2px, 1px, 0);
   }
   68% {
-    color: color-mix(in srgb, var(--glitch-color-primary) 92%, transparent);
-    text-shadow: 0 0 1.35rem color-mix(in srgb, var(--glitch-color-primary) 65%, transparent);
+    color: color-mix(in srgb, var(--inara-color-primary) 92%, transparent);
+    text-shadow: 0 0 1.35rem color-mix(in srgb, var(--inara-color-primary) 65%, transparent);
     transform: translate3d(2px, -1px, 0);
   }
   100% {
@@ -3533,56 +3533,56 @@ button.terminalStatusPreview:focus-visible {
   }
 }
 
-@keyframes glitchArrivalPanel {
+@keyframes inaraArrivalPanel {
   0% {
-    background: color-mix(in srgb, var(--glitch-color-primary-dark) 82%, transparent);
-    border-color: color-mix(in srgb, var(--glitch-color-warning) 50%, transparent);
-    box-shadow: 0 1.85rem 3.9rem color-mix(in srgb, var(--glitch-color-background) 70%, transparent);
+    background: color-mix(in srgb, var(--inara-color-primary-dark) 82%, transparent);
+    border-color: color-mix(in srgb, var(--inara-color-warning) 50%, transparent);
+    box-shadow: 0 1.85rem 3.9rem color-mix(in srgb, var(--inara-color-background) 70%, transparent);
     filter: saturate(1.05);
     transform: translate3d(0, 8px, 0);
   }
   40% {
-    background: color-mix(in srgb, var(--glitch-color-surface) 90%, transparent);
-    border-color: color-mix(in srgb, var(--glitch-color-primary) 38%, transparent);
-    box-shadow: 0 1.95rem 4rem color-mix(in srgb, var(--glitch-color-background) 75%, transparent);
+    background: color-mix(in srgb, var(--inara-color-surface) 90%, transparent);
+    border-color: color-mix(in srgb, var(--inara-color-primary) 38%, transparent);
+    box-shadow: 0 1.95rem 4rem color-mix(in srgb, var(--inara-color-background) 75%, transparent);
     transform: translate3d(-2px, 2px, 0);
   }
   68% {
-    background: color-mix(in srgb, var(--glitch-color-background) 90%, transparent);
-    border-color: color-mix(in srgb, var(--glitch-color-primary) 34%, transparent);
+    background: color-mix(in srgb, var(--inara-color-background) 90%, transparent);
+    border-color: color-mix(in srgb, var(--inara-color-primary) 34%, transparent);
     transform: translate3d(2px, -2px, 0);
   }
   100% {
-    background: var(--glitch-panel);
-    border-color: var(--glitch-panel-border);
-    box-shadow: 0 1.75rem 3.5rem color-mix(in srgb, var(--glitch-color-background) 80%, transparent);
+    background: var(--inara-panel);
+    border-color: var(--inara-panel-border);
+    box-shadow: 0 1.75rem 3.5rem color-mix(in srgb, var(--inara-color-background) 80%, transparent);
     filter: none;
     transform: none;
   }
 }
 
-@keyframes glitchArrivalBadge {
+@keyframes inaraArrivalBadge {
   0% {
-    background: color-mix(in srgb, var(--glitch-color-warning) 28%, transparent);
-    border-color: color-mix(in srgb, var(--glitch-color-warning) 55%, transparent);
-    color: color-mix(in srgb, var(--glitch-color-warning) 92%, transparent);
+    background: color-mix(in srgb, var(--inara-color-warning) 28%, transparent);
+    border-color: color-mix(in srgb, var(--inara-color-warning) 55%, transparent);
+    color: color-mix(in srgb, var(--inara-color-warning) 92%, transparent);
     transform: translate3d(0, 4px, 0);
   }
   55% {
-    background: color-mix(in srgb, var(--glitch-color-primary) 22%, transparent);
-    border-color: color-mix(in srgb, var(--glitch-color-primary) 42%, transparent);
-    color: color-mix(in srgb, var(--glitch-color-primary) 85%, transparent);
+    background: color-mix(in srgb, var(--inara-color-primary) 22%, transparent);
+    border-color: color-mix(in srgb, var(--inara-color-primary) 42%, transparent);
+    color: color-mix(in srgb, var(--inara-color-primary) 85%, transparent);
     transform: translate3d(-2px, 0, 0);
   }
   70% {
-    background: color-mix(in srgb, var(--glitch-color-success) 20%, transparent);
-    border-color: color-mix(in srgb, var(--glitch-color-primary) 38%, transparent);
+    background: color-mix(in srgb, var(--inara-color-success) 20%, transparent);
+    border-color: color-mix(in srgb, var(--inara-color-primary) 38%, transparent);
     transform: translate3d(1px, -1px, 0);
   }
   100% {
-    background: color-mix(in srgb, var(--glitch-color-primary) 12%, transparent);
-    border: 1px solid color-mix(in srgb, var(--glitch-color-primary) 42%, transparent);
-    color: var(--glitch-accent);
+    background: color-mix(in srgb, var(--inara-color-primary) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--inara-color-primary) 42%, transparent);
+    color: var(--inara-accent);
     transform: none;
   }
 }

--- a/src/client/pages/inara/cargo.js
+++ b/src/client/pages/inara/cargo.js
@@ -1,0 +1,17 @@
+import Layout from 'components/layout'
+import Panel from 'components/panel'
+import { useSocket } from 'lib/socket'
+import { InaraWorkspaceNavItems } from 'lib/navigation-items'
+import { CargoHoldPanel } from './status'
+
+export default function InaraCargoPage () {
+  const { connected, active, ready } = useSocket()
+
+  return (
+    <Layout connected={connected} active={active} ready={ready}>
+      <Panel layout='full-width' scrollable navigation={InaraWorkspaceNavItems('Cargo')}>
+        <CargoHoldPanel />
+      </Panel>
+    </Layout>
+  )
+}

--- a/src/client/pages/inara/index.js
+++ b/src/client/pages/inara/index.js
@@ -6,7 +6,7 @@ import { useSocket } from 'lib/socket'
 export default function InaraPage () {
   const { connected, active } = useSocket()
 
-  if (typeof window !== 'undefined') Router.push('/inara/status')
+  if (typeof window !== 'undefined') Router.push('/inara/trade-routes')
 
   return (
     <Layout connected={connected} active={active}>

--- a/src/client/pages/inara/mining-locations.js
+++ b/src/client/pages/inara/mining-locations.js
@@ -1,0 +1,17 @@
+import Layout from 'components/layout'
+import Panel from 'components/panel'
+import { useSocket } from 'lib/socket'
+import { InaraWorkspaceNavItems } from 'lib/navigation-items'
+import { PristineMiningPanel } from './status'
+
+export default function InaraMiningLocationsPage () {
+  const { connected, active, ready } = useSocket()
+
+  return (
+    <Layout connected={connected} active={active} ready={ready}>
+      <Panel layout='full-width' scrollable navigation={InaraWorkspaceNavItems('Mining Locations')}>
+        <PristineMiningPanel />
+      </Panel>
+    </Layout>
+  )
+}

--- a/src/client/pages/inara/mining-missions.js
+++ b/src/client/pages/inara/mining-missions.js
@@ -1,0 +1,17 @@
+import Layout from 'components/layout'
+import Panel from 'components/panel'
+import { useSocket } from 'lib/socket'
+import { InaraWorkspaceNavItems } from 'lib/navigation-items'
+import { MissionsPanel } from './status'
+
+export default function InaraMiningMissionsPage () {
+  const { connected, active, ready } = useSocket()
+
+  return (
+    <Layout connected={connected} active={active} ready={ready}>
+      <Panel layout='full-width' scrollable navigation={InaraWorkspaceNavItems('Mining Missions')}>
+        <MissionsPanel />
+      </Panel>
+    </Layout>
+  )
+}

--- a/src/client/pages/inara/outfitting.js
+++ b/src/client/pages/inara/outfitting.js
@@ -1,24 +1,17 @@
-import { useEffect } from 'react'
 import Layout from 'components/layout'
 import Panel from 'components/panel'
 import { useSocket } from 'lib/socket'
 import { InaraPanelNavItems } from 'lib/navigation-items'
-import styles from '../glitch.module.css'
+import styles from '../inara-workspace.module.css'
 
 export default function InaraOutfittingPage () {
   const { connected, active } = useSocket()
   const navItems = InaraPanelNavItems('Outfitting')
 
-  useEffect(() => {
-    if (typeof document === 'undefined' || !document.body) return undefined
-    document.body.classList.add('glitch-theme')
-    return () => document.body.classList.remove('glitch-theme')
-  }, [])
-
   return (
     <Layout connected={connected} active={active}>
-      <Panel layout='full-width' scrollable navigation={navItems} className={styles.glitchPanel}>
-        <div className={styles.glitch}>
+      <Panel layout='full-width' scrollable navigation={navItems} className={styles.inaraPanel}>
+        <div className={styles.inara}>
           <div className={styles.hero}>
             <div className={styles.heroHeader}>
               <h1 className={styles.heroTitle}>Outfitting Tools</h1>

--- a/src/client/pages/inara/search.js
+++ b/src/client/pages/inara/search.js
@@ -1,24 +1,17 @@
-import { useEffect } from 'react'
 import Layout from 'components/layout'
 import Panel from 'components/panel'
 import { useSocket } from 'lib/socket'
 import { InaraPanelNavItems } from 'lib/navigation-items'
-import styles from '../glitch.module.css'
+import styles from '../inara-workspace.module.css'
 
 export default function InaraSearchPage() {
   const { connected, active } = useSocket()
   const navItems = InaraPanelNavItems('Search')
 
-  useEffect(() => {
-    if (typeof document === 'undefined' || !document.body) return undefined
-    document.body.classList.add('glitch-theme')
-    return () => document.body.classList.remove('glitch-theme')
-  }, [])
-
   return (
     <Layout connected={connected} active={active}>
-      <Panel layout='full-width' scrollable navigation={navItems} className={styles.glitchPanel}>
-        <div className={styles.glitch}>
+      <Panel layout='full-width' scrollable navigation={navItems} className={styles.inaraPanel}>
+        <div className={styles.inara}>
           <div className={styles.hero}>
             <div className={styles.heroHeader}>
               <h1 className={styles.heroTitle}>Signal Search</h1>

--- a/src/client/pages/inara/status.js
+++ b/src/client/pages/inara/status.js
@@ -17,9 +17,8 @@ import { sanitizeInaraText } from 'lib/sanitize-inara-text'
 import { stationIconFromType, getStationIconName } from 'lib/station-icons'
 import { createMockCargoManifest, createMockCommodityValuations, generateMockTradeRoutes, NON_COMMODITY_KEYS, normaliseCommodityKey } from 'lib/inara-mock-data'
 import { getInaraStrings, getInaraString } from 'lib/inara-addon'
-import { isGlitchThemeEnabled, addGlitchThemeChangeListener, THEME_STORAGE_KEY } from 'lib/glitch-settings'
 import { InaraPanelNavItems } from 'lib/navigation-items'
-import styles from '../glitch.module.css'
+import styles from '../inara-workspace.module.css'
 
 const METRIC_VARIANT_CLASS_MAP = {
   neutral: styles.metricChipNeutral,
@@ -35,7 +34,7 @@ export const TERMINAL_PROMPT_TYPE_CLASS_MAP = {
   cipher: styles.terminalPromptCipher,
   binary: styles.terminalPromptBinary,
   decrypt: styles.terminalPromptDecrypt,
-  glitch: styles.terminalPromptGlitch,
+  inara: styles.terminalPromptInara,
   system: styles.terminalPromptSystem,
   credit: styles.terminalPromptCredit,
   transaction: styles.terminalPromptTransaction,
@@ -52,7 +51,7 @@ export const TERMINAL_TEXT_TYPE_CLASS_MAP = {
   cipher: styles.terminalTextCipher,
   binary: styles.terminalTextBinary,
   decrypt: styles.terminalTextDecrypt,
-  glitch: styles.terminalTextGlitch,
+  inara: styles.terminalTextInara,
   system: styles.terminalTextSystem,
   credit: styles.terminalTextCredit,
   transaction: styles.terminalTextTransaction,
@@ -86,12 +85,12 @@ const LARGE_PAD_SIZE_VALUE = '3'
 function LoadingSpinner ({ label, inline = false }) {
   return (
     <div
-      className={`glitch-spinner${inline ? ' glitch-spinner--inline' : ' glitch-spinner--block'}`}
+      className={`inara-spinner${inline ? ' inara-spinner--inline' : ' inara-spinner--block'}`}
       role='status'
       aria-live='polite'
     >
-      <span className='glitch-spinner__icon' aria-hidden='true' />
-      {label ? <span className='glitch-spinner__label'>{label}</span> : null}
+      <span className='inara-spinner__icon' aria-hidden='true' />
+      {label ? <span className='inara-spinner__label'>{label}</span> : null}
     </div>
   )
 }
@@ -915,7 +914,7 @@ function getFactionStandingDisplay(factionName, standings) {
 
   const normalizedStanding = typeof info.standing === 'string' ? info.standing.trim().toLowerCase() : ''
   let className = null
-  let baseColor = 'var(--glitch-subdued)'
+  let baseColor = 'var(--inara-subdued)'
   if (normalizedStanding === 'ally') {
     className = styles.tableTextSuccess
     baseColor = '#29f3c3'
@@ -924,7 +923,7 @@ function getFactionStandingDisplay(factionName, standings) {
     baseColor = '#ff5fc1'
   } else if (normalizedStanding) {
     className = styles.tableTextNeutral
-    baseColor = 'var(--glitch-accent)'
+    baseColor = 'var(--inara-accent)'
   }
 
   const reputationLabel = typeof info.reputation === 'number'
@@ -1218,7 +1217,7 @@ const CURRENT_SYSTEM_CONTAINER_STYLE = {
 }
 
 const CURRENT_SYSTEM_LABEL_STYLE = {
-  color: 'var(--glitch-accent)',
+  color: 'var(--inara-accent)',
   fontSize: '0.75rem',
   letterSpacing: '.08em',
   textTransform: 'uppercase',
@@ -1250,7 +1249,7 @@ const FILTER_FIELD_STYLE = {
 const FILTER_LABEL_STYLE = {
   display: 'block',
   marginBottom: 0,
-  color: 'var(--glitch-accent)',
+  color: 'var(--inara-accent)',
   fontSize: '0.75rem',
   textTransform: 'uppercase',
   letterSpacing: '.08em'
@@ -1265,7 +1264,7 @@ const FILTER_CONTROL_STYLE = {
   borderRadius: '.35rem',
   border: '1px solid rgba(127, 233, 255, 0.35)',
   background: 'rgba(5, 8, 13, 0.75)',
-  color: 'var(--glitch-ink)',
+  color: 'var(--inara-ink)',
   lineHeight: '1.2',
   boxSizing: 'border-box'
 }
@@ -1273,7 +1272,7 @@ const FILTER_CONTROL_STYLE = {
 const FILTER_TOGGLE_BUTTON_STYLE = {
   background: 'rgba(127, 233, 255, 0.12)',
   border: '1px solid rgba(127, 233, 255, 0.4)',
-  color: 'var(--glitch-accent)',
+  color: 'var(--inara-accent)',
   borderRadius: '0',
   padding: '0 1rem',
   fontSize: '0.85rem',
@@ -1293,7 +1292,7 @@ const FILTER_SUMMARY_STYLE = {
 }
 
 const FILTER_SUMMARY_TEXT_STYLE = {
-  color: 'var(--glitch-accent)',
+  color: 'var(--inara-accent)',
   fontSize: '0.85rem',
   fontWeight: 500,
   whiteSpace: 'nowrap',
@@ -1337,7 +1336,7 @@ function parseNumberFromText (value) {
   return Number.isFinite(parsed) ? parsed : null
 }
 
-function CreditsIcon ({ size = 22, color = 'var(--glitch-color-success)' }) {
+function CreditsIcon ({ size = 22, color = 'var(--inara-color-success)' }) {
   const paths = Icons.credits
   if (!paths) return null
   return (
@@ -1354,7 +1353,7 @@ function CreditsIcon ({ size = 22, color = 'var(--glitch-color-success)' }) {
 
 CreditsIcon.defaultProps = {
   size: 22,
-  color: 'var(--glitch-color-success)'
+  color: 'var(--inara-color-success)'
 }
 
 function extractProfitPerTon (route) {
@@ -2239,20 +2238,20 @@ function MissionsPanel () {
           <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
             <div>
               <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
-              <div className='glitch-accent' style={CURRENT_SYSTEM_NAME_STYLE}>{displaySystemName || 'Unknown'}</div>
+              <div className='inara-accent' style={CURRENT_SYSTEM_NAME_STYLE}>{displaySystemName || 'Unknown'}</div>
             </div>
             {sourceUrl && (
-              <div className='glitch__data-source glitch-muted'>
+              <div className='inara__data-source inara-muted'>
                 INARA intercept feed compiled from community relays.
               </div>
             )}
           </div>
-          <p style={{ color: 'var(--glitch-muted)', marginTop: '-0.5rem' }}>
+          <p style={{ color: 'var(--inara-muted)', marginTop: '-0.5rem' }}>
             Availability signals originate from INARA contributors and may trail live mission boards.
           </p>
           {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
         </div>
-        <div className='glitch-panel-table'>
+        <div className='inara-panel-table'>
           <div className='scrollable' style={TABLE_SCROLL_AREA_STYLE}>
             {displayMessage && status !== 'idle' && status !== 'loading' && (
               <div className={`${styles.tableMessage} ${status === 'populated' ? styles.tableMessageBorder : ''}`}>
@@ -2325,7 +2324,7 @@ function MissionsPanel () {
                               <i className='icon system-object-icon icarus-terminal-location-filled text-secondary' style={{ marginRight: '.5rem' }} />
                               )
                             : (
-                              <i className='icon system-object-icon icarus-terminal-location' style={{ marginRight: '.5rem', color: 'var(--glitch-subdued)' }} />
+                              <i className='icon system-object-icon icarus-terminal-location' style={{ marginRight: '.5rem', color: 'var(--inara-subdued)' }} />
                               )}
                           {mission.system
                             ? <CopyOnClick copyMessageKey='system'>{mission.system}</CopyOnClick>
@@ -3052,7 +3051,7 @@ function CargoHoldPanel () {
         <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
           <div>
             <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
-            <div className='glitch-accent' style={CURRENT_SYSTEM_NAME_STYLE}>{currentSystemName || 'Unknown'}</div>
+            <div className='inara-accent' style={CURRENT_SYSTEM_NAME_STYLE}>{currentSystemName || 'Unknown'}</div>
           </div>
         </div>
       </div>
@@ -3281,7 +3280,7 @@ function CargoHoldPanel () {
                 </div>
               </div>
 
-              <div className='glitch-panel-table'>
+              <div className='inara-panel-table'>
                 <div className='scrollable' style={STATION_TABLE_SCROLL_AREA_STYLE}>
                   {listings.length === 0 ? (
                     <div className={styles.detailEmptyState}>
@@ -3430,7 +3429,7 @@ function CargoHoldPanel () {
         })()
         : (
           <>
-            <div className='glitch-panel-table'>
+            <div className='inara-panel-table'>
               <div className='scrollable' style={TABLE_SCROLL_AREA_STYLE}>
                 {commodityContext ? (
                   <CommoditySummary
@@ -4908,7 +4907,7 @@ function TradeRoutesPanel ({ onStatusChange = () => {} }) {
           </div>
         </div>
       </Panel>
-      <div className='glitch-panel-table'>
+      <div className='inara-panel-table'>
         <div
           className='scrollable'
           style={TABLE_SCROLL_AREA_STYLE}
@@ -5157,21 +5156,21 @@ function PristineMiningPanel () {
           <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
             <div>
               <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
-              <div className='glitch-accent' style={CURRENT_SYSTEM_NAME_STYLE}>{displaySystemName || 'Unknown'}</div>
+              <div className='inara-accent' style={CURRENT_SYSTEM_NAME_STYLE}>{displaySystemName || 'Unknown'}</div>
             </div>
             {sourceUrl && (
-              <div className='glitch__data-source glitch-muted'>
+              <div className='inara__data-source inara-muted'>
                 INARA prospecting relays aligned with survey intel.
               </div>
             )}
           </div>
-          <p style={{ color: 'var(--glitch-muted)', marginTop: '-0.5rem' }}>
+          <p style={{ color: 'var(--inara-muted)', marginTop: '-0.5rem' }}>
             Geological echoes are sourced from volunteer INARA submissions and may lag in-system discoveries.
           </p>
           {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
         </div>
         <div
-          className={`glitch-panel-table pristine-mining__container${inspectorReserved ? ' pristine-mining__container--inspector' : ''}`}
+          className={`inara-panel-table pristine-mining__container${inspectorReserved ? ' pristine-mining__container--inspector' : ''}`}
         >
           <div
             className={`scrollable pristine-mining__results${inspectorReserved ? ' pristine-mining__results--inspector' : ''}`}
@@ -5234,7 +5233,7 @@ function PristineMiningPanel () {
                       >
                         <td className={`${styles.tableCellTop} ${styles.tableCellTight}`}>
                           <div style={{ display: 'flex', flexDirection: 'column' }}>
-                            <span className='glitch-accent'>{location.body || '--'}</span>
+                            <span className='inara-accent'>{location.body || '--'}</span>
                             {detailText && (
                               <span className={styles.tableSubtext}>{detailText}</span>
                             )}
@@ -5244,12 +5243,12 @@ function PristineMiningPanel () {
                           <div className={`${styles.tableCellInline} text-no-wrap`}>
                             {location.isTargetSystem
                               ? (
-                                <i className='icon system-object-icon icarus-terminal-location-filled glitch-accent' style={{ marginRight: '.5rem' }} />
+                                <i className='icon system-object-icon icarus-terminal-location-filled inara-accent' style={{ marginRight: '.5rem' }} />
                                 )
                               : (
-                                <i className='icon system-object-icon icarus-terminal-location' style={{ marginRight: '.5rem', color: 'var(--glitch-subdued)' }} />
+                                <i className='icon system-object-icon icarus-terminal-location' style={{ marginRight: '.5rem', color: 'var(--inara-subdued)' }} />
                                 )}
-                            <span className='glitch-accent'>
+                            <span className='inara-accent'>
                               {location.system
                                 ? <CopyOnClick copyMessageKey='system'>{location.system}</CopyOnClick>
                                 : '--'}
@@ -5260,14 +5259,14 @@ function PristineMiningPanel () {
                         <td className={`text-right text-no-wrap ${styles.tableCellTop} ${styles.tableCellTight}`}>{distanceDisplay || '--'}</td>
                       </tr>
                       {isExpanded && (
-                        <tr className={`${styles.tableDetailRow} glitch-table-detail-row`} data-inara-table-row='pending'>
+                        <tr className={`${styles.tableDetailRow} inara-table-detail-row`} data-inara-table-row='pending'>
                           <td colSpan='4' style={{ padding: '0 1.5rem 1.5rem', background: 'rgba(5, 8, 13, 0.85)', borderTop: '1px solid rgba(127, 233, 255, 0.18)' }}>
                             <div className='pristine-mining__detail'>
                               <div className='pristine-mining__detail-info'>
                                 <div className='pristine-mining__detail-summary'>
                                   {detailText && <span>{detailText}</span>}
-                                  {bodyDistanceDisplay && <span>Body Distance: <span className='glitch-accent'>{bodyDistanceDisplay}</span></span>}
-                                  {distanceDisplay && <span>System Distance: <span className='glitch-accent'>{distanceDisplay}</span></span>}
+                                  {bodyDistanceDisplay && <span>Body Distance: <span className='inara-accent'>{bodyDistanceDisplay}</span></span>}
+                                  {distanceDisplay && <span>System Distance: <span className='inara-accent'>{distanceDisplay}</span></span>}
                                 </div>
                                 {(location.systemUrl || location.bodyUrl) && (
                                   <div className='pristine-mining__detail-links'>
@@ -5386,7 +5385,7 @@ function randomCallsign () {
 
 function randomEndpoint () {
   const protocol = randomChoice(['mesh', 'flux', 'relay', 'beacon', 'packet', 'datastream'])
-  const host = `${randomChoice(['glitch', 'syndicate', 'perseus', 'umbra', 'aurora', 'dusk'])}.${randomChoice(['alpha', 'beta', 'gamma', 'delta', 'kappa', 'lambda'])}`
+  const host = `${randomChoice(['inara', 'syndicate', 'perseus', 'umbra', 'aurora', 'dusk'])}.${randomChoice(['alpha', 'beta', 'gamma', 'delta', 'kappa', 'lambda'])}`
   return `${protocol}://${host}.${randomChoice(['io', 'net', 'grid', 'node'])}`
 }
 
@@ -5458,7 +5457,7 @@ export function createTransactionSequence (entry = {}, { simulation = false, pre
   const balanceLabel = formatTokenAmount(Number.isFinite(entry.balance) ? entry.balance : null)
   const jackpotActive = Boolean(metadata.jackpot)
   const isDebit = entry.type === 'spend'
-  const glyphLineType = jackpotActive ? 'jackpotFloodGlyph' : isDebit ? 'debitGlyph' : 'glitch'
+  const glyphLineType = jackpotActive ? 'jackpotFloodGlyph' : isDebit ? 'debitGlyph' : 'inara'
   const glyphLabelChoices = jackpotActive
     ? ['₿Ξ₿Ξ', 'Ξ₪Ξ₪', '₿₿₿₿₿', '₪₪₪₪₪₪', 'ΞΞΞΞΞΞ']
     : isDebit
@@ -5472,7 +5471,7 @@ export function createTransactionSequence (entry = {}, { simulation = false, pre
     if (glyphLineType === 'debitGlyph') {
       return generateDebitGlyphString(randomInteger(48, 88))
     }
-    return generateGlitchString(randomInteger(54, 96))
+    return generateInaraString(randomInteger(54, 96))
   }
 
   const makeGlyphLine = seedSuffix => ({
@@ -5553,11 +5552,11 @@ export function createJackpotFloodConfig (entry = {}, { prefersReducedMotion = f
   for (let index = 0; index < floodCount; index += 1) {
     floodLines.push({
       line: {
-        type: jackpotActive ? 'jackpotFloodGlyph' : 'glitch',
+        type: jackpotActive ? 'jackpotFloodGlyph' : 'inara',
         label: randomChoice(floodLabelChoices),
         text: jackpotActive
           ? generateCurrencyCascadeString(randomInteger(96, 156))
-          : generateGlitchString(randomInteger(64, 112)),
+          : generateInaraString(randomInteger(64, 112)),
         seed: `jackpot-flood-${index}`
       },
       delay: prefersReducedMotion ? 60 : randomInteger(18, 64)
@@ -5567,7 +5566,7 @@ export function createJackpotFloodConfig (entry = {}, { prefersReducedMotion = f
   return { floodLines, floodDuration, jackpotActive }
 }
 
-function generateGlitchString (length = 64) {
+function generateInaraString (length = 64) {
   const baseGlyphs = [
     '@', '%', '&', '*', '/', '\\', '|', '<', '>', '^', '~', '?', '!', '$', ':', ';', '_', '[', ']', '{', '}', '(', ')',
     '#', '=', '-', '+', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
@@ -5678,7 +5677,7 @@ function formatTokenAmount (value) {
 function extractLedgerSource (metadata = {}) {
   const candidates = [metadata.source, metadata.endpoint, metadata.event, metadata.origin]
   const resolved = candidates.find(value => typeof value === 'string' && value.trim())
-  return resolved ? resolved.trim() : 'glitch'
+  return resolved ? resolved.trim() : 'inara'
 }
 
 function extractLedgerReason (metadata = {}) {
@@ -5907,13 +5906,13 @@ function generateMenaceLines (balance) {
   const echoText = randomChoice(MENACE_ECHOES)()
   return [
     { type: 'alert', label: '!!!', text: alertText },
-    { type: 'system', label: 'glitch', text: echoText }
+    { type: 'system', label: 'inara', text: echoText }
   ]
 }
 
 function generateTerminalLine () {
   const generators = {
-    command: () => ({ type: 'command', label: 'glitch@ship', text: generateCommandText() }),
+    command: () => ({ type: 'command', label: 'inara@ship', text: generateCommandText() }),
     response: () => ({ type: 'response', label: randomChoice(['mesh', 'telemetry', 'analysis']), text: generateResponseText() }),
     cipher: () => ({ type: 'cipher', label: 'cipher', text: generateCipherString(randomInteger(32, 64)) }),
     binary: () => ({ type: 'binary', label: 'payload', text: generateBinaryString(randomInteger(6, 10)) }),
@@ -6257,14 +6256,14 @@ function InaraTerminalOverlay () {
         : viewState === TERMINAL_VIEW.EXPANDED
           ? TERMINAL_HEIGHT_EXPANDED
           : TERMINAL_HEIGHT_NORMAL
-    host.style.setProperty('--glitch-terminal-height', nextHeight)
+    host.style.setProperty('--inara-terminal-height', nextHeight)
   }, [viewState])
 
   useEffect(() => {
     const host = terminalRef.current?.parentElement
     return () => {
       if (host) {
-        host.style.removeProperty('--glitch-terminal-height')
+        host.style.removeProperty('--inara-terminal-height')
       }
     }
   }, [])
@@ -6344,7 +6343,7 @@ function InaraTerminalOverlay () {
     ref.timeouts = []
   }, [])
 
-  const triggerCreditCelebration = useCallback((entry = {}, { message, messageLabel = 'glitch', messageType = 'jackpotSummary' } = {}) => {
+  const triggerCreditCelebration = useCallback((entry = {}, { message, messageLabel = 'inara', messageType = 'jackpotSummary' } = {}) => {
     if (typeof window === 'undefined') return
     if (!entry || typeof entry !== 'object') return
     const entryId = entry.id || null
@@ -6432,7 +6431,7 @@ function InaraTerminalOverlay () {
       simulation
     })
 
-    triggerCreditCelebration(entry, { message: summary, messageLabel: 'glitch', messageType: 'jackpotSummary' })
+    triggerCreditCelebration(entry, { message: summary, messageLabel: 'inara', messageType: 'jackpotSummary' })
 
     const { floodLines, floodDuration } = createJackpotFloodConfig(entry, { prefersReducedMotion })
 
@@ -6476,7 +6475,7 @@ function InaraTerminalOverlay () {
       {
         line: {
           type: 'jackpotSummary',
-          label: 'glitch',
+          label: 'inara',
           text: summary,
           seed: 'jackpot-summary'
         }
@@ -6681,9 +6680,9 @@ function InaraTerminalOverlay () {
     }
 
     const buildFloodLine = () => ({
-      type: 'glitch',
+      type: 'inara',
       label: '####',
-      text: generateGlitchString(randomInteger(56, 92))
+      text: generateInaraString(randomInteger(56, 92))
     })
 
     if (state.queue.length > 0) {
@@ -6885,7 +6884,7 @@ function InaraTerminalOverlay () {
 
   const maximizeIcon = isExpanded ? '▭' : '▢'
 
-  const statusPreviewLabel = latestLine?.label ?? 'glitch'
+  const statusPreviewLabel = latestLine?.label ?? 'inara'
   const statusPreviewText = latestLine?.text ?? 'Link stable'
 
   return (
@@ -6957,7 +6956,7 @@ function InaraTerminalOverlay () {
             ) : (
               <div className={styles.terminalHeaderContent}>
                 <span className={styles.terminalTitle}>Ship Uplink Console</span>
-                <span className={styles.terminalStatus}>Channel mesh://glitch</span>
+                <span className={styles.terminalStatus}>Channel mesh://inara</span>
               </div>
             )}
           </div>
@@ -7020,65 +7019,7 @@ function InaraTerminalOverlay () {
 export default function InaraStatusPage () {
   const [activeTab, setActiveTab] = useState('tradeRoutes')
   const [tradeRoutesStatus, setTradeRoutesStatus] = useState('idle')
-  const [arrivalMode, setArrivalMode] = useState(false)
-  const [themeEnabled, setThemeEnabled] = useState(() => {
-    if (typeof window === 'undefined') return false
-    return isGlitchThemeEnabled()
-  })
   const { connected, ready, active: socketActive } = useSocket()
-  useLayoutEffect(() => {
-    if (typeof document === 'undefined' || !document.body) return undefined
-
-    const { body } = document
-    if (themeEnabled) {
-      body.classList.add('glitch-theme')
-    } else {
-      body.classList.remove('glitch-theme')
-    }
-
-    return () => {
-      body.classList.remove('glitch-theme')
-    }
-  }, [themeEnabled])
-  useEffect(() => {
-    if (typeof window === 'undefined') return undefined
-
-    const storageHandler = (event) => {
-      if (event.key === THEME_STORAGE_KEY) {
-        setThemeEnabled(isGlitchThemeEnabled())
-      }
-    }
-
-    const removeListener = addGlitchThemeChangeListener(setThemeEnabled)
-    window.addEventListener('storage', storageHandler)
-
-    return () => {
-      removeListener()
-      window.removeEventListener('storage', storageHandler)
-    }
-  }, [])
-  useEffect(() => {
-    if (typeof window === 'undefined') return undefined
-    let timeoutId
-    try {
-      const stored = window.sessionStorage?.getItem('glitch.assimilationArrival')
-      if (stored) {
-        const timestamp = Number(stored)
-        if (!Number.isNaN(timestamp) && Date.now() - timestamp < 8000) {
-          setArrivalMode(true)
-          timeoutId = window.setTimeout(() => setArrivalMode(false), 5200)
-        }
-        window.sessionStorage.removeItem('glitch.assimilationArrival')
-      }
-    } catch (err) {
-      // Ignore storage read errors
-    }
-    return () => {
-      if (timeoutId) {
-        window.clearTimeout(timeoutId)
-      }
-    }
-  }, [])
   const inaraTabs = useMemo(() => {
     const panelItems = [
       { name: 'Trade Routes', icon: 'route', active: activeTab === 'tradeRoutes', onClick: () => setActiveTab('tradeRoutes') },
@@ -7091,24 +7032,20 @@ export default function InaraStatusPage () {
     return [...panelItems, ...sharedNavItems]
   }, [activeTab])
 
-  const glitchClassName = [
-    styles.glitch,
-    arrivalMode ? styles.arrival : '',
-    themeEnabled ? '' : styles.glitchIcarus
-  ].filter(Boolean).join(' ')
+  const workspaceClassName = [styles.inara, styles.inaraIcarus].join(' ')
 
   const loaderVisible = activeTab === 'tradeRoutes' && tradeRoutesStatus === 'loading'
 
   return (
-    <Layout connected={connected} active={socketActive} ready={ready} loader={loaderVisible} className={styles.glitchLayout}>
+    <Layout connected={connected} active={socketActive} ready={ready} loader={loaderVisible} className={styles.inaraLayout}>
       <Panel
         layout='full-width'
         scrollable
         navigation={inaraTabs}
         search={false}
-        className={styles.glitchPanel}
+        className={styles.inaraPanel}
       >
-        <div className={glitchClassName}>
+        <div className={workspaceClassName}>
           <div className={styles.shell}>
             <div className={styles.tabPanels}>
               <div style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
@@ -7133,4 +7070,11 @@ export default function InaraStatusPage () {
       </Panel>
     </Layout>
   )
+}
+
+export {
+  TradeRoutesPanel,
+  CargoHoldPanel,
+  MissionsPanel,
+  PristineMiningPanel
 }

--- a/src/client/pages/inara/trade-routes.js
+++ b/src/client/pages/inara/trade-routes.js
@@ -1,0 +1,19 @@
+import { useState } from 'react'
+import Layout from 'components/layout'
+import Panel from 'components/panel'
+import { useSocket } from 'lib/socket'
+import { InaraWorkspaceNavItems } from 'lib/navigation-items'
+import { TradeRoutesPanel } from './status'
+
+export default function InaraTradeRoutesPage () {
+  const { connected, active, ready } = useSocket()
+  const [tradeRoutesStatus, setTradeRoutesStatus] = useState('idle')
+
+  return (
+    <Layout connected={connected} active={active} ready={ready} loader={tradeRoutesStatus === 'loading'}>
+      <Panel layout='full-width' scrollable navigation={InaraWorkspaceNavItems('Trade Routes')}>
+        <TradeRoutesPanel onStatusChange={setTradeRoutesStatus} />
+      </Panel>
+    </Layout>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the INARA workspace layout with a new Icarus-focused stylesheet and update the status page to drop theme toggles in favour of the inara panel shell
- update the INARA search and outfitting stubs plus shared pirate radio, station summary, trade route, and transfer context styles to consume the new inara tokens
- align animate-table-effect helpers and INARA tests with the renamed theme module

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: Next.js SWC transform rejects the `serverComponents` field in the generated options)*

------
https://chatgpt.com/codex/tasks/task_e_68e463d3d8348323b2f74b335c711067