### PR TITLE
Center trade route profit metrics

### DIFF
--- a/src/client/pages/inara-workspace.module.css
+++ b/src/client/pages/inara-workspace.module.css
@@ -2173,6 +2173,7 @@ button.terminalStatusPreview:focus-visible {
   display: grid;
   gap: 0.4rem;
   min-width: 0;
+  padding: 0.4rem 0 0.45rem;
 }
 
 .tradeRouteStationRow {
@@ -2181,6 +2182,7 @@ button.terminalStatusPreview:focus-visible {
   align-items: stretch;
   gap: 0.75rem;
   min-width: 0;
+  min-height: 4.85rem;
 }
 
 .tradeRouteStationIcon {
@@ -2211,6 +2213,7 @@ button.terminalStatusPreview:focus-visible {
   align-items: flex-start;
   gap: 0.3rem;
   min-width: 0;
+  justify-content: center;
 }
 
 .tradeRouteStationName {
@@ -2401,14 +2404,20 @@ button.terminalStatusPreview:focus-visible {
   text-align: center;
 }
 
+.tradeRouteProfitSpacerCell {
+  padding: 0 !important;
+  border-top: none;
+  background: transparent;
+}
+
 .tradeRouteProfitBanner {
   --trade-route-profit-mix: 18%;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
-  padding: 0.65rem 1.25rem;
+  flex-wrap: wrap;
+  gap: 0.85rem 1.5rem;
+  padding: 0.45rem 1.25rem 0.6rem;
   background: color-mix(in srgb, var(--inara-color-success) var(--trade-route-profit-mix), transparent);
   border-top: 1px solid color-mix(in srgb, var(--inara-color-success) calc(var(--trade-route-profit-mix) + 10%), transparent);
   border-bottom: 1px solid color-mix(in srgb, var(--inara-color-success) calc(var(--trade-route-profit-mix) - 4%), transparent);
@@ -2426,37 +2435,24 @@ button.terminalStatusPreview:focus-visible {
   border-color: color-mix(in srgb, var(--inara-color-success) calc(var(--trade-route-profit-mix) + 16%), transparent);
 }
 
-.tradeRouteProfitTitle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  text-transform: uppercase;
-  font-size: 0.85rem;
-  letter-spacing: 0.22em;
-  color: var(--inara-text-soft);
-}
-
-.tradeRouteProfitTitle :global(svg) {
-  width: 1.2rem;
-  height: 1.2rem;
-  color: var(--inara-color-success);
-  opacity: 0.85;
-}
-
 .tradeRouteProfitInline {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 0.9rem;
+  justify-content: center;
   width: 100%;
 }
 
 .tradeRouteProfitInlineList {
   display: inline-flex;
-  flex-wrap: wrap;
-  gap: 1.35rem;
+  flex: 1 1 auto;
+  flex-wrap: nowrap;
+  gap: 0.85rem 1.5rem;
   align-items: center;
   justify-content: center;
+  min-width: 0;
+  overflow: hidden;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }
 
 .tradeRouteProfitInlineItem {
@@ -2471,10 +2467,10 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tradeRouteProfitInlineLabel {
-  font-size: 0.8rem;
-  letter-spacing: 0.16em;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--inara-color-success) 36%, var(--inara-text-soft));
+  color: color-mix(in srgb, var(--inara-color-success) 40%, var(--inara-text-soft));
 }
 
 .tradeRouteProfitInlineValue {
@@ -2487,6 +2483,26 @@ button.terminalStatusPreview:focus-visible {
   color: color-mix(in srgb, var(--inara-color-success) 16%, var(--inara-text-soft));
   font-weight: 600;
   opacity: 0.75;
+}
+
+.tradeRouteProfitInlineList > * {
+  flex-shrink: 0;
+}
+
+.tradeRouteProfitInlineList::-webkit-scrollbar {
+  display: none;
+}
+
+@media (max-width: 880px) {
+  .tradeRouteProfitMetricHour {
+    display: none !important;
+  }
+}
+
+@media (max-width: 720px) {
+  .tradeRouteProfitMetricTrip {
+    display: none !important;
+  }
 }
 
 @media (max-width: 1440px) {

--- a/src/client/pages/inara/status.js
+++ b/src/client/pages/inara/status.js
@@ -466,6 +466,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
 
   const profitPerTon = formatCredits(route?.summary?.profitPerUnit ?? route?.profitPerUnit, route?.summary?.profitPerUnitText || route?.profitPerUnitText)
   const profitPerTrip = formatCredits(route?.summary?.profitPerTrip, route?.summary?.profitPerTripText)
+  const profitPerHour = formatCredits(route?.summary?.profitPerHour ?? route?.profitPerHour, route?.summary?.profitPerHourText || route?.profitPerHourText)
   const profitPerTonValueRaw = extractProfitPerTon(route)
 
   const updatedDisplay = formatRelativeTime(route?.summary?.updated || route?.updatedAt || route?.lastUpdated || route?.timestamp)
@@ -530,19 +531,16 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   const profitRowClasses = [styles.tradeRouteProfitRowWrapper]
   if (isSelected) profitRowClasses.push(styles.tradeRouteProfitRowWrapperSelected)
 
-  const inlineProfitMetrics = []
+  const profitPerTonDisplay = profitPerTon && profitPerTon !== '--' ? profitPerTon : null
+  const profitPerTripDisplay = profitPerTrip && profitPerTrip !== '--' ? profitPerTrip : null
+  const profitPerHourDisplay = profitPerHour && profitPerHour !== '--' ? profitPerHour : null
 
-  if (profitPerTon && profitPerTon !== '--') {
-    inlineProfitMetrics.push({ key: 'ton', label: 'Ton', value: profitPerTon })
-  }
-
-  if (profitPerTrip && profitPerTrip !== '--') {
-    inlineProfitMetrics.push({ key: 'trip', label: 'Trip', value: profitPerTrip })
-  }
-
-  if (updatedDisplay) {
-    inlineProfitMetrics.push({ key: 'updated', label: 'Last updated', value: updatedDisplay })
-  }
+  const inlineProfitMetrics = [
+    { key: 'ton', label: 'Per/Ton', value: profitPerTonDisplay, metricClass: styles.tradeRouteProfitMetricTon },
+    { key: 'trip', label: 'Per/Trip', value: profitPerTripDisplay, metricClass: styles.tradeRouteProfitMetricTrip },
+    { key: 'hour', label: 'Per/Hour', value: profitPerHourDisplay, metricClass: styles.tradeRouteProfitMetricHour },
+    { key: 'updated', label: 'Last Update', value: updatedDisplay || null }
+  ]
 
   return (
     <>
@@ -661,32 +659,39 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
         onClick={handleClick}
         data-inara-table-row='profit'
       >
-        <td colSpan={3} className={`${styles.tableCellTop} ${styles.tradeRouteProfitCell}`}>
+        <td className={`${styles.tableCellTop} ${styles.tradeRouteProfitSpacerCell}`} aria-hidden='true' />
+        <td className={`${styles.tableCellTop} ${styles.tradeRouteProfitCell}`}>
           <div
             className={`${styles.tradeRouteProfitBanner}${isSelected ? ` ${styles.tradeRouteProfitBannerSelected}` : ''}`}
             style={profitHighlightStyle}
           >
             <div className={styles.tradeRouteProfitInline}>
-              <div className={styles.tradeRouteProfitTitle}>
-                <CreditsIcon size={18} />
-                <span>Profit Outlook</span>
-              </div>
               <div className={styles.tradeRouteProfitInlineList}>
-                {inlineProfitMetrics.map((metric, index) => (
-                  <React.Fragment key={metric.key}>
-                    <div className={styles.tradeRouteProfitInlineItem}>
-                      <span className={styles.tradeRouteProfitInlineLabel}>{metric.label}:</span>
-                      <span className={styles.tradeRouteProfitInlineValue}>{renderValue(metric.value)}</span>
-                    </div>
-                    {index < inlineProfitMetrics.length - 1 ? (
-                      <span className={styles.tradeRouteProfitSeparator} aria-hidden='true'>-</span>
-                    ) : null}
-                  </React.Fragment>
-                ))}
+                {inlineProfitMetrics.map((metric, index) => {
+                  const metricClasses = [styles.tradeRouteProfitInlineItem]
+                  if (metric.metricClass) metricClasses.push(metric.metricClass)
+                  const nextMetric = inlineProfitMetrics[index + 1]
+                  const separatorClasses = [styles.tradeRouteProfitSeparator]
+                  if (metric.metricClass) separatorClasses.push(metric.metricClass)
+                  if (nextMetric?.metricClass) separatorClasses.push(nextMetric.metricClass)
+
+                  return (
+                    <React.Fragment key={metric.key}>
+                      <div className={metricClasses.join(' ')}>
+                        <span className={styles.tradeRouteProfitInlineLabel}>{metric.label}:</span>
+                        <span className={styles.tradeRouteProfitInlineValue}>{renderValue(metric.value)}</span>
+                      </div>
+                      {index < inlineProfitMetrics.length - 1 ? (
+                        <span className={separatorClasses.join(' ')} aria-hidden='true'>|</span>
+                      ) : null}
+                    </React.Fragment>
+                  )
+                })}
               </div>
             </div>
           </div>
         </td>
+        <td className={`${styles.tableCellTop} ${styles.tradeRouteProfitSpacerCell}`} aria-hidden='true' />
       </tr>
     </>
   )
@@ -4640,7 +4645,19 @@ function TradeRoutesPanel ({ onStatusChange = () => {} }) {
                 {renderSortArrow('stationA')}
               </button>
             </th>
-            <th scope='col' aria-sort='none'>Commodities</th>
+            <th
+              scope='col'
+              aria-sort={sortField === 'profit' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+            >
+              <button
+                type='button'
+                className={`${styles.tableHeaderButton} ${sortField === 'profit' ? styles.tableHeaderButtonActive : ''}`}
+                onClick={() => handleSortChange('profit')}
+              >
+                Profit
+                {renderSortArrow('profit')}
+              </button>
+            </th>
             <th
               scope='col'
               aria-sort={sortField === 'stationB' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}


### PR DESCRIPTION
## Summary
- center the trade route profit banner beneath the commodity flow column and collapse it to a single inline row of Per/Ton, Per/Trip, Per/Hour, and Last Update metrics with green profit values
- expand the station columns for a taller presentation while preserving the profit banner at narrow breakpoints and keeping profit-per-ton visible until the smallest widths

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client


------
https://chatgpt.com/codex/tasks/task_e_68e57bb11c0c8323b763cbf1493dd8a8