### PR TITLE
Align INARA hero text with engineering style

### DIFF
--- a/src/client/pages/inara/outfitting.js
+++ b/src/client/pages/inara/outfitting.js
@@ -12,14 +12,9 @@ export default function InaraOutfittingPage () {
     <Layout connected={connected} active={active}>
       <Panel layout='full-width' scrollable navigation={navItems} className={styles.inaraPanel}>
         <div className={styles.inara}>
-          <div className={styles.hero}>
-            <div className={styles.heroHeader}>
-              <h1 className={styles.heroTitle}>Outfitting Tools</h1>
-              <p className={styles.heroSubtitle}>
-                Ship build intelligence is in fabrication. Stay tuned for modular loadouts and curated upgrade paths.
-              </p>
-            </div>
-          </div>
+          <h2>Outfitting Tools</h2>
+          <h3 className='text-primary'>Ship build intelligence is in fabrication.</h3>
+          <p className='text-primary'>Stay tuned for modular loadouts and curated upgrade paths.</p>
 
           <div className={styles.shell}>
             <div className={styles.placeholder}>Outfitting consoles are coming online soon.</div>

--- a/src/client/pages/inara/search.js
+++ b/src/client/pages/inara/search.js
@@ -12,14 +12,9 @@ export default function InaraSearchPage() {
     <Layout connected={connected} active={active}>
       <Panel layout='full-width' scrollable navigation={navItems} className={styles.inaraPanel}>
         <div className={styles.inara}>
-          <div className={styles.hero}>
-            <div className={styles.heroHeader}>
-              <h1 className={styles.heroTitle}>Signal Search</h1>
-              <p className={styles.heroSubtitle}>
-                Global lookup is recalibrating to the new assimilation backbone. Search returns soon.
-              </p>
-            </div>
-          </div>
+          <h2>Signal Search</h2>
+          <h3 className='text-primary'>Global lookup is recalibrating to the new assimilation backbone.</h3>
+          <p className='text-primary'>Search returns soon.</p>
 
           <div className={styles.shell}>
             <div className={styles.placeholder}>General search is temporarily disabled.</div>

--- a/src/client/pages/inara/status.js
+++ b/src/client/pages/inara/status.js
@@ -2233,8 +2233,13 @@ function MissionsPanel () {
         className={`${styles.tablePanel} layout__panel--secondary-navigation`}
       >
         <div className={styles.tableSectionHeader}>
-          <h2 className={styles.tableSectionTitle}>Mining Missions</h2>
-          <p className={styles.sectionHint}>INARA decrypts volunteer manifests to shortlist mining opportunities aligned to your current system.</p>
+          <h2>Mining Missions</h2>
+          <h3 className='text-primary'>
+            INARA decrypts volunteer manifests to shortlist mining opportunities aligned to your current system.
+          </h3>
+          <p className='text-primary'>
+            Availability signals originate from INARA contributors and may trail live mission boards.
+          </p>
           <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
             <div>
               <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
@@ -2246,9 +2251,6 @@ function MissionsPanel () {
               </div>
             )}
           </div>
-          <p style={{ color: 'var(--inara-muted)', marginTop: '-0.5rem' }}>
-            Availability signals originate from INARA contributors and may trail live mission boards.
-          </p>
           {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
         </div>
         <div className='inara-panel-table'>
@@ -3029,32 +3031,34 @@ function CargoHoldPanel () {
         className={`${styles.tablePanel} layout__panel--secondary-navigation`}
       >
         <div className={styles.tableSectionHeader}>
-        <h2 className={styles.tableSectionTitle}>Cargo Hold</h2>
-        <p className={styles.sectionHint}>Monitor mining hauls, track capacity in real time, and surface the most lucrative buyers across nearby systems.</p>
-        <div className={styles.cargoProgress}>
-          <div className={styles.cargoProgressHeader}>
-            <span className={styles.cargoProgressLabel}>Cargo Hold Utilisation</span>
-            <span className={styles.cargoProgressValue}>{cargoFillDescriptor}</span>
+          <h2>Cargo Hold</h2>
+          <h3 className='text-primary'>
+            Monitor mining hauls, track capacity in real time, and surface the most lucrative buyers across nearby systems.
+          </h3>
+          <div className={styles.cargoProgress}>
+            <div className={styles.cargoProgressHeader}>
+              <span className={styles.cargoProgressLabel}>Cargo Hold Utilisation</span>
+              <span className={styles.cargoProgressValue}>{cargoFillDescriptor}</span>
+            </div>
+            <div
+              className={styles.cargoProgressTrack}
+              role='progressbar'
+              aria-label='Cargo hold utilisation'
+              aria-valuemin={0}
+              aria-valuemax={cargoMeterMax}
+              aria-valuenow={cargoMeterNow}
+              aria-valuetext={cargoMeterValueText}
+            >
+              <span className={styles.cargoProgressFill} style={{ width: `${cargoFillPercent}%` }} />
+            </div>
           </div>
-          <div
-            className={styles.cargoProgressTrack}
-            role='progressbar'
-            aria-label='Cargo hold utilisation'
-            aria-valuemin={0}
-            aria-valuemax={cargoMeterMax}
-            aria-valuenow={cargoMeterNow}
-            aria-valuetext={cargoMeterValueText}
-          >
-            <span className={styles.cargoProgressFill} style={{ width: `${cargoFillPercent}%` }} />
+          <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
+            <div>
+              <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
+              <div className='inara-accent' style={CURRENT_SYSTEM_NAME_STYLE}>{currentSystemName || 'Unknown'}</div>
+            </div>
           </div>
         </div>
-        <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
-          <div>
-            <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
-            <div className='inara-accent' style={CURRENT_SYSTEM_NAME_STYLE}>{currentSystemName || 'Unknown'}</div>
-          </div>
-        </div>
-      </div>
 
       <div className={`${styles.sectionFrameElevated} ${styles.sectionPaddingTight}`}>
         <div className={styles.metricGrid}>
@@ -4629,9 +4633,13 @@ function TradeRoutesPanel ({ onStatusChange = () => {} }) {
       >
         <div className={styles.tradeRoutesControls}>
           <div className={styles.tableSectionHeader}>
-            <h2 id='trade-routes-filters-heading' className={styles.tableSectionTitle}>Trade Route Intelligence</h2>
-            <h3 className={styles.tradeRoutesHeroSubtitle}>Plan efficient cargo loops tailored to your current ship.</h3>
-            <p className={styles.tradeRoutesHeroDescription}>Cross-reference INARA freight whispers to surface lucrative corridors suited to your ship profile.</p>
+            <h2 id='trade-routes-filters-heading'>Trade Route Intelligence</h2>
+            <h3 className='text-primary'>
+              Plan efficient cargo loops tailored to your current ship.
+            </h3>
+            <p className='text-primary'>
+              Cross-reference INARA freight whispers to surface lucrative corridors suited to your ship profile.
+            </p>
           </div>
           <TradeRouteFilterPanel
             filters={filters}
@@ -5152,8 +5160,13 @@ function PristineMiningPanel () {
         className={`${styles.tablePanel} layout__panel--secondary-navigation`}
       >
         <div className={styles.tableSectionHeader}>
-          <h2 className={styles.tableSectionTitle}>Pristine Mining Locations</h2>
-          <p className={styles.sectionHint}>INARA listens for rare reserve chatter across the network to pinpoint high-value extraction sites.</p>
+          <h2>Pristine Mining Locations</h2>
+          <h3 className='text-primary'>
+            INARA listens for rare reserve chatter across the network to pinpoint high-value extraction sites.
+          </h3>
+          <p className='text-primary'>
+            Geological echoes are sourced from volunteer INARA submissions and may lag in-system discoveries.
+          </p>
           <div style={CURRENT_SYSTEM_CONTAINER_STYLE}>
             <div>
               <div style={CURRENT_SYSTEM_LABEL_STYLE}>Current System</div>
@@ -5165,9 +5178,6 @@ function PristineMiningPanel () {
               </div>
             )}
           </div>
-          <p style={{ color: 'var(--inara-muted)', marginTop: '-0.5rem' }}>
-            Geological echoes are sourced from volunteer INARA submissions and may lag in-system discoveries.
-          </p>
           {error && <div style={{ color: '#ff4d4f', textAlign: 'center', marginTop: '1rem' }}>{error}</div>}
         </div>
         <div


### PR DESCRIPTION
## Summary
- restyle the INARA search and outfitting pages to use the shared engineering hero heading hierarchy
- refresh the INARA status panels (mining missions, cargo hold, trade routes, pristine mining) so their hero copy follows the engineering typography treatment

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: Next.js SWC transform rejects the `serverComponents` option in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e47d8d0e448323a0ac7454c96712e3