### PR TITLE
feat: configurable distance and update thresholds

### DIFF
--- a/src/client/components/panels/inara/commodity-summary.js
+++ b/src/client/components/panels/inara/commodity-summary.js
@@ -13,7 +13,12 @@ import {
   formatSystemDistance
 } from 'lib/inara-formatters'
 import { stationIconFromType } from 'lib/station-icons'
-import getDistanceSeverityColor from 'lib/distance-colors'
+import {
+  getDistanceSeverity,
+  getStationDistanceSeverity,
+  getUpdateSeverity
+} from 'lib/distance-colors'
+import { useInaraThresholdSettingsContext } from 'lib/inara-thresholds'
 
 export function CommodityIcon ({ category, size = 26 }) {
   const config = getCommodityIconConfig(category)
@@ -50,13 +55,15 @@ function buildMetrics (entries) {
       return {
         label: typeof entry.label === 'string' ? entry.label : entry.label,
         value: entry.value,
-        priority: Boolean(entry.priority)
+        priority: Boolean(entry.priority),
+        color: entry.color
       }
     })
     .filter(Boolean)
 }
 
 export default function CommoditySummary ({ summary, shipSourceSegment, className, valueIcon, shipJumpRange }) {
+  const thresholdSettings = useInaraThresholdSettingsContext()
   const memoized = useMemo(() => {
     if (!summary) return null
 
@@ -73,8 +80,13 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
       : '--'
 
     const summarySystemDistance = formatSystemDistance(summary.distanceLy, summary.distanceLyText)
-    const summaryDistanceColor = getDistanceSeverityColor(summary.distanceLy, shipJumpRange)
+    const summaryDistanceSeverity = getDistanceSeverity(summary.distanceLy, shipJumpRange, { thresholds: thresholdSettings })
     const summaryStationDistance = formatStationDistance(summary.distanceLs, summary.distanceLsText)
+    const summaryStationSeverity = getStationDistanceSeverity(summary.distanceLs, { thresholds: thresholdSettings })
+    const summaryUpdatedRaw = summary.updatedAt || null
+    const summaryUpdatedSeverity = summaryUpdatedRaw
+      ? getUpdateSeverity(summaryUpdatedRaw, { thresholds: thresholdSettings })
+      : { color: null }
     const summaryUpdated = summary.updatedAt
       ? formatRelativeTime(summary.updatedAt)
       : (summary.updatedText || '')
@@ -99,6 +111,10 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
     const originName = summary.originStationName || 'Local Market'
     const originSystem = summary.originSystemName || ''
     const originType = summary.originStationType || ''
+    const originUpdatedRaw = summary.originUpdatedAt || null
+    const originUpdatedSeverity = originUpdatedRaw
+      ? getUpdateSeverity(originUpdatedRaw, { thresholds: thresholdSettings })
+      : { color: null }
     const originUpdated = summary.originUpdatedAt
       ? formatRelativeTime(summary.originUpdatedAt)
       : (summary.originUpdatedText || '')
@@ -128,7 +144,7 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
       sourceMetrics.push({ label: 'Buy', value: localPriceDisplay, priority: true })
     }
     if (originUpdated) {
-      sourceMetrics.push({ label: 'Updated', value: originUpdated })
+      sourceMetrics.push({ label: 'Updated', value: originUpdated, color: originUpdatedSeverity.color })
     }
 
     const destinationMetrics = []
@@ -139,7 +155,7 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
       destinationMetrics.push({ label: 'Demand', value: summaryDemandIndicator, priority: true })
     }
     if (summaryUpdated) {
-      destinationMetrics.push({ label: 'Updated', value: summaryUpdated })
+      destinationMetrics.push({ label: 'Updated', value: summaryUpdated, color: summaryUpdatedSeverity.color })
     }
 
     const valueSecondaryParts = []
@@ -151,7 +167,8 @@ export default function CommoditySummary ({ summary, shipSourceSegment, classNam
       label: 'Distance',
       value: summarySystemDistance || '',
       secondary: summaryStationDistance || '',
-      valueColor: summaryDistanceColor || undefined
+      valueColor: summaryDistanceSeverity.color || undefined,
+      secondaryColor: summaryStationSeverity.color || undefined
     }
 
     const sourceSegment = shipSourceSegment

--- a/src/client/components/panels/inara/transfer-context-summary.js
+++ b/src/client/components/panels/inara/transfer-context-summary.js
@@ -30,7 +30,8 @@ function StationSegment ({ icon, name, color, subtexts, metrics, ariaLabel }) {
           const priority = typeof metric.priority === 'boolean'
             ? metric.priority
             : /supply|demand|buy|sell|profit/i.test(`${label} ${value}`)
-          return { label, value, priority }
+          const color = typeof metric.color === 'string' && metric.color.trim() ? metric.color : undefined
+          return { label, value, priority, color }
         })
         .filter(Boolean)
     : []
@@ -64,7 +65,16 @@ function StationSegment ({ icon, name, color, subtexts, metrics, ariaLabel }) {
             return (
               <div key={`station-metric-${index}`} className={metricClass.join(' ')}>
                 {metric.label ? <span className={styles.metricLabel}>{metric.label}</span> : null}
-                {metric.value ? <span className={styles.metricValue}>{metric.value}</span> : null}
+                {metric.value
+                  ? (
+                      <span
+                        className={styles.metricValue}
+                        style={metric.color ? { color: metric.color } : undefined}
+                      >
+                        {metric.value}
+                      </span>
+                    )
+                  : null}
               </div>
             )
           })}
@@ -92,7 +102,8 @@ StationSegment.propTypes = {
     PropTypes.shape({
       label: PropTypes.node,
       value: PropTypes.node,
-      priority: PropTypes.bool
+      priority: PropTypes.bool,
+      color: PropTypes.string
     })
   ),
   ariaLabel: PropTypes.string
@@ -152,10 +163,11 @@ CommoditySegment.propTypes = {
   ariaLabel: PropTypes.string
 }
 
