### PR TITLE
Polish compact trade route layout details

### DIFF
--- a/src/client/pages/inara-workspace.module.css
+++ b/src/client/pages/inara-workspace.module.css
@@ -91,6 +91,7 @@
 .inara {
   position: relative;
   min-height: 100%;
+  --inara-viewport-height: 100vh;
   --inara-terminal-height: clamp(180px, 18vh, 220px);
   --inara-bg: var(--inara-color-background);
   --inara-panel: color-mix(in srgb, var(--inara-color-background) 88%, transparent);
@@ -133,6 +134,18 @@
     var(--inara-bg);
   color: var(--inara-ink);
   overflow: hidden;
+}
+
+@supports (height: 100svh) {
+  .inara {
+    --inara-viewport-height: 100svh;
+  }
+}
+
+@supports (height: 100dvh) {
+  .inara {
+    --inara-viewport-height: 100dvh;
+  }
 }
 
 .inaraIcarus {
@@ -2169,6 +2182,18 @@ button.terminalStatusPreview:focus-visible {
   min-width: 0;
 }
 
+.tradeRouteStationStack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.tradeRouteStationCompact {
+  display: none;
+  min-width: 0;
+}
+
 .tradeRouteStationGrid {
   display: grid;
   gap: 0.4rem;
@@ -2259,6 +2284,15 @@ button.terminalStatusPreview:focus-visible {
   z-index: 0;
   justify-content: flex-start;
   --trade-route-flow-fill: rgba(93, 46, 255, 0.24);
+  --trade-route-flow-pointer: 1.65rem;
+}
+
+.tradeRouteCommodityRowCompact {
+  grid-template-columns: minmax(0, 1fr);
+  justify-items: flex-start;
+  text-align: left;
+  gap: 0.4rem;
+  --trade-route-flow-pointer: 1.25rem;
 }
 
 .tradeRouteCommodityRow > * {
@@ -2277,11 +2311,23 @@ button.terminalStatusPreview:focus-visible {
 }
 
 .tradeRouteCommodityRowOutbound::before {
-  clip-path: polygon(0 0, calc(100% - 1.65rem) 0, 100% 50%, calc(100% - 1.65rem) 100%, 0 100%);
+  clip-path: polygon(
+    0 0,
+    calc(100% - var(--trade-route-flow-pointer)) 0,
+    100% 50%,
+    calc(100% - var(--trade-route-flow-pointer)) 100%,
+    0 100%
+  );
 }
 
 .tradeRouteCommodityRowReturn::before {
-  clip-path: polygon(1.65rem 0, 100% 0, 100% 100%, 1.65rem 100%, 0 50%);
+  clip-path: polygon(
+    var(--trade-route-flow-pointer) 0,
+    100% 0,
+    100% 100%,
+    var(--trade-route-flow-pointer) 100%,
+    0 50%
+  );
 }
 
 .tradeRouteFlowNeutral {
@@ -2330,6 +2376,10 @@ button.terminalStatusPreview:focus-visible {
   font-size: 0.9rem;
   white-space: nowrap;
   padding: 0.2rem 0.6rem;
+}
+
+.tradeRouteCommodityPriceCompact {
+  padding-inline: 0;
 }
 
 .tradeRouteCommodityPriceBuy {
@@ -2450,7 +2500,8 @@ button.terminalStatusPreview:focus-visible {
   align-items: center;
   justify-content: center;
   min-width: 0;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
@@ -2520,6 +2571,91 @@ button.terminalStatusPreview:focus-visible {
 @media (max-width: 1120px) {
   .tradeRouteHideNarrow {
     display: none !important;
+  }
+}
+
+@media (max-width: 720px) {
+  .tradeRoutesTable {
+    min-width: 0;
+  }
+
+  .tradeRoutesTable thead th:nth-child(2) {
+    display: none;
+  }
+
+  .tradeRoutesItemCell {
+    display: none;
+  }
+
+  .tradeRouteCommodityGrid {
+    display: none;
+  }
+
+  .tradeRouteStationStack {
+    gap: 0.6rem;
+  }
+
+  .tradeRouteStationCompact {
+    display: grid;
+    gap: 0.45rem;
+  }
+
+  .tradeRouteCommodityRowCompact {
+    padding: 0.6rem 0.75rem;
+  }
+
+  .tradeRouteCommodityRowCompact .tradeRouteCommodityName {
+    text-align: left;
+  }
+
+  .tradeRouteCommodityPriceCompact {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  .tradeRouteStationRow {
+    min-height: 0;
+  }
+
+  .tradeRouteStationChips {
+    justify-content: flex-start;
+  }
+
+  .tradeRouteProfitRowWrapper {
+    display: block;
+  }
+
+  .tradeRouteProfitRowWrapper td:not(:first-child):not(:last-child) {
+    display: block;
+    width: 100%;
+  }
+
+  .tradeRouteProfitRowWrapper td:first-child,
+  .tradeRouteProfitRowWrapper td:last-child {
+    display: none;
+  }
+
+  .tradeRouteProfitCell {
+    padding: 0 !important;
+    width: 100%;
+  }
+
+  .tradeRouteProfitBanner {
+    border-radius: 0.75rem;
+    padding-inline: 1rem;
+    width: 100%;
+  }
+
+  .tradeRouteProfitInline {
+    justify-content: flex-start;
+  }
+
+  .tradeRouteProfitInlineList {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    gap: 0.65rem 1rem;
+    padding-block: 0.2rem;
   }
 }
 

--- a/src/client/pages/inara/status.js
+++ b/src/client/pages/inara/status.js
@@ -474,6 +474,66 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   const renderValue = value => (value ? value : <span className={styles.tradeRoutePlaceholder}>--</span>)
   const renderPrice = value => (value ? value : null)
 
+  const renderCommodityRow = (direction, { variant = 'default' } = {}) => {
+    const isOutbound = direction === 'outbound'
+    const commodityDisplay = isOutbound ? outboundCommodityDisplay : returnCommodityDisplay
+    const buyPriceDisplay = isOutbound ? outboundPriceDisplay : returnPriceDisplay
+    const sellPriceDisplay = isOutbound ? outboundSellPriceDisplay : returnSellPriceDisplay
+    const demandState = isOutbound ? outboundDemandState : returnDemandState
+    const flowClass = isOutbound ? outboundFlowClass : returnFlowClass
+    const stationAria = isOutbound ? destinationStationAria : originStationAria
+    const directionLabel = isOutbound ? 'Outbound to' : 'Return to'
+
+    const rowClasses = [
+      styles.tradeRouteCommodityRow,
+      isOutbound ? styles.tradeRouteCommodityRowOutbound : styles.tradeRouteCommodityRowReturn,
+      flowClass
+    ]
+
+    const leadingPriceClasses = [
+      styles.tradeRouteCommodityPrice,
+      isOutbound ? styles.tradeRouteCommodityPriceBuy : styles.tradeRouteCommodityPriceSell
+    ]
+
+    const trailingPriceClasses = [
+      styles.tradeRouteCommodityPrice,
+      isOutbound ? styles.tradeRouteCommodityPriceSell : styles.tradeRouteCommodityPriceBuy
+    ]
+
+    if (variant === 'compact') {
+      rowClasses.push(styles.tradeRouteCommodityRowCompact)
+      leadingPriceClasses.push(styles.visuallyHidden)
+      trailingPriceClasses.push(styles.visuallyHidden)
+    }
+
+    if (variant !== 'compact') {
+      leadingPriceClasses.push(styles.tradeRouteHideMedium)
+      trailingPriceClasses.push(styles.tradeRouteHideMedium)
+    } else {
+      leadingPriceClasses.push(styles.tradeRouteCommodityPriceCompact)
+      trailingPriceClasses.push(styles.tradeRouteCommodityPriceCompact)
+    }
+
+    return (
+      <div className={rowClasses.join(' ')}>
+        <span className={styles.visuallyHidden}>{`${directionLabel} ${stationAria}`}</span>
+        {demandState ? (
+          <span className={styles.visuallyHidden}>
+            {demandState.label}
+            {demandState.text ? ` — ${demandState.text}` : ''}
+          </span>
+        ) : null}
+        <span className={leadingPriceClasses.join(' ')}>
+          {renderPrice(isOutbound ? buyPriceDisplay : sellPriceDisplay)}
+        </span>
+        <span className={styles.tradeRouteCommodityName}>{renderValue(commodityDisplay)}</span>
+        <span className={trailingPriceClasses.join(' ')}>
+          {renderPrice(isOutbound ? sellPriceDisplay : buyPriceDisplay)}
+        </span>
+      </div>
+    )
+  }
+
   const metricVariantClasses = {
     neutral: styles.metricChipNeutral,
     success: styles.metricChipSuccess,
@@ -556,98 +616,78 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
         data-selected={isSelected ? 'true' : 'false'}
       >
         <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell}`}>
-          <div className={styles.tradeRouteStationGrid}>
-            <div className={styles.tradeRouteStationRow}>
-              <span
-                className={styles.tradeRouteStationIcon}
-                title={originStandingDisplay.title || undefined}
-              >
-                {originIconName
-                  ? <StationIcon icon={originIconName} color={originStandingDisplay.iconColor} size='100%' />
-                  : null}
-              </span>
-              <div className={styles.tradeRouteStationContent}>
-                <span className={styles.tradeRouteStationName} title={originStationDisplay || undefined}>{renderValue(originStationDisplay)}</span>
-                <span className={styles.tradeRouteStationSystem} title={originSystemName || undefined}>{renderValue(originSystemName)}</span>
-                <div className={styles.tradeRouteStationChips}>
-                  {renderMetricChip({
-                    value: originSystemDistanceDisplay,
-                    variant: originSystemDistanceVariant,
-                    title: 'Distance to system',
-                    color: originSystemDistanceColor || undefined
-                  })}
-                  {renderMetricChip({
-                    value: originStationDistanceDisplay,
-                    variant: originStationDistanceVariant,
-                    title: 'Distance to station'
-                  })}
+          <div className={styles.tradeRouteStationStack}>
+            <div className={styles.tradeRouteStationGrid}>
+              <div className={styles.tradeRouteStationRow}>
+                <span
+                  className={styles.tradeRouteStationIcon}
+                  title={originStandingDisplay.title || undefined}
+                >
+                  {originIconName
+                    ? <StationIcon icon={originIconName} color={originStandingDisplay.iconColor} size='100%' />
+                    : null}
+                </span>
+                <div className={styles.tradeRouteStationContent}>
+                  <span className={styles.tradeRouteStationName} title={originStationDisplay || undefined}>{renderValue(originStationDisplay)}</span>
+                  <span className={styles.tradeRouteStationSystem} title={originSystemName || undefined}>{renderValue(originSystemName)}</span>
+                  <div className={styles.tradeRouteStationChips}>
+                    {renderMetricChip({
+                      value: originSystemDistanceDisplay,
+                      variant: originSystemDistanceVariant,
+                      title: 'Distance to system',
+                      color: originSystemDistanceColor || undefined
+                    })}
+                    {renderMetricChip({
+                      value: originStationDistanceDisplay,
+                      variant: originStationDistanceVariant,
+                      title: 'Distance to station'
+                    })}
+                  </div>
                 </div>
               </div>
+            </div>
+            <div className={styles.tradeRouteStationCompact}>
+              {renderCommodityRow('outbound', { variant: 'compact' })}
             </div>
           </div>
         </td>
         <td className={`${styles.tableCellTop} ${styles.tradeRoutesItemCell}`}>
           <div className={styles.tradeRouteCommodityGrid}>
-            <div className={`${styles.tradeRouteCommodityRow} ${styles.tradeRouteCommodityRowOutbound} ${outboundFlowClass}`}>
-              <span className={styles.visuallyHidden}>Outbound to {destinationStationAria}</span>
-              {outboundDemandState ? (
-                <span className={styles.visuallyHidden}>
-                  {outboundDemandState.label}
-                  {outboundDemandState.text ? ` — ${outboundDemandState.text}` : ''}
-                </span>
-              ) : null}
-              <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteCommodityPriceBuy} ${styles.tradeRouteHideMedium}`}>
-              {renderPrice(outboundPriceDisplay)}
-            </span>
-            <span className={styles.tradeRouteCommodityName}>{renderValue(outboundCommodityDisplay)}</span>
-              <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteCommodityPriceSell} ${styles.tradeRouteHideMedium}`}>
-                {renderPrice(outboundSellPriceDisplay)}
-              </span>
-            </div>
-            <div className={`${styles.tradeRouteCommodityRow} ${styles.tradeRouteCommodityRowReturn} ${returnFlowClass}`}>
-              <span className={styles.visuallyHidden}>Return to {originStationAria}</span>
-              {returnDemandState ? (
-                <span className={styles.visuallyHidden}>
-                  {returnDemandState.label}
-                  {returnDemandState.text ? ` — ${returnDemandState.text}` : ''}
-                </span>
-              ) : null}
-              <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteCommodityPriceSell} ${styles.tradeRouteHideMedium}`}>
-              {renderPrice(returnSellPriceDisplay)}
-            </span>
-            <span className={styles.tradeRouteCommodityName}>{renderValue(returnCommodityDisplay)}</span>
-              <span className={`${styles.tradeRouteCommodityPrice} ${styles.tradeRouteCommodityPriceBuy} ${styles.tradeRouteHideMedium}`}>
-                {renderPrice(returnPriceDisplay)}
-              </span>
-            </div>
+            {renderCommodityRow('outbound')}
+            {renderCommodityRow('return')}
           </div>
         </td>
         <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell}`}>
-          <div className={styles.tradeRouteStationGrid}>
-            <div className={styles.tradeRouteStationRow}>
-              <span
-                className={styles.tradeRouteStationIcon}
-                title={destinationStandingDisplay.title || undefined}
-              >
-                {destinationIconName
-                  ? <StationIcon icon={destinationIconName} color={destinationStandingDisplay.iconColor} size='100%' />
-                  : null}
-              </span>
-              <div className={styles.tradeRouteStationContent}>
-                <span className={styles.tradeRouteStationName} title={destinationStationDisplay || undefined}>{renderValue(destinationStationDisplay)}</span>
-                <span className={styles.tradeRouteStationSystem} title={destinationSystemName || undefined}>{renderValue(destinationSystemName)}</span>
-                <div className={styles.tradeRouteStationChips}>
-                  {renderMetricChip({
-                    value: destinationSystemDistanceDisplay,
-                    variant: destinationSystemDistanceVariant,
-                    title: 'Distance to system',
-                    color: destinationSystemDistanceColor || undefined
-                  })}
-                  {renderMetricChip({
-                    value: destinationStationDistanceDisplay,
-                    variant: destinationStationDistanceVariant,
-                    title: 'Distance to station'
-                  })}
+          <div className={styles.tradeRouteStationStack}>
+            <div className={styles.tradeRouteStationCompact}>
+              {renderCommodityRow('return', { variant: 'compact' })}
+            </div>
+            <div className={styles.tradeRouteStationGrid}>
+              <div className={styles.tradeRouteStationRow}>
+                <span
+                  className={styles.tradeRouteStationIcon}
+                  title={destinationStandingDisplay.title || undefined}
+                >
+                  {destinationIconName
+                    ? <StationIcon icon={destinationIconName} color={destinationStandingDisplay.iconColor} size='100%' />
+                    : null}
+                </span>
+                <div className={styles.tradeRouteStationContent}>
+                  <span className={styles.tradeRouteStationName} title={destinationStationDisplay || undefined}>{renderValue(destinationStationDisplay)}</span>
+                  <span className={styles.tradeRouteStationSystem} title={destinationSystemName || undefined}>{renderValue(destinationSystemName)}</span>
+                  <div className={styles.tradeRouteStationChips}>
+                    {renderMetricChip({
+                      value: destinationSystemDistanceDisplay,
+                      variant: destinationSystemDistanceVariant,
+                      title: 'Distance to system',
+                      color: destinationSystemDistanceColor || undefined
+                    })}
+                    {renderMetricChip({
+                      value: destinationStationDistanceDisplay,
+                      variant: destinationStationDistanceVariant,
+                      title: 'Distance to station'
+                    })}
+                  </div>
                 </div>
               </div>
             </div>
@@ -703,8 +743,16 @@ function normaliseName (value) {
 
 const MISSIONS_CACHE_KEY = 'icarus.inaraMiningMissions.v1'
 const MISSIONS_CACHE_LIMIT = 8
-const TABLE_SCROLL_AREA_STYLE = { maxHeight: 'calc(100vh - 360px)', overflowY: 'auto' }
-const STATION_TABLE_SCROLL_AREA_STYLE = { maxHeight: 'calc(100vh - 340px)', overflowY: 'auto' }
+const TABLE_SCROLL_AREA_STYLE = {
+  minHeight: 'max(0px, calc(var(--inara-viewport-height, 100vh) - 360px))',
+  maxHeight: 'max(0px, calc(var(--inara-viewport-height, 100vh) - 360px))',
+  overflowY: 'auto'
+}
+const STATION_TABLE_SCROLL_AREA_STYLE = {
+  minHeight: 'max(0px, calc(var(--inara-viewport-height, 100vh) - 340px))',
+  maxHeight: 'max(0px, calc(var(--inara-viewport-height, 100vh) - 340px))',
+  overflowY: 'auto'
+}
 
 function getMissionsCacheStorage () {
   if (typeof window === 'undefined') {


### PR DESCRIPTION
## Summary
- hide buy/sell prices on compact trade route flow arrows, keep the return arrow above Station B, and restore arrowheads for the narrowest layout
- update responsive styling so compact flow arrows sit beneath/above their stations, the profit banner spans both stations on the smallest breakpoint, and its metrics remain visible as space allows
- align scrollable panel heights with the viewport using CSS vars so list views reach the bottom edge on compact screens

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: Failed to load SWC binary for linux/x64)*

------
https://chatgpt.com/codex/tasks/task_e_68e58d54cf7083239e1037e8609cdf23