### PR TITLE
Refine trade route station layout

### DIFF
--- a/src/client/pages/inara-workspace.module.css
+++ b/src/client/pages/inara-workspace.module.css
@@ -1500,10 +1500,10 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRoutesTable {
   --trade-route-caret-column-width: 2.75rem;
-  --trade-route-station-column-width: 19.5rem;
-  --trade-route-profit-column-width: 15rem;
-  --trade-route-commodity-min-width: 18rem;
-  min-width: 1080px;
+  --trade-route-station-column-width: 18rem;
+  --trade-route-profit-column-width: 13.5rem;
+  --trade-route-commodity-min-width: 17rem;
+  min-width: 1020px;
   width: 100%;
   border-collapse: separate;
   border-spacing: 0;
@@ -1538,6 +1538,22 @@ button.terminalStatusPreview:focus-visible {
   min-width: var(--trade-route-commodity-min-width);
 }
 
+.tradeRoutesStationCell {
+  padding: 0.6rem 0.75rem;
+}
+
+.tradeRoutesStationCellOrigin {
+  padding-inline-end: 0.3rem;
+}
+
+.tradeRoutesStationCellDestination {
+  padding-inline-start: 0.3rem;
+}
+
+.tradeRoutesItemCell {
+  padding: 0.6rem 0;
+}
+
 .tradeRoutesTable th:nth-child(4),
 .tradeRoutesTable td:nth-child(4) {
   width: var(--trade-route-profit-column-width);
@@ -1546,31 +1562,31 @@ button.terminalStatusPreview:focus-visible {
 
 @media (max-width: 1680px) {
   .tradeRoutesTable {
-    --trade-route-station-column-width: 18.5rem;
-    --trade-route-profit-column-width: 14.25rem;
+    --trade-route-station-column-width: 17rem;
+    --trade-route-profit-column-width: 12.75rem;
   }
 }
 
 @media (max-width: 1480px) {
   .tradeRoutesTable {
-    --trade-route-station-column-width: 17.5rem;
-    --trade-route-profit-column-width: 13.5rem;
+    --trade-route-station-column-width: 16rem;
+    --trade-route-profit-column-width: 12rem;
   }
 }
 
 @media (max-width: 1320px) {
   .tradeRoutesTable {
-    --trade-route-station-column-width: 16.5rem;
-    --trade-route-profit-column-width: 12.75rem;
-    --trade-route-commodity-min-width: 16.5rem;
+    --trade-route-station-column-width: 15rem;
+    --trade-route-profit-column-width: 11.25rem;
+    --trade-route-commodity-min-width: 15.5rem;
   }
 }
 
 @media (max-width: 1180px) {
   .tradeRoutesTable {
-    --trade-route-station-column-width: 15.5rem;
+    --trade-route-station-column-width: 14rem;
     --trade-route-profit-column-width: 6rem;
-    --trade-route-commodity-min-width: 15.5rem;
+    --trade-route-commodity-min-width: 14.5rem;
   }
 }
 
@@ -2169,20 +2185,23 @@ button.terminalStatusPreview:focus-visible {
   min-width: 0;
 }
 
+
 .tradeRouteStationGrid {
   display: grid;
-  gap: 0.4rem;
   min-width: 0;
-  padding: 0.4rem 0 0.45rem;
+  padding: 0.2rem 0;
+  height: 100%;
+  align-content: stretch;
+  grid-auto-rows: 1fr;
 }
 
 .tradeRouteStationRow {
   display: grid;
-  grid-template-columns: minmax(2.75rem, max-content) minmax(calc(var(--trade-route-station-column-width, 18.5rem) - 3.25rem), 1fr);
+  grid-template-columns: minmax(2.45rem, max-content) minmax(calc(var(--trade-route-station-column-width, 18rem) - 2.9rem), 1fr);
   align-items: stretch;
-  gap: 0.75rem;
+  gap: 0.55rem;
   min-width: 0;
-  min-height: 4.85rem;
+  min-height: 100%;
 }
 
 .tradeRouteStationIcon {
@@ -2190,10 +2209,10 @@ button.terminalStatusPreview:focus-visible {
   align-items: center;
   justify-content: center;
   align-self: stretch;
-  padding: 0.15rem;
-  min-width: 2.6rem;
-  min-height: 2.6rem;
-  max-width: 3.2rem;
+  padding: 0.1rem;
+  min-width: 2.35rem;
+  min-height: 2.35rem;
+  max-width: 3rem;
   height: 100%;
   max-height: 100%;
   color: var(--inara-accent);
@@ -2211,9 +2230,10 @@ button.terminalStatusPreview:focus-visible {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.3rem;
+  gap: 0.25rem;
   min-width: 0;
   justify-content: center;
+  height: 100%;
 }
 
 .tradeRouteStationName {
@@ -2244,6 +2264,7 @@ button.terminalStatusPreview:focus-visible {
   display: grid;
   gap: 0.45rem;
   min-width: 0;
+  height: 100%;
 }
 
 .tradeRouteCommodityRow {
@@ -2253,7 +2274,7 @@ button.terminalStatusPreview:focus-visible {
   gap: 0.35rem;
   min-width: 0;
   position: relative;
-  padding: 0.4rem 0.75rem;
+  padding: 0.4rem 0.65rem;
   border-radius: 0.75rem;
   overflow: hidden;
   z-index: 0;
@@ -2491,6 +2512,12 @@ button.terminalStatusPreview:focus-visible {
 
 .tradeRouteProfitInlineList::-webkit-scrollbar {
   display: none;
+}
+
+@media (max-width: 1040px) {
+  .tradeRouteProfitMetricUpdated {
+    display: none !important;
+  }
 }
 
 @media (max-width: 880px) {

--- a/src/client/pages/inara/status.js
+++ b/src/client/pages/inara/status.js
@@ -539,7 +539,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
     { key: 'ton', label: 'Per/Ton', value: profitPerTonDisplay, metricClass: styles.tradeRouteProfitMetricTon },
     { key: 'trip', label: 'Per/Trip', value: profitPerTripDisplay, metricClass: styles.tradeRouteProfitMetricTrip },
     { key: 'hour', label: 'Per/Hour', value: profitPerHourDisplay, metricClass: styles.tradeRouteProfitMetricHour },
-    { key: 'updated', label: 'Last Update', value: updatedDisplay || null }
+    { key: 'updated', label: 'Last Update', value: updatedDisplay || null, metricClass: styles.tradeRouteProfitMetricUpdated }
   ]
 
   return (
@@ -555,7 +555,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
         aria-pressed={isSelected}
         data-selected={isSelected ? 'true' : 'false'}
       >
-        <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell}`}>
+        <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell} ${styles.tradeRoutesStationCellOrigin}`}>
           <div className={styles.tradeRouteStationGrid}>
             <div className={styles.tradeRouteStationRow}>
               <span
@@ -622,7 +622,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
             </div>
           </div>
         </td>
-        <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell}`}>
+        <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell} ${styles.tradeRoutesStationCellDestination}`}>
           <div className={styles.tradeRouteStationGrid}>
             <div className={styles.tradeRouteStationRow}>
               <span


### PR DESCRIPTION
## Summary
- tighten the trade route station cells to reduce horizontal padding and let station tiles fill the row height
- adjust trade route commodity flow spacing and breakpoints so profit metrics hide in the required order on smaller widths

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Next.js cannot load the linux/x64 SWC binary in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5888daa308323843e975d99e803b8