-function DistanceSegment ({ label, value, secondary, valueColor }) {
+function DistanceSegment ({ label, value, secondary, valueColor, secondaryColor }) {
   if (!label && !value && !secondary) return null
 
   const valueStyle = valueColor ? { color: valueColor } : undefined
+  const secondaryStyle = secondaryColor ? { color: secondaryColor } : valueStyle
 
   return (
     <div className={`${styles.segment} ${styles.distanceSegment}`}>
@@ -166,7 +178,7 @@ function DistanceSegment ({ label, value, secondary, valueColor }) {
       {value ? <span className={styles.distanceValue} style={valueStyle}>{sanitizeText(value)}</span> : null}
       {secondary
         ? (
-            <span className={`${styles.distanceSecondary} ${styles.optionalWide}`} style={valueStyle}>
+            <span className={`${styles.distanceSecondary} ${styles.optionalWide}`} style={secondaryStyle}>
               {sanitizeText(secondary)}
             </span>
           )
@@ -179,14 +191,16 @@ DistanceSegment.defaultProps = {
   label: '',
   value: '',
   secondary: '',
-  valueColor: ''
+  valueColor: '',
+  secondaryColor: ''
 }
 
 DistanceSegment.propTypes = {
   label: PropTypes.string,
   value: PropTypes.string,
   secondary: PropTypes.string,
-  valueColor: PropTypes.string
+  valueColor: PropTypes.string,
+  secondaryColor: PropTypes.string
 }
 
 function ValueSegment ({ icon, label, value, secondary }) {

--- a/src/client/components/settings.js
+++ b/src/client/components/settings.js
@@ -2,6 +2,39 @@ import { useState, useEffect, Fragment } from 'react'
 import { sendEvent, eventListener } from 'lib/socket'
 import { SettingsNavItems } from 'lib/navigation-items'
 import packageJson from '../../../package.json'
+import {
+  DEFAULT_INARA_THRESHOLD_SETTINGS,
+  sanitizeInaraThresholdSettings,
+  loadInaraThresholdSettings,
+  saveInaraThresholdSettings,
+  subscribeToInaraThresholdSettings
+} from 'lib/inara-thresholds'
+
+const INITIAL_THRESHOLD_INPUTS = formatThresholdInputs(DEFAULT_INARA_THRESHOLD_SETTINGS)
+
+function formatNumberInput (value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  if (typeof value === 'string') return value
+  return ''
+}
+
+function formatThresholdInputs (settings) {
+  const sanitized = sanitizeInaraThresholdSettings(settings)
+  return {
+    systemDistance: {
+      greenMultiplier: formatNumberInput(sanitized.systemDistance.greenMultiplier),
+      redMultiplier: formatNumberInput(sanitized.systemDistance.redMultiplier)
+    },
+    stationDistance: {
+      green: formatNumberInput(sanitized.stationDistance.green),
+      red: formatNumberInput(sanitized.stationDistance.red)
+    },
+    updateHours: {
+      green: formatNumberInput(sanitized.updateHours.green),
+      red: formatNumberInput(sanitized.updateHours.red)
+    }
+  }
+}
 
 function Settings ({ visible, toggleVisible = () => {}, defaultActiveSettingsPanel = 'Theme' }) {
   const [activeSettingsPanel, setActiveSettingsPanel] = useState(defaultActiveSettingsPanel)
@@ -60,19 +93,40 @@ function Settings ({ visible, toggleVisible = () => {}, defaultActiveSettingsPan
 
 function InaraSettings () {
   const [useMockData, setUseMockData] = useState(false)
+  const [thresholdInputs, setThresholdInputs] = useState(INITIAL_THRESHOLD_INPUTS)
   const [saved, setSaved] = useState(false)
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       setUseMockData(window.localStorage.getItem('inaraUseMockData') === 'true')
+      setThresholdInputs(formatThresholdInputs(loadInaraThresholdSettings()))
+    }
+    const unsubscribe = subscribeToInaraThresholdSettings(settings => {
+      setThresholdInputs(formatThresholdInputs(settings))
+    })
+    return () => {
+      if (typeof unsubscribe === 'function') unsubscribe()
     }
   }, [])
+
+  const handleThresholdChange = (section, key, value) => {
+    setThresholdInputs(current => ({
+      ...current,
+      [section]: {
+        ...current[section],
+        [key]: value
+      }
+    }))
+  }
 
   function handleSave (event) {
     event.preventDefault()
     if (typeof window !== 'undefined') {
       window.localStorage.setItem('inaraUseMockData', useMockData ? 'true' : 'false')
     }
+    const sanitizedThresholds = sanitizeInaraThresholdSettings(thresholdInputs)
+    setThresholdInputs(formatThresholdInputs(sanitizedThresholds))
+    saveInaraThresholdSettings(sanitizedThresholds)
     setSaved(true)
     setTimeout(() => setSaved(false), 1500)
   }
@@ -92,6 +146,90 @@ function InaraSettings () {
             Enable Trade Route Layout Sandbox (use mock data)
           </span>
         </label>
+        <div style={{ marginBottom: '1.5rem' }}>
+          <h4 className='text-primary' style={{ marginBottom: '.5rem' }}>Distance &amp; Update Thresholds</h4>
+          <p className='text-muted' style={{ marginTop: 0 }}>
+            Customize when system and station distances, along with update timestamps, transition between green, blue, yellow,
+            and red indicators.
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <section>
+              <h5 className='text-primary' style={{ margin: 0, fontSize: '0.95rem' }}>System Distance (× jump range)</h5>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '0.75rem', marginTop: '.65rem' }}>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '.25rem' }}>
+                  <span className='text-muted'>Brightest green ≤</span>
+                  <input
+                    type='number'
+                    min='0'
+                    step='0.1'
+                    value={thresholdInputs.systemDistance.greenMultiplier}
+                    onChange={event => handleThresholdChange('systemDistance', 'greenMultiplier', event.target.value)}
+                  />
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '.25rem' }}>
+                  <span className='text-muted'>Brightest red ≥</span>
+                  <input
+                    type='number'
+                    min='0'
+                    step='0.1'
+                    value={thresholdInputs.systemDistance.redMultiplier}
+                    onChange={event => handleThresholdChange('systemDistance', 'redMultiplier', event.target.value)}
+                  />
+                </label>
+              </div>
+            </section>
+            <section>
+              <h5 className='text-primary' style={{ margin: 0, fontSize: '0.95rem' }}>Station Distance (light seconds)</h5>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '0.75rem', marginTop: '.65rem' }}>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '.25rem' }}>
+                  <span className='text-muted'>Brightest green ≤</span>
+                  <input
+                    type='number'
+                    min='0'
+                    step='1'
+                    value={thresholdInputs.stationDistance.green}
+                    onChange={event => handleThresholdChange('stationDistance', 'green', event.target.value)}
+                  />
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '.25rem' }}>
+                  <span className='text-muted'>Brightest red ≥</span>
+                  <input
+                    type='number'
+                    min='0'
+                    step='1'
+                    value={thresholdInputs.stationDistance.red}
+                    onChange={event => handleThresholdChange('stationDistance', 'red', event.target.value)}
+                  />
+                </label>
+              </div>
+            </section>
+            <section>
+              <h5 className='text-primary' style={{ margin: 0, fontSize: '0.95rem' }}>Time Since Update (hours)</h5>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '0.75rem', marginTop: '.65rem' }}>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '.25rem' }}>
+                  <span className='text-muted'>Brightest green ≤</span>
+                  <input
+                    type='number'
+                    min='0'
+                    step='0.5'
+                    value={thresholdInputs.updateHours.green}
+                    onChange={event => handleThresholdChange('updateHours', 'green', event.target.value)}
+                  />
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '.25rem' }}>
+                  <span className='text-muted'>Brightest red ≥</span>
+                  <input
+                    type='number'
+                    min='0'
+                    step='0.5'
+                    value={thresholdInputs.updateHours.red}
+                    onChange={event => handleThresholdChange('updateHours', 'red', event.target.value)}
+                  />
+                </label>
+              </div>
+            </section>
+          </div>
+        </div>
         <button type='submit' style={{ fontSize: '1.1rem' }}>{saved ? 'Saved!' : 'Save'}</button>
       </form>
     </div>

