### PR TITLE
Refine trade route price display spacing

### DIFF
--- a/src/client/pages/inara-workspace.module.css
+++ b/src/client/pages/inara-workspace.module.css
@@ -2245,7 +2245,7 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteCommodityRow {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) max-content;
+  grid-template-columns: minmax(0, 1fr);
   align-items: center;
   gap: 0.35rem;
   min-width: 0;
@@ -2323,11 +2323,62 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tradeRouteCommodityPrice {
-  grid-column: 2;
   color: var(--inara-text-soft);
   font-size: 0.9rem;
   white-space: nowrap;
+  padding: 0.2rem 0.6rem;
+}
+
+.tradeRouteCommodityPriceBuy {
+  justify-self: start;
+  text-align: left;
+  padding-inline-start: 0.75rem;
+}
+
+.tradeRouteCommodityPriceSell {
   justify-self: end;
+  text-align: right;
+  padding-inline-end: 0.75rem;
+}
+
+.tradeRouteCommodityRowReturn .tradeRouteCommodityPriceSell {
+  justify-self: start;
+  text-align: left;
+  padding-inline-start: 0.75rem;
+  padding-inline-end: 0.6rem;
+}
+
+.tradeRouteCommodityRowReturn .tradeRouteCommodityPriceBuy {
+  justify-self: end;
+  text-align: right;
+  padding-inline-end: 0.75rem;
+  padding-inline-start: 0.6rem;
+}
+
+@media (min-width: 1441px) {
+  .tradeRouteCommodityRow {
+    grid-template-columns: max-content minmax(0, 1fr) max-content;
+  }
+
+  .tradeRouteCommodityName {
+    grid-column: 2;
+  }
+
+  .tradeRouteCommodityRowOutbound .tradeRouteCommodityPriceBuy {
+    grid-column: 1;
+  }
+
+  .tradeRouteCommodityRowOutbound .tradeRouteCommodityPriceSell {
+    grid-column: 3;
+  }
+
+  .tradeRouteCommodityRowReturn .tradeRouteCommodityPriceSell {
+    grid-column: 1;
+  }
+
+  .tradeRouteCommodityRowReturn .tradeRouteCommodityPriceBuy {
+    grid-column: 3;
+  }
 }
 
 .tradeRoutePlaceholder {

--- a/src/client/pages/inara/status.js
+++ b/src/client/pages/inara/status.js
@@ -455,7 +455,9 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   const outboundCommodityDisplay = outboundCommodity === '--' ? '' : outboundCommodity
   const returnCommodityDisplay = returnCommodity === '--' ? '' : returnCommodity
   const outboundPriceDisplay = resolvePriceDisplay(outboundInfo.buy, 'Buy')
+  const outboundSellPriceDisplay = resolvePriceDisplay(outboundInfo.sell, 'Sell')
   const returnPriceDisplay = resolvePriceDisplay(returnInfo.buy, 'Buy')
+  const returnSellPriceDisplay = resolvePriceDisplay(returnInfo.sell, 'Sell')
   const outboundDemandState = resolveDemandFlowState(outboundInfo.sell)
   const returnDemandState = resolveDemandFlowState(returnInfo.sell)
   const outboundFlowClass = getDemandFlowClass(outboundDemandState)
@@ -469,6 +471,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   const updatedDisplay = formatRelativeTime(route?.summary?.updated || route?.updatedAt || route?.lastUpdated || route?.timestamp)
 
   const renderValue = value => (value ? value : <span className={styles.tradeRoutePlaceholder}>--</span>)
+  const renderPrice = value => (value ? value : null)
 
   const metricVariantClasses = {
     neutral: styles.metricChipNeutral,
@@ -565,9 +568,12 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                 {outboundDemandState.text ? ` — ${outboundDemandState.text}` : ''}
               </span>
             ) : null}
+            <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteCommodityPriceBuy} ${styles.tradeRouteHideMedium}`}>
+              {renderPrice(outboundPriceDisplay)}
+            </span>
             <span className={styles.tradeRouteCommodityName}>{renderValue(outboundCommodityDisplay)}</span>
-            <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteHideMedium}`}>
-              {renderValue(outboundPriceDisplay)}
+            <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteCommodityPriceSell} ${styles.tradeRouteHideMedium}`}>
+              {renderPrice(outboundSellPriceDisplay)}
             </span>
           </div>
           <div className={`${styles.tradeRouteCommodityRow} ${styles.tradeRouteCommodityRowReturn} ${returnFlowClass}`}>
@@ -578,9 +584,12 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                 {returnDemandState.text ? ` — ${returnDemandState.text}` : ''}
               </span>
             ) : null}
+            <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteCommodityPriceSell} ${styles.tradeRouteHideMedium}`}>
+              {renderPrice(returnSellPriceDisplay)}
+            </span>
             <span className={styles.tradeRouteCommodityName}>{renderValue(returnCommodityDisplay)}</span>
-            <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteHideMedium}`}>
-              {renderValue(returnPriceDisplay)}
+            <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteCommodityPriceBuy} ${styles.tradeRouteHideMedium}`}>
+              {renderPrice(returnPriceDisplay)}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- show trade route buy and sell prices on the appropriate sides of the flow arrow when space allows
- update the trade route commodity row grid so wide viewports display three columns with directional alignment
- hide trade route price labels when no value is available and pad price text so it stays within the arrow

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client`


------
https://chatgpt.com/codex/tasks/task_e_68e567767ee88323b12626f87cd9c516