### PR TITLE
Add shared INARA request cache

### DIFF
--- a/src/client/pages/api/inara-commodity-values.js
+++ b/src/client/pages/api/inara-commodity-values.js
@@ -2,9 +2,9 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import https from 'https'
-import fetch from 'node-fetch'
 import { load } from 'cheerio'
 import { estimateByteSize, spendTokensForInaraExchange } from './token-currency.js'
+import { fetchWithInaraCache } from './inara-request-cache.js'
 
 const INARA_BASE_URL = 'https://inara.cz'
 const INARA_COMMODITY_SEARCH_URL = `${INARA_BASE_URL}/elite/commodities/`
@@ -238,7 +238,7 @@ async function loadCommodityOptions () {
     let fetchError = null
 
     try {
-      const response = await fetch(url.toString(), {
+      const response = await fetchWithInaraCache(url.toString(), {
         agent: ipv4HttpsAgent,
         headers: {
           'User-Agent': 'Mozilla/5.0 (compatible; ICARUS Terminal)'
@@ -413,7 +413,7 @@ async function fetchCommoditySearchListings ({ commodityId, commodityName, nearS
   let fetchError = null
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithInaraCache(url, {
       agent: ipv4HttpsAgent,
       headers: {
         'User-Agent': 'Mozilla/5.0 (compatible; ICARUS Terminal)'

--- a/src/client/pages/api/inara-missions.js
+++ b/src/client/pages/api/inara-missions.js
@@ -1,7 +1,7 @@
-import fetch from 'node-fetch'
 import https from 'https'
 import { load } from 'cheerio'
 import { estimateByteSize, spendTokensForInaraExchange } from './token-currency.js'
+import { fetchWithInaraCache } from './inara-request-cache.js'
 
 const BASE_URL = 'https://inara.cz'
 const MINING_MISSION_TYPE = 7
@@ -103,7 +103,7 @@ export default async function handler (req, res) {
   let caughtError = null
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithInaraCache(url, {
       agent: ipv4HttpsAgent,
       headers: INARA_REQUEST_HEADERS
     })

--- a/src/client/pages/api/inara-pristine-mining.js
+++ b/src/client/pages/api/inara-pristine-mining.js
@@ -1,7 +1,7 @@
-import fetch from 'node-fetch'
 import https from 'https'
 import { load } from 'cheerio'
 import { estimateByteSize, spendTokensForInaraExchange } from './token-currency.js'
+import { fetchWithInaraCache } from './inara-request-cache.js'
 
 const BASE_URL = 'https://inara.cz'
 const ipv4HttpsAgent = new https.Agent({ family: 4 })
@@ -146,7 +146,7 @@ export default async function handler (req, res) {
   let caughtError = null
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithInaraCache(url, {
       agent: ipv4HttpsAgent,
       headers: INARA_REQUEST_HEADERS
     })

--- a/src/client/pages/api/inara-request-cache.js
+++ b/src/client/pages/api/inara-request-cache.js
@@ -1,0 +1,208 @@
+import fetch from 'node-fetch'
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000
+const MAX_CACHE_SIZE = 200
+
+function getCacheStore () {
+  if (!global.__INARA_FETCH_CACHE__) {
+    global.__INARA_FETCH_CACHE__ = new Map()
+  }
+  return global.__INARA_FETCH_CACHE__
+}
+
+function getCacheOrder () {
+  if (!global.__INARA_FETCH_CACHE_ORDER__) {
+    global.__INARA_FETCH_CACHE_ORDER__ = []
+  }
+  return global.__INARA_FETCH_CACHE_ORDER__
+}
+
+function getInFlightStore () {
+  if (!global.__INARA_FETCH_INFLIGHT__) {
+    global.__INARA_FETCH_INFLIGHT__ = new Map()
+  }
+  return global.__INARA_FETCH_INFLIGHT__
+}
+
+function pruneExpiredEntries (cache, now, ttlMs) {
+  if (!cache || cache.size === 0) return
+  for (const [key, entry] of cache.entries()) {
+    if (!entry || typeof entry.timestamp !== 'number') {
+      cache.delete(key)
+      continue
+    }
+    if ((now - entry.timestamp) > ttlMs) {
+      cache.delete(key)
+      const order = getCacheOrder()
+      const index = order.indexOf(key)
+      if (index !== -1) order.splice(index, 1)
+    }
+  }
+}
+
+function recordCacheEntryOrder (key) {
+  const order = getCacheOrder()
+  const existingIndex = order.indexOf(key)
+  if (existingIndex !== -1) order.splice(existingIndex, 1)
+  order.push(key)
+  while (order.length > MAX_CACHE_SIZE) {
+    const oldest = order.shift()
+    if (oldest !== undefined) {
+      const cache = getCacheStore()
+      const cachedEntry = cache.get(oldest)
+      if (!cachedEntry || (Date.now() - cachedEntry.timestamp) > FIVE_MINUTES_MS) {
+        cache.delete(oldest)
+      }
+    }
+  }
+}
+
+function normaliseHeaders (response) {
+  const headerMap = new Map()
+  if (!response || !response.headers || typeof response.headers.forEach !== 'function') {
+    return headerMap
+  }
+  response.headers.forEach((value, key) => {
+    if (!key) return
+    headerMap.set(String(key).toLowerCase(), value)
+  })
+  return headerMap
+}
+
+function createHeadersInterface (headerMap) {
+  return {
+    get (name) {
+      if (!name) return null
+      return headerMap.get(String(name).toLowerCase()) ?? null
+    },
+    has (name) {
+      if (!name) return false
+      return headerMap.has(String(name).toLowerCase())
+    },
+    entries () {
+      return headerMap.entries()
+    },
+    keys () {
+      return headerMap.keys()
+    },
+    values () {
+      return headerMap.values()
+    },
+    forEach (callback) {
+      if (typeof callback !== 'function') return
+      for (const [key, value] of headerMap.entries()) {
+        callback(value, key, this)
+      }
+    },
+    [Symbol.iterator]: function * iterator () {
+      yield * headerMap.entries()
+    }
+  }
+}
+
+function createCachedResponse (entry, fromCache = false) {
+  const headersInterface = createHeadersInterface(entry.headers || new Map())
+  const bodyText = entry.body
+
+  return {
+    status: entry.status,
+    ok: typeof entry.ok === 'boolean' ? entry.ok : (entry.status >= 200 && entry.status < 300),
+    url: entry.url,
+    headers: headersInterface,
+    fromCache,
+    cachedAt: entry.timestamp,
+    text: async () => bodyText,
+    json: async () => {
+      if (typeof bodyText !== 'string') return null
+      return JSON.parse(bodyText)
+    },
+    clone: () => createCachedResponse(entry, fromCache)
+  }
+}
+
+export async function fetchWithInaraCache (url, options = {}) {
+  if (!url) throw new Error('fetchWithInaraCache requires a URL')
+
+  const { fetchImpl, cacheTtlMs, ...fetchOptions } = options || {}
+  const method = typeof fetchOptions.method === 'string' ? fetchOptions.method.toUpperCase() : 'GET'
+  const ttlMs = typeof cacheTtlMs === 'number' && Number.isFinite(cacheTtlMs) ? cacheTtlMs : FIVE_MINUTES_MS
+  const fetchFn = typeof fetchImpl === 'function' ? fetchImpl : fetch
+
+  if (method !== 'GET') {
+    return fetchFn(url, fetchOptions)
+  }
+
+  const cache = getCacheStore()
+  const now = Date.now()
+  pruneExpiredEntries(cache, now, ttlMs)
+
+  const cachedEntry = cache.get(url)
+  if (cachedEntry && (now - cachedEntry.timestamp) <= ttlMs && cachedEntry.status === 200) {
+    return createCachedResponse(cachedEntry, true)
+  }
+  if (cachedEntry && (now - cachedEntry.timestamp) > ttlMs) {
+    cache.delete(url)
+  }
+
+  const inFlight = getInFlightStore()
+  if (inFlight.has(url)) {
+    const entry = await inFlight.get(url)
+    if (entry) {
+      const withinTtl = (Date.now() - entry.timestamp) <= ttlMs
+      return createCachedResponse(entry, entry.status === 200 && withinTtl)
+    }
+  }
+
+  const fetchPromise = (async () => {
+    const response = await fetchFn(url, fetchOptions)
+    const headers = normaliseHeaders(response)
+    const body = await response.text()
+    const record = {
+      url,
+      status: response.status,
+      ok: response.ok,
+      headers,
+      body,
+      timestamp: Date.now()
+    }
+
+    if (response.status === 200) {
+      cache.set(url, record)
+      recordCacheEntryOrder(url)
+    } else {
+      cache.delete(url)
+    }
+
+    return record
+  })()
+
+  inFlight.set(url, fetchPromise)
+
+  try {
+    const entry = await fetchPromise
+    return createCachedResponse(entry, false)
+  } finally {
+    inFlight.delete(url)
+  }
+}
+
+export function clearInaraCache () {
+  if (global.__INARA_FETCH_CACHE__) {
+    global.__INARA_FETCH_CACHE__.clear()
+  }
+  if (global.__INARA_FETCH_CACHE_ORDER__) {
+    global.__INARA_FETCH_CACHE_ORDER__.length = 0
+  }
+}
+
+export function getInaraCacheSnapshot () {
+  const cache = getCacheStore()
+  const snapshot = {}
+  for (const [key, entry] of cache.entries()) {
+    snapshot[key] = {
+      status: entry.status,
+      timestamp: entry.timestamp
+    }
+  }
+  return snapshot
+}

--- a/src/client/pages/api/inara-trade-routes.js
+++ b/src/client/pages/api/inara-trade-routes.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch'
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
@@ -9,6 +8,7 @@ import System from '../../../service/lib/event-handlers/system.js'
 import distance from '../../../shared/distance.js'
 import { appendInaraLogEntry } from './inara-log-utils.js'
 import { estimateByteSize, spendTokensForInaraExchange } from './token-currency.js'
+import { fetchWithInaraCache } from './inara-request-cache.js'
 
 const logPath = path.join(process.cwd(), 'inara-trade-routes.log')
 const ipv4HttpsAgent = new https.Agent({ family: 4 })
@@ -476,7 +476,7 @@ export default async function handler(req, res) {
   let caughtError = null
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithInaraCache(url, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (compatible; ICARUS/1.0)',
         'Accept-Language': 'en-US,en;q=0.9'

--- a/src/client/pages/api/inara-websearch.js
+++ b/src/client/pages/api/inara-websearch.js
@@ -1,7 +1,6 @@
 // Backend API: Proxies INARA nearest-outfitting for ships only
 // Only supports ship search (not modules or other outfitting)
 
-import fetch from 'node-fetch'
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
@@ -10,6 +9,7 @@ import System from '../../../service/lib/event-handlers/system.js'
 import distance from '../../../shared/distance.js'
 import { appendInaraLogEntry } from './inara-log-utils.js'
 import { estimateByteSize, spendTokensForInaraExchange } from './token-currency.js'
+import { fetchWithInaraCache } from './inara-request-cache.js'
 
 const logPath = path.join(process.cwd(), 'inara-websearch.log')
 function logInaraSearch(entry) {
@@ -330,7 +330,7 @@ export default async function handler(req, res) {
   let caughtError = null
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithInaraCache(url, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (compatible; ICARUS/1.0)',
         'Accept-Language': 'en-US,en;q=0.9'


### PR DESCRIPTION
## Summary
- add a shared `fetchWithInaraCache` helper that caches successful INARA GET responses for five minutes and deduplicates in-flight requests
- update trade routes, outfitting websearch, pristine mining, missions, and commodity value API routes to use the shared cache

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c22c31fc8323b658ce4438febb94