--- a/src/client/lib/distance-colors.js
+++ b/src/client/lib/distance-colors.js
@@ -1,27 +1,160 @@
+import { DEFAULT_INARA_THRESHOLD_SETTINGS } from './inara-thresholds'
+
+const COLOR_SCALE = [
+  { stop: 0, color: 'var(--color-success)' },
+  { stop: 0.34, color: 'var(--color-info)' },
+  { stop: 0.67, color: 'var(--color-primary)' },
+  { stop: 1, color: 'var(--color-danger)' }
+]
+
+function clamp (value, min, max) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function mixColors (startColor, endColor, ratio) {
+  const normalized = clamp(ratio, 0, 1)
+  if (normalized <= 0) return startColor
+  if (normalized >= 1) return endColor
+  const weightEnd = Math.round(normalized * 100)
+  const weightStart = 100 - weightEnd
+  if (weightEnd === 0) return startColor
+  if (weightEnd === 100) return endColor
+  return `color-mix(in srgb, ${startColor} ${weightStart}%, ${endColor} ${weightEnd}%)`
+}
+
+function normalizeThresholds (green, red) {
+  const safeGreen = Number.isFinite(green) ? green : null
+  const safeRed = Number.isFinite(red) ? red : null
+  if (safeGreen === null || safeRed === null) return null
+  if (safeRed <= safeGreen) {
+    return {
+      green: safeGreen,
+      red: safeGreen + Math.max(1, Math.abs(safeGreen) * 0.25)
+    }
+  }
+  return { green: safeGreen, red: safeRed }
+}
+
+function getRatio (value, green, red) {
+  if (!Number.isFinite(value)) return null
+  const thresholds = normalizeThresholds(green, red)
+  if (!thresholds) return null
+  if (value <= thresholds.green) return 0
+  if (value >= thresholds.red) return 1
+  return (value - thresholds.green) / (thresholds.red - thresholds.green)
+}
+
+function getColorFromRatio (ratio) {
+  if (!Number.isFinite(ratio)) return null
+  const normalized = clamp(ratio, 0, 1)
+  if (normalized <= 0) return COLOR_SCALE[0].color
+  if (normalized >= 1) return COLOR_SCALE[COLOR_SCALE.length - 1].color
+  for (let index = 0; index < COLOR_SCALE.length - 1; index += 1) {
+    const start = COLOR_SCALE[index]
+    const end = COLOR_SCALE[index + 1]
+    if (normalized >= start.stop && normalized <= end.stop) {
+      const span = end.stop - start.stop
+      if (span <= 0) continue
+      const segmentRatio = (normalized - start.stop) / span
+      return mixColors(start.color, end.color, segmentRatio)
+    }
+  }
+  return COLOR_SCALE[COLOR_SCALE.length - 1].color
+}
+
+function getVariantFromRatio (ratio) {
+  if (!Number.isFinite(ratio)) return 'neutral'
+  if (ratio <= 0) return 'success'
+  if (ratio >= 1) return 'warning'
+  return ratio <= 0.5 ? 'caution' : 'warning'
+}
+
+function resolveThresholds (settings = DEFAULT_INARA_THRESHOLD_SETTINGS) {
+  return settings || DEFAULT_INARA_THRESHOLD_SETTINGS
+}
+
+function resolveSystemThresholds (settings) {
+  const thresholds = resolveThresholds(settings)
+  return thresholds.systemDistance || DEFAULT_INARA_THRESHOLD_SETTINGS.systemDistance
+}
+
+function resolveStationThresholds (settings) {
+  const thresholds = resolveThresholds(settings)
+  return thresholds.stationDistance || DEFAULT_INARA_THRESHOLD_SETTINGS.stationDistance
+}
+
+function resolveUpdateThresholds (settings) {
+  const thresholds = resolveThresholds(settings)
+  return thresholds.updateHours || DEFAULT_INARA_THRESHOLD_SETTINGS.updateHours
+}
+
+function buildSeverity (value, greenThreshold, redThreshold) {
+  const ratio = getRatio(value, greenThreshold, redThreshold)
+  if (ratio === null) {
+    return { color: null, variant: 'neutral', ratio: null }
+  }
+  const color = getColorFromRatio(ratio)
+  const variant = getVariantFromRatio(ratio)
+  return { color, variant, ratio }
+}
+
+export function getDistanceSeverity (distanceLy, jumpRangeLy, options = {}) {
+  if (!Number.isFinite(distanceLy)) {
+    return { color: null, variant: 'neutral', ratio: null }
+  }
+
+  const thresholds = resolveSystemThresholds(options.thresholds)
+  const jumpRangeValid = Number.isFinite(jumpRangeLy) && jumpRangeLy > 0
+  const greenThreshold = jumpRangeValid
+    ? jumpRangeLy * thresholds.greenMultiplier
+    : thresholds.fallbackGreenLy
+  const redThreshold = jumpRangeValid
+    ? jumpRangeLy * thresholds.redMultiplier
+    : thresholds.fallbackRedLy
+
+  return buildSeverity(distanceLy, greenThreshold, redThreshold)
+}
+
 export function getDistanceSeverityColor (distanceLy, jumpRangeLy, options = {}) {
-  const maxMultiplier = typeof options.maxMultiplier === 'number' && options.maxMultiplier > 1
-    ? options.maxMultiplier
-    : 5
+  return getDistanceSeverity(distanceLy, jumpRangeLy, options).color
+}
 
