### PR TITLE
Keep header title consistent across INARA

### DIFF
--- a/src/client/components/header.js
+++ b/src/client/components/header.js
@@ -98,7 +98,7 @@ export default function Header ({ connected, active }) {
   }
 
   const currentPath = `/${(router.pathname.split('/')[1] || '').toLowerCase()}`
-  const displayTitle = currentPath === '/inara' ? 'INARA-ATLAS' : 'ICARUS TERMINAL'
+  const displayTitle = 'ICARUS TERMINAL'
   const accessibleTitle = displayTitle.replace('-', ' ')
 
   let signalClassName = 'icon icarus-terminal-signal '


### PR DESCRIPTION
## Summary
- remove the INARA-specific title override in the header so the app title remains consistent

## Testing
- `npm test -- --runInBand --config jest.config.js`
- `npm run build:client` *(fails: Failed to load SWC binary for linux/x64 in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ba1c75988323bba60c4b88112f73