### PR TITLE
Fix duplicate station columns in INARA trade routes table

### DIFF
--- a/src/client/pages/inara/status.js
+++ b/src/client/pages/inara/status.js
@@ -615,7 +615,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
         aria-pressed={isSelected}
         data-selected={isSelected ? 'true' : 'false'}
       >
-        <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell}`}>
+        <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell} ${styles.tradeRoutesStationCellOrigin}`}>
           <div className={styles.tradeRouteStationStack}>
             <div className={styles.tradeRouteStationGrid}>
               <div className={styles.tradeRouteStationRow}>
@@ -642,38 +642,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                       variant: originStationDistanceVariant,
                       title: 'Distance to station'
                     })}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </td>
-        <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell} ${styles.tradeRoutesStationCellOrigin}`}>
-          <div className={styles.tradeRouteStationGrid}>
-            <div className={styles.tradeRouteStationRow}>
-              <span
-                className={styles.tradeRouteStationIcon}
-                title={originStandingDisplay.title || undefined}
-              >
-                {originIconName
-                  ? <StationIcon icon={originIconName} color={originStandingDisplay.iconColor} size='100%' />
-                  : null}
-              </span>
-              <div className={styles.tradeRouteStationContent}>
-                <span className={styles.tradeRouteStationName} title={originStationDisplay || undefined}>{renderValue(originStationDisplay)}</span>
-                <span className={styles.tradeRouteStationSystem} title={originSystemName || undefined}>{renderValue(originSystemName)}</span>
-                <div className={styles.tradeRouteStationChips}>
-                  {renderMetricChip({
-                    value: originSystemDistanceDisplay,
-                    variant: originSystemDistanceVariant,
-                    title: 'Distance to system',
-                    color: originSystemDistanceColor || undefined
-                  })}
-                  {renderMetricChip({
-                    value: originStationDistanceDisplay,
-                    variant: originStationDistanceVariant,
-                    title: 'Distance to station'
-                  })}
+                  </div>
                 </div>
               </div>
             </div>
@@ -688,7 +657,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
             {renderCommodityRow('return')}
           </div>
         </td>
-        <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell}`}>
+        <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell} ${styles.tradeRoutesStationCellDestination}`}>
           <div className={styles.tradeRouteStationStack}>
             <div className={styles.tradeRouteStationCompact}>
               {renderCommodityRow('return', { variant: 'compact' })}
@@ -718,38 +687,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                       variant: destinationStationDistanceVariant,
                       title: 'Distance to station'
                     })}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </td>
-        <td className={`${styles.tableCellTop} ${styles.tradeRoutesStationCell} ${styles.tradeRoutesStationCellDestination}`}>
-          <div className={styles.tradeRouteStationGrid}>
-            <div className={styles.tradeRouteStationRow}>
-              <span
-                className={styles.tradeRouteStationIcon}
-                title={destinationStandingDisplay.title || undefined}
-              >
-                {destinationIconName
-                  ? <StationIcon icon={destinationIconName} color={destinationStandingDisplay.iconColor} size='100%' />
-                  : null}
-              </span>
-              <div className={styles.tradeRouteStationContent}>
-                <span className={styles.tradeRouteStationName} title={destinationStationDisplay || undefined}>{renderValue(destinationStationDisplay)}</span>
-                <span className={styles.tradeRouteStationSystem} title={destinationSystemName || undefined}>{renderValue(destinationSystemName)}</span>
-                <div className={styles.tradeRouteStationChips}>
-                  {renderMetricChip({
-                    value: destinationSystemDistanceDisplay,
-                    variant: destinationSystemDistanceVariant,
-                    title: 'Distance to system',
-                    color: destinationSystemDistanceColor || undefined
-                  })}
-                  {renderMetricChip({
-                    value: destinationStationDistanceDisplay,
-                    variant: destinationStationDistanceVariant,
-                    title: 'Distance to station'
-                  })}
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- restore the trade route table row structure to the intended three-column layout
- keep the compact commodity chips within the station cells while applying the new origin/destination padding helpers

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: Failed to load SWC binary for linux/x64)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ab15bebc8323aaa7342e305850a0