-  if (!Number.isFinite(distanceLy) || !Number.isFinite(jumpRangeLy) || jumpRangeLy <= 0) {
-    return null
+export function getStationDistanceSeverity (distanceLs, options = {}) {
+  if (!Number.isFinite(distanceLs)) {
+    return { color: null, variant: 'neutral', ratio: null }
   }
+  const thresholds = resolveStationThresholds(options.thresholds)
+  return buildSeverity(distanceLs, thresholds.green, thresholds.red)
+}
 
-  if (distanceLy <= 0 || distanceLy <= jumpRangeLy) {
-    return 'var(--color-success)'
+export function getStationDistanceSeverityColor (distanceLs, options = {}) {
+  return getStationDistanceSeverity(distanceLs, options).color
+}
+
+export function resolveHoursSince (value) {
+  if (Number.isFinite(value)) {
+    return value
   }
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  const diffMs = Date.now() - date.getTime()
+  if (!Number.isFinite(diffMs) || diffMs < 0) return 0
+  return diffMs / (1000 * 60 * 60)
+}
 
-  const ratio = Math.max(1, distanceLy / jumpRangeLy)
-  const cappedRatio = Math.min(ratio, maxMultiplier)
-  const normalized = (cappedRatio - 1) / (maxMultiplier - 1)
-  const warningWeight = Math.min(100, Math.max(0, Math.round(normalized * 100)))
-  const successWeight = 100 - warningWeight
-
-  if (warningWeight === 100) {
-    return 'var(--color-danger)'
+export function getUpdateSeverity (hoursSince, options = {}) {
+  const normalizedHours = resolveHoursSince(hoursSince)
+  if (!Number.isFinite(normalizedHours)) {
+    return { color: null, variant: 'neutral', ratio: null, hours: null }
   }
+  const thresholds = resolveUpdateThresholds(options.thresholds)
+  const severity = buildSeverity(normalizedHours, thresholds.green, thresholds.red)
+  return { ...severity, hours: normalizedHours }
+}
 
-  return `color-mix(in srgb, var(--color-success) ${successWeight}%, var(--color-danger) ${warningWeight}%)`
+export function getUpdateSeverityColor (hoursSince, options = {}) {
+  return getUpdateSeverity(hoursSince, options).color
 }
 
 export default getDistanceSeverityColor

--- a/src/client/lib/inara-thresholds.js
+++ b/src/client/lib/inara-thresholds.js
@@ -1,0 +1,173 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+export const DEFAULT_INARA_THRESHOLD_SETTINGS = {
+  systemDistance: {
+    greenMultiplier: 1,
+    redMultiplier: 3,
+    fallbackGreenLy: 15,
+    fallbackRedLy: 35
+  },
+  stationDistance: {
+    green: 1000,
+    red: 20000
+  },
+  updateHours: {
+    green: 8,
+    red: 24
+  }
+}
+
+export const INARA_THRESHOLD_STORAGE_KEY = 'inara-threshold-settings'
+export const INARA_THRESHOLD_EVENT = 'inara-threshold-settings-updated'
+
+export const InaraThresholdSettingsContext = createContext(DEFAULT_INARA_THRESHOLD_SETTINGS)
+
+export function useInaraThresholdSettingsContext () {
+  return useContext(InaraThresholdSettingsContext)
+}
+
+function toFiniteNumber (value) {
+  const parsed = typeof value === 'string' && value.trim() !== '' ? Number(value) : value
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function sanitizeSystemDistanceSettings (input = {}) {
+  const defaults = DEFAULT_INARA_THRESHOLD_SETTINGS.systemDistance
+  const result = {
+    greenMultiplier: defaults.greenMultiplier,
+    redMultiplier: defaults.redMultiplier,
+    fallbackGreenLy: defaults.fallbackGreenLy,
+    fallbackRedLy: defaults.fallbackRedLy
+  }
+
+  const greenMultiplier = toFiniteNumber(input.greenMultiplier)
+  if (greenMultiplier !== null && greenMultiplier > 0) {
+    result.greenMultiplier = greenMultiplier
+  }
+
+  const redMultiplier = toFiniteNumber(input.redMultiplier)
+  if (redMultiplier !== null && redMultiplier > 0) {
+    result.redMultiplier = Math.max(redMultiplier, result.greenMultiplier + 0.01)
+  }
+
+  const fallbackGreen = toFiniteNumber(input.fallbackGreenLy)
+  if (fallbackGreen !== null && fallbackGreen >= 0) {
+    result.fallbackGreenLy = fallbackGreen
+  }
+
+  const fallbackRed = toFiniteNumber(input.fallbackRedLy)
+  if (fallbackRed !== null && fallbackRed >= 0) {
+    result.fallbackRedLy = Math.max(fallbackRed, result.fallbackGreenLy + 0.01)
+  }
+
+  if (result.redMultiplier <= result.greenMultiplier) {
+    result.redMultiplier = result.greenMultiplier + 0.01
+  }
+
+  if (result.fallbackRedLy <= result.fallbackGreenLy) {
+    result.fallbackRedLy = result.fallbackGreenLy + 1
+  }
+
+  return result
+}
+
+function sanitizeRangeSettings (input = {}, defaults) {
+  const result = { green: defaults.green, red: defaults.red }
+  const green = toFiniteNumber(input.green)
+  if (green !== null && green >= 0) {
+    result.green = green
+  }
+  const red = toFiniteNumber(input.red)
+  if (red !== null && red >= 0) {
+    result.red = Math.max(red, result.green + 1)
+  }
+  if (result.red <= result.green) {
+    result.red = result.green + 1
+  }
+  return result
+}
+
+export function sanitizeInaraThresholdSettings (input) {
+  if (!input || typeof input !== 'object') return DEFAULT_INARA_THRESHOLD_SETTINGS
+  return {
+    systemDistance: sanitizeSystemDistanceSettings(input.systemDistance),
+    stationDistance: sanitizeRangeSettings(input.stationDistance, DEFAULT_INARA_THRESHOLD_SETTINGS.stationDistance),
+    updateHours: sanitizeRangeSettings(input.updateHours, DEFAULT_INARA_THRESHOLD_SETTINGS.updateHours)
+  }
+}
+
+export function loadInaraThresholdSettings () {
+  if (typeof window === 'undefined') {
+    return DEFAULT_INARA_THRESHOLD_SETTINGS
+  }
+
+  try {
+    const raw = window.localStorage.getItem(INARA_THRESHOLD_STORAGE_KEY)
+    if (!raw) return DEFAULT_INARA_THRESHOLD_SETTINGS
+    const parsed = JSON.parse(raw)
+    return sanitizeInaraThresholdSettings(parsed)
+  } catch (err) {
+    console.error('Unable to read INARA threshold settings from localStorage', err)
+    return DEFAULT_INARA_THRESHOLD_SETTINGS
+  }
+}
+
+export function saveInaraThresholdSettings (settings) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    const sanitized = sanitizeInaraThresholdSettings(settings)
+    window.localStorage.setItem(INARA_THRESHOLD_STORAGE_KEY, JSON.stringify(sanitized))
+    window.dispatchEvent(new CustomEvent(INARA_THRESHOLD_EVENT, { detail: sanitized }))
+  } catch (err) {
+    console.error('Unable to save INARA threshold settings to localStorage', err)
+  }
+}
+
+export function subscribeToInaraThresholdSettings (callback = () => {}) {
+  if (typeof window === 'undefined') {
+    return () => {}
+  }
+
+  const handleCustomEvent = event => {
+    if (event?.detail) {
+      callback(sanitizeInaraThresholdSettings(event.detail))
+    } else {
+      callback(loadInaraThresholdSettings())
+    }
+  }
+
+  const handleStorageEvent = event => {
+    if (event.key && event.key !== INARA_THRESHOLD_STORAGE_KEY) return
+    callback(loadInaraThresholdSettings())
+  }
+
+  window.addEventListener(INARA_THRESHOLD_EVENT, handleCustomEvent)
+  window.addEventListener('storage', handleStorageEvent)
+
+  return () => {
+    window.removeEventListener(INARA_THRESHOLD_EVENT, handleCustomEvent)
+    window.removeEventListener('storage', handleStorageEvent)
+  }
+}
+
+export function useInaraThresholdSettings () {
+  const [settings, setSettings] = useState(DEFAULT_INARA_THRESHOLD_SETTINGS)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    setSettings(loadInaraThresholdSettings())
+    const unsubscribe = subscribeToInaraThresholdSettings(setSettings)
+    return () => {
+      if (typeof unsubscribe === 'function') {
+        unsubscribe()
+      }
+    }
+  }, [])
+
+  return settings
+}
+
+export default DEFAULT_INARA_THRESHOLD_SETTINGS

--- a/src/client/pages/inara/status.js
+++ b/src/client/pages/inara/status.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback, Fragment } from 'react'
+import React, { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback, useContext, Fragment } from 'react'
 import Layout from 'components/layout'
 import Panel from 'components/panel'
 import Icons from 'lib/icons'
@@ -12,7 +12,15 @@ import animateTableEffect from 'lib/animate-table-effect'
 import { useSocket, sendEvent, eventListener } from 'lib/socket'
 import { getShipLandingPadSize } from 'lib/ship-pad-sizes'
 import { formatCredits, formatRelativeTime, formatStationDistance, formatSystemDistance } from 'lib/inara-formatters'
-import getDistanceSeverityColor from 'lib/distance-colors'
+import {
+  getDistanceSeverity,
+  getStationDistanceSeverity,
+  getUpdateSeverity
+} from 'lib/distance-colors'
+import {
+  InaraThresholdSettingsContext,
+  useInaraThresholdSettings
+} from 'lib/inara-thresholds'
 import { sanitizeInaraText } from 'lib/sanitize-inara-text'
 import { stationIconFromType, getStationIconName } from 'lib/station-icons'
 import { createMockCargoManifest, createMockCommodityValuations, generateMockTradeRoutes, NON_COMMODITY_KEYS, normaliseCommodityKey } from 'lib/inara-mock-data'
@@ -415,6 +423,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   shipJumpRange = null,
   maxProfitPerTon = 0
 }) {
+  const thresholdSettings = useContext(InaraThresholdSettingsContext)
   const originLocal = route?.origin?.local
   const destinationLocal = route?.destination?.local
 
@@ -469,7 +478,9 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
   const profitPerHour = formatCredits(route?.summary?.profitPerHour ?? route?.profitPerHour, route?.summary?.profitPerHourText || route?.profitPerHourText)
   const profitPerTonValueRaw = extractProfitPerTon(route)
 
-  const updatedDisplay = formatRelativeTime(route?.summary?.updated || route?.updatedAt || route?.lastUpdated || route?.timestamp)
+  const updatedSource = route?.summary?.updated || route?.updatedAt || route?.lastUpdated || route?.timestamp || null
+  const updatedDisplay = updatedSource ? formatRelativeTime(updatedSource) : ''
+  const updatedSeverity = getUpdateSeverity(updatedSource, { thresholds: thresholdSettings })
 
   const renderValue = value => (value ? value : <span className={styles.tradeRoutePlaceholder}>--</span>)
   const renderPrice = value => (value ? value : null)
@@ -502,12 +513,16 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
     )
   }
 
-  const originStationDistanceVariant = getStationDistanceVariant(originStationDistance.value)
-  const destinationStationDistanceVariant = getStationDistanceVariant(destinationStationDistance.value)
-  const originSystemDistanceVariant = getSystemDistanceVariant(originSystemDistance.value, shipJumpRange)
-  const destinationSystemDistanceVariant = getSystemDistanceVariant(destinationSystemDistance.value, shipJumpRange)
-  const originSystemDistanceColor = getDistanceSeverityColor(originSystemDistance.value, shipJumpRange)
-  const destinationSystemDistanceColor = getDistanceSeverityColor(destinationSystemDistance.value, shipJumpRange)
+  const originStationSeverity = getStationDistanceSeverity(originStationDistance.value, { thresholds: thresholdSettings })
+  const destinationStationSeverity = getStationDistanceSeverity(destinationStationDistance.value, { thresholds: thresholdSettings })
+  const originSystemSeverity = getDistanceSeverity(originSystemDistance.value, shipJumpRange, { thresholds: thresholdSettings })
+  const destinationSystemSeverity = getDistanceSeverity(destinationSystemDistance.value, shipJumpRange, { thresholds: thresholdSettings })
+  const originStationDistanceVariant = originStationSeverity.variant || 'neutral'
+  const destinationStationDistanceVariant = destinationStationSeverity.variant || 'neutral'
+  const originSystemDistanceVariant = originSystemSeverity.variant || 'neutral'
+  const destinationSystemDistanceVariant = destinationSystemSeverity.variant || 'neutral'
+  const originSystemDistanceColor = originSystemSeverity.color
+  const destinationSystemDistanceColor = destinationSystemSeverity.color
 
   const handleClick = () => onSelect(route)
   const handleKeyDown = event => onKeyDown(event, route)
@@ -539,7 +554,7 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
     { key: 'ton', label: 'Per/Ton', value: profitPerTonDisplay, metricClass: styles.tradeRouteProfitMetricTon },
     { key: 'trip', label: 'Per/Trip', value: profitPerTripDisplay, metricClass: styles.tradeRouteProfitMetricTrip },
     { key: 'hour', label: 'Per/Hour', value: profitPerHourDisplay, metricClass: styles.tradeRouteProfitMetricHour },
-    { key: 'updated', label: 'Last Update', value: updatedDisplay || null, metricClass: styles.tradeRouteProfitMetricUpdated }
+    { key: 'updated', label: 'Last Update', value: updatedDisplay || null, metricClass: styles.tradeRouteProfitMetricUpdated, color: updatedSeverity.color }
   ]
 
   return (
@@ -579,7 +594,8 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                   {renderMetricChip({
                     value: originStationDistanceDisplay,
                     variant: originStationDistanceVariant,
-                    title: 'Distance to station'
+                    title: 'Distance to station',
+                    color: originStationSeverity.color || undefined
                   })}
                 </div>
               </div>
@@ -646,7 +662,8 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                   {renderMetricChip({
                     value: destinationStationDistanceDisplay,
                     variant: destinationStationDistanceVariant,
-                    title: 'Distance to station'
+                    title: 'Distance to station',
+                    color: destinationStationSeverity.color || undefined
                   })}
                 </div>
               </div>
@@ -679,7 +696,12 @@ const TradeRouteTableRow = React.memo(function TradeRouteTableRow ({
                     <React.Fragment key={metric.key}>
                       <div className={metricClasses.join(' ')}>
                         <span className={styles.tradeRouteProfitInlineLabel}>{metric.label}:</span>
-                        <span className={styles.tradeRouteProfitInlineValue}>{renderValue(metric.value)}</span>
+                        <span
+                          className={styles.tradeRouteProfitInlineValue}
+                          style={metric.color ? { color: metric.color } : undefined}
+                        >
+                          {renderValue(metric.value)}
+                        </span>
                       </div>
                       {index < inlineProfitMetrics.length - 1 ? (
                         <span className={separatorClasses.join(' ')} aria-hidden='true'>|</span>
@@ -1512,27 +1534,6 @@ function resolveStationDistance (station = {}) {
   }
 }
 
-function getStationDistanceVariant (value) {
-  if (typeof value !== 'number' || Number.isNaN(value)) return 'neutral'
-  if (value <= 500) return 'success'
-  if (value <= 1500) return 'caution'
-  return 'warning'
-}
-
-function getSystemDistanceVariant (value, jumpRange) {
-  if (typeof value !== 'number' || Number.isNaN(value)) return 'neutral'
-  if (typeof jumpRange !== 'number' || Number.isNaN(jumpRange) || jumpRange <= 0) {
-    if (value <= 15) return 'success'
-    if (value <= 35) return 'caution'
-    return 'warning'
-  }
-
-  const ratio = value / jumpRange
-  if (ratio <= 1) return 'success'
-  if (ratio <= 2) return 'caution'
-  return 'warning'
-}
-
 function resolveStationSystemDistance (route, type) {
   const target = type === 'destination' ? route?.destination : route?.origin
   const local = target?.local || {}
@@ -2089,6 +2090,7 @@ function MissionsPanel () {
   const [factionStandings, setFactionStandings] = useState({})
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [lastUpdatedAt, setLastUpdatedAt] = useState(null)
+  const thresholdSettings = useContext(InaraThresholdSettingsContext)
 
   const displayMessage = useMemo(() => {
     if (typeof message !== 'string') return ''
@@ -2346,7 +2348,11 @@ function MissionsPanel () {
                 {missions.map((mission, index) => {
                   const key = `${mission.system || 'unknown'}-${mission.faction || 'faction'}-${index}`
                   const distanceDisplay = formatSystemDistance(mission.distanceLy, mission.distanceText)
+                  const distanceSeverity = getDistanceSeverity(mission.distanceLy ?? null, null, { thresholds: thresholdSettings })
                   const updatedDisplay = formatRelativeTime(mission.updatedAt || mission.updatedText)
+                  const updatedSeverity = mission.updatedAt
+                    ? getUpdateSeverity(mission.updatedAt, { thresholds: thresholdSettings })
+                    : { color: null }
                   const isTargetSystem = mission.isTargetSystem
                   const factionKey = normaliseFactionKey(mission.faction)
                   const factionInfo = factionKey ? factionStandings[factionKey] : null
@@ -2388,8 +2394,24 @@ function MissionsPanel () {
                             : '--'}
                         </div>
                       </td>
-                      <td className={`${styles.tableCellTop} hidden-small text-right`}>{distanceDisplay || '--'}</td>
-                      <td className={`${styles.tableCellTop} hidden-small text-right`}>{updatedDisplay || mission.updatedText || '--'}</td>
+                      <td className={`${styles.tableCellTop} hidden-small text-right`}>
+                        {distanceDisplay
+                          ? (
+                              <span style={distanceSeverity.color ? { color: distanceSeverity.color } : undefined}>
+                                {distanceDisplay}
+                              </span>
+                            )
+                          : '--'}
+                      </td>
+                      <td className={`${styles.tableCellTop} hidden-small text-right`}>
+                        {updatedDisplay
+                          ? (
+                              <span style={updatedSeverity.color ? { color: updatedSeverity.color } : undefined}>
+                                {updatedDisplay}
+                              </span>
+                            )
+                          : (mission.updatedText || '--')}
+                      </td>
                     </tr>
                   )
                 })}
@@ -3216,9 +3238,13 @@ function CargoHoldPanel () {
           const originSystem = sanitizedOrigin?.systemName || ''
           const originType = sanitizedOrigin?.stationType || ''
           const originIconName = originStationName ? stationIconFromType(originType || '') : null
-          const originUpdated = sanitizedOrigin?.updatedAt
+          const originUpdatedRaw = sanitizedOrigin?.updatedAt || null
+          const originUpdated = originUpdatedRaw
             ? formatRelativeTime(sanitizedOrigin.updatedAt)
             : (sanitizedOrigin?.updatedText || '')
+          const originUpdatedSeverity = originUpdatedRaw
+            ? getUpdateSeverity(originUpdatedRaw, { thresholds: thresholdSettings })
+            : { color: null }
           const originDemandIndicator = sanitizedOrigin?.demandText
             ? (
                 <DemandIndicator
@@ -3241,7 +3267,7 @@ function CargoHoldPanel () {
             sourceMetrics.push({ label: 'Demand', value: originDemandIndicator, priority: true })
           }
           if (originUpdated) {
-            sourceMetrics.push({ label: 'Updated', value: originUpdated })
+            sourceMetrics.push({ label: 'Updated', value: originUpdated, color: originUpdatedSeverity.color })
           }
           const destinationMetrics = []
           if (selectedPriceDisplay && selectedPriceDisplay !== '--') {
@@ -3250,8 +3276,12 @@ function CargoHoldPanel () {
           if (selectedDemandIndicator) {
             destinationMetrics.push({ label: 'Demand', value: selectedDemandIndicator, priority: true })
           }
+          const selectedUpdatedRaw = resolvedListing?.updatedAt || null
+          const selectedUpdatedSeverity = selectedUpdatedRaw
+            ? getUpdateSeverity(selectedUpdatedRaw, { thresholds: thresholdSettings })
+            : { color: null }
           if (selectedUpdated) {
-            destinationMetrics.push({ label: 'Updated', value: selectedUpdated })
+            destinationMetrics.push({ label: 'Updated', value: selectedUpdated, color: selectedUpdatedSeverity.color })
           }
           const quantityDisplay = Number(detail.quantity || 0).toLocaleString()
           const quantityText = quantityDisplay ? `${quantityDisplay} t` : ''
@@ -3270,12 +3300,14 @@ function CargoHoldPanel () {
             detail.commoditySymbol && detail.commoditySymbol !== detail.commodityName ? detail.commoditySymbol : null,
             profitPerUnitDisplay && profitPerUnitDisplay !== '--' ? `Profit/t ${profitPerUnitDisplay}` : null
           ].filter(Boolean)
-          const distanceColor = getDistanceSeverityColor(resolvedListing?.distanceLy ?? null, ship?.maxJumpRange ?? null)
+          const distanceSeverity = getDistanceSeverity(resolvedListing?.distanceLy ?? null, ship?.maxJumpRange ?? null, { thresholds: thresholdSettings })
+          const stationDistanceSeverity = getStationDistanceSeverity(resolvedListing?.distanceLs ?? null, { thresholds: thresholdSettings })
           const distanceSegment = {
             label: 'Distance',
             value: selectedSystemDistance || '',
             secondary: selectedStationDistance || '',
-            valueColor: distanceColor || undefined
+            valueColor: distanceSeverity.color || undefined,
+            secondaryColor: stationDistanceSeverity.color || undefined
           }
           const valueSecondaryParts = []
           if (profitPerUnitDisplay && profitPerUnitDisplay !== '--') valueSecondaryParts.push(`Per t ${profitPerUnitDisplay}`)
@@ -3409,12 +3441,16 @@ function CargoHoldPanel () {
                             const isSelected = listing.__id === defaultSelectedId
                             const stationIcon = stationIconFromType(listing.stationType || '')
                             const systemDistanceDisplay = formatSystemDistance(listing.distanceLy, listing.distanceLyText)
-                            const systemDistanceColor = getDistanceSeverityColor(listing.distanceLy ?? null, ship?.maxJumpRange ?? null)
+                            const systemDistanceSeverity = getDistanceSeverity(listing.distanceLy ?? null, ship?.maxJumpRange ?? null, { thresholds: thresholdSettings })
+                            const stationDistanceSeverity = getStationDistanceSeverity(listing.distanceLs ?? null, { thresholds: thresholdSettings })
                             const stationDistanceDisplay = formatStationDistance(listing.distanceLs, listing.distanceLsText)
                             const demandDisplay = sanitizeInaraText(listing.demandText) || (typeof listing.demand === 'number' ? listing.demand.toLocaleString() : '')
                             const updatedDisplay = listing.updatedAt
                               ? formatRelativeTime(listing.updatedAt)
                               : (listing.updatedText || '')
+                            const updatedSeverity = listing.updatedAt
+                              ? getUpdateSeverity(listing.updatedAt, { thresholds: thresholdSettings })
+                              : { color: null }
                             const priceDisplay = formatCredits(listing.price, listing.priceText || '--')
                             const rowClasses = [styles.tableRowInteractive]
                             if (isSelected) rowClasses.push(styles.stationRowSelected)
@@ -3449,13 +3485,21 @@ function CargoHoldPanel () {
                                 <td className={`${styles.tableCellTop} ${styles.tableCellWrap}`}>
                                   {systemDistanceDisplay
                                     ? (
-                                      <span style={systemDistanceColor ? { color: systemDistanceColor } : undefined}>
+                                      <span style={systemDistanceSeverity.color ? { color: systemDistanceSeverity.color } : undefined}>
                                         {systemDistanceDisplay}
                                       </span>
                                       )
                                     : '--'}
                                 </td>
-                                <td className={`${styles.tableCellTop} ${styles.tableCellWrap}`}>{stationDistanceDisplay || '--'}</td>
+                                <td className={`${styles.tableCellTop} ${styles.tableCellWrap}`}>
+                                  {stationDistanceDisplay
+                                    ? (
+                                      <span style={stationDistanceSeverity.color ? { color: stationDistanceSeverity.color } : undefined}>
+                                        {stationDistanceDisplay}
+                                      </span>
+                                      )
+                                    : '--'}
+                                </td>
                                 <td className={`${styles.tableCellTop} ${styles.tableCellWrap}`}>
                                   {((listing.demandText || demandDisplay) && (listing.demandText || demandDisplay).toString().trim())
                                     ? (
@@ -3470,7 +3514,12 @@ function CargoHoldPanel () {
                                 <td className={`text-right ${styles.tableCellTop} ${styles.tableCellCompact}`}>
                                   <div>{priceDisplay}</div>
                                   {updatedDisplay ? (
-                                    <div className={styles.tableMetaMuted}>Updated {updatedDisplay}</div>
+                                    <div
+                                      className={styles.tableMetaMuted}
+                                      style={updatedSeverity.color ? { color: updatedSeverity.color } : undefined}
+                                    >
+                                      Updated {updatedDisplay}
+                                    </div>
                                   ) : null}
                                 </td>
                               </tr>
@@ -3551,9 +3600,13 @@ function CargoHoldPanel () {
                         )
                       : null
                     const inaraUpdatedText = sanitizeInaraText(inaraContextEntry?.updatedText) || inaraContextEntry?.updatedText || ''
-                    const inaraUpdated = inaraContextEntry?.updatedAt
+                    const inaraUpdatedRaw = inaraContextEntry?.updatedAt || null
+                    const inaraUpdated = inaraUpdatedRaw
                       ? formatRelativeTime(inaraContextEntry.updatedAt)
                       : inaraUpdatedText
+                    const inaraUpdatedSeverity = inaraUpdatedRaw
+                      ? getUpdateSeverity(inaraUpdatedRaw, { thresholds: thresholdSettings })
+                      : { color: null }
                     const inaraPriceDisplay = typeof inaraPrice === 'number' ? formatCredits(inaraPrice, '--') : '--'
                     const bestValueDisplay = typeof bestValue === 'number' ? formatCredits(bestValue, '--') : '--'
 
@@ -3597,8 +3650,11 @@ function CargoHoldPanel () {
                     const contextSummary = isContextRow ? commodityContext : null
                     const contextDistance = contextSummary ? formatStationDistance(contextSummary.distanceLs, contextSummary.distanceLsText) : ''
                     const contextSystemDistance = contextSummary ? formatSystemDistance(contextSummary.distanceLy, contextSummary.distanceLyText) : ''
-                    const contextSystemDistanceColor = contextSummary
-                      ? getDistanceSeverityColor(contextSummary.distanceLy ?? null, ship?.maxJumpRange ?? null)
+                    const contextSystemSeverity = contextSummary
+                      ? getDistanceSeverity(contextSummary.distanceLy ?? null, ship?.maxJumpRange ?? null, { thresholds: thresholdSettings })
+                      : null
+                    const contextStationSeverity = contextSummary
+                      ? getStationDistanceSeverity(contextSummary.distanceLs ?? null, { thresholds: thresholdSettings })
                       : null
                     const rowClassNames = [styles.tableRowInteractive]
                     if (isContextRow) rowClassNames.push(styles.tableRowContext)
@@ -3653,13 +3709,19 @@ function CargoHoldPanel () {
                                     <span className={styles.tableContextFootnote}>
                                       {contextSystemDistance
                                         ? (
-                                          <span style={contextSystemDistanceColor ? { color: contextSystemDistanceColor } : undefined}>
+                                          <span style={contextSystemSeverity?.color ? { color: contextSystemSeverity.color } : undefined}>
                                             {contextSystemDistance}
                                           </span>
                                           )
                                         : null}
                                       {contextSystemDistance && contextDistance ? ' / ' : null}
-                                      {contextDistance || null}
+                                      {contextDistance
+                                        ? (
+                                          <span style={contextStationSeverity?.color ? { color: contextStationSeverity.color } : undefined}>
+                                            {contextDistance}
+                                          </span>
+                                          )
+                                        : null}
                                     </span>
                                   )}
                                 </div>
@@ -3699,7 +3761,12 @@ function CargoHoldPanel () {
                             </div>
                           )}
                           {inaraUpdated && (
-                            <div className={styles.tableMetaMuted}>Updated {inaraUpdated}</div>
+                            <div
+                              className={styles.tableMetaMuted}
+                              style={inaraUpdatedSeverity.color ? { color: inaraUpdatedSeverity.color } : undefined}
+                            >
+                              Updated {inaraUpdated}
+                            </div>
                           )}
                         </td>
                         <td className={`text-right ${styles.tableCellTop} ${styles.tableCellTight}`}>
@@ -3747,6 +3814,7 @@ function CargoHoldPanel () {
 
 function TradeRoutesPanel ({ onStatusChange = () => {} }) {
   const { connected, ready } = useSocket()
+  const thresholdSettings = useContext(InaraThresholdSettingsContext)
   const systemSelector = useSystemSelector({ autoSelectCurrent: true })
   const {
     currentSystem,
@@ -4437,12 +4505,16 @@ function TradeRoutesPanel ({ onStatusChange = () => {} }) {
     [routeContext, selectedRoute]
   )
 
-  const originStationDistanceVariant = getStationDistanceVariant(originStationDistance.value)
-  const destinationStationDistanceVariant = getStationDistanceVariant(destinationStationDistance.value)
-  const originSystemDistanceVariant = getSystemDistanceVariant(originSystemDistance.value, shipStatus?.maxJumpRange ?? null)
-  const destinationSystemDistanceVariant = getSystemDistanceVariant(destinationSystemDistance.value, shipStatus?.maxJumpRange ?? null)
-  const originSystemDistanceColor = getDistanceSeverityColor(originSystemDistance.value, shipStatus?.maxJumpRange ?? null)
-  const destinationSystemDistanceColor = getDistanceSeverityColor(destinationSystemDistance.value, shipStatus?.maxJumpRange ?? null)
+  const originStationSeverity = getStationDistanceSeverity(originStationDistance.value, { thresholds: thresholdSettings })
+  const destinationStationSeverity = getStationDistanceSeverity(destinationStationDistance.value, { thresholds: thresholdSettings })
+  const originSystemSeverity = getDistanceSeverity(originSystemDistance.value, shipStatus?.maxJumpRange ?? null, { thresholds: thresholdSettings })
+  const destinationSystemSeverity = getDistanceSeverity(destinationSystemDistance.value, shipStatus?.maxJumpRange ?? null, { thresholds: thresholdSettings })
+  const originStationDistanceVariant = originStationSeverity.variant || 'neutral'
+  const destinationStationDistanceVariant = destinationStationSeverity.variant || 'neutral'
+  const originSystemDistanceVariant = originSystemSeverity.variant || 'neutral'
+  const destinationSystemDistanceVariant = destinationSystemSeverity.variant || 'neutral'
+  const originSystemDistanceColor = originSystemSeverity.color
+  const destinationSystemDistanceColor = destinationSystemSeverity.color
 
   const originStationType = useMemo(() => {
     if (!routeContext) return ''
@@ -4574,6 +4646,13 @@ function TradeRoutesPanel ({ onStatusChange = () => {} }) {
     if (!updated) return ''
     return formatRelativeTime(updated)
   }, [routeContext, selectedRoute])
+
+  const routeUpdatedSeverity = useMemo(() => {
+    if (!routeContext) return { color: null }
+    const updated = extractUpdatedAt(selectedRoute)
+    if (!updated) return { color: null }
+    return getUpdateSeverity(updated, { thresholds: thresholdSettings })
+  }, [routeContext, selectedRoute, thresholdSettings])
 
   const routeProfitMetrics = useMemo(() => {
     if (!routeContext) return []
@@ -4784,7 +4863,10 @@ function TradeRoutesPanel ({ onStatusChange = () => {} }) {
                       </div>
                       <div className={styles.tradeRouteContextMetric}>
                         <span className={styles.tradeRouteContextMetricLabel}>Orbital Distance</span>
-                        <span className={buildMetricChipClasses(originStationDistanceVariant)}>
+                        <span
+                          className={buildMetricChipClasses(originStationDistanceVariant)}
+                          style={originStationSeverity.color ? { '--chip-color': originStationSeverity.color } : undefined}
+                        >
                           {originStationDistance.display || '--'}
                         </span>
                       </div>
@@ -4815,7 +4897,12 @@ function TradeRoutesPanel ({ onStatusChange = () => {} }) {
                     </div>
                     {routeUpdatedDisplay ? (
                       <div className={styles.tradeRouteContextConnectorMeta}>
-                        <span className={styles.tradeRouteContextConnectorMetaText}>Updated {routeUpdatedDisplay}</span>
+                        <span
+                          className={styles.tradeRouteContextConnectorMetaText}
+                          style={routeUpdatedSeverity.color ? { color: routeUpdatedSeverity.color } : undefined}
+                        >
+                          Updated {routeUpdatedDisplay}
+                        </span>
                       </div>
                     ) : null}
                   </div>
@@ -4868,7 +4955,10 @@ function TradeRoutesPanel ({ onStatusChange = () => {} }) {
                       </div>
                       <div className={styles.tradeRouteContextMetric}>
                         <span className={styles.tradeRouteContextMetricLabel}>Orbital Distance</span>
-                        <span className={buildMetricChipClasses(destinationStationDistanceVariant)}>
+                        <span
+                          className={buildMetricChipClasses(destinationStationDistanceVariant)}
+                          style={destinationStationSeverity.color ? { '--chip-color': destinationStationSeverity.color } : undefined}
+                        >
                           {destinationStationDistance.display || '--'}
                         </span>
                       </div>
@@ -7091,6 +7181,7 @@ export default function InaraStatusPage () {
   const [activeTab, setActiveTab] = useState('tradeRoutes')
   const [tradeRoutesStatus, setTradeRoutesStatus] = useState('idle')
   const { connected, ready, active: socketActive } = useSocket()
+  const thresholdSettings = useInaraThresholdSettings()
   const inaraTabs = useMemo(() => {
     const panelItems = [
       { name: 'Trade Routes', icon: 'route', active: activeTab === 'tradeRoutes', onClick: () => setActiveTab('tradeRoutes') },
@@ -7108,38 +7199,40 @@ export default function InaraStatusPage () {
   const loaderVisible = activeTab === 'tradeRoutes' && tradeRoutesStatus === 'loading'
 
   return (
-    <Layout connected={connected} active={socketActive} ready={ready} loader={loaderVisible} className={styles.inaraLayout}>
-      <Panel
-        layout='full-width'
-        scrollable
-        navigation={inaraTabs}
-        search={false}
-        className={styles.inaraPanel}
-      >
-        <div className={workspaceClassName}>
-          <div className={styles.shell}>
-            <div className={styles.tabPanels}>
-              <div style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
-                <TradeRoutesPanel onStatusChange={setTradeRoutesStatus} />
-              </div>
-              <div style={{ display: activeTab === 'cargoHold' ? 'block' : 'none' }}>
-                <CargoHoldPanel />
-              </div>
-              <div style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
-                <MissionsPanel />
-              </div>
-              <div style={{ display: activeTab === 'pristineMining' ? 'block' : 'none' }}>
-                <PristineMiningPanel />
-              </div>
-              <div style={{ display: activeTab === 'pirateRadio' ? 'block' : 'none' }}>
-                <PirateRadioPanel />
+    <InaraThresholdSettingsContext.Provider value={thresholdSettings}>
+      <Layout connected={connected} active={socketActive} ready={ready} loader={loaderVisible} className={styles.inaraLayout}>
+        <Panel
+          layout='full-width'
+          scrollable
+          navigation={inaraTabs}
+          search={false}
+          className={styles.inaraPanel}
+        >
+          <div className={workspaceClassName}>
+            <div className={styles.shell}>
+              <div className={styles.tabPanels}>
+                <div style={{ display: activeTab === 'tradeRoutes' ? 'block' : 'none' }}>
+                  <TradeRoutesPanel onStatusChange={setTradeRoutesStatus} />
+                </div>
+                <div style={{ display: activeTab === 'cargoHold' ? 'block' : 'none' }}>
+                  <CargoHoldPanel />
+                </div>
+                <div style={{ display: activeTab === 'missions' ? 'block' : 'none' }}>
+                  <MissionsPanel />
+                </div>
+                <div style={{ display: activeTab === 'pristineMining' ? 'block' : 'none' }}>
+                  <PristineMiningPanel />
+                </div>
+                <div style={{ display: activeTab === 'pirateRadio' ? 'block' : 'none' }}>
+                  <PirateRadioPanel />
+                </div>
               </div>
             </div>
+            <InaraTerminalOverlay />
           </div>
-          <InaraTerminalOverlay />
-        </div>
-      </Panel>
-    </Layout>
+        </Panel>
+      </Layout>
+    </InaraThresholdSettingsContext.Provider>
   )
 }
 


### PR DESCRIPTION
## Summary
- add shared INARA threshold settings with persistence and context support
- expose system, station, and update threshold controls in settings with gradient severity logic
- apply configurable colors to trade route, commodity, and mission distance/update displays

## Testing
- npm test -- --runInBand --config jest.config.js
- npm run build:client *(fails: SWC binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5992b2a5c8323a2486e012edc6b21