### PR TITLE
Fix INARA HTTP client fallbacks for packaged service

### DIFF
--- a/src/client/pages/api/inara-request-cache.js
+++ b/src/client/pages/api/inara-request-cache.js
@@ -328,11 +328,18 @@ async function axiosRequest (url, options = {}) {
     timeout: options.timeout
   })
 
+  let body = response.data
+  if (body === undefined && typeof response.text === 'function') {
+    body = await response.text()
+  } else if (body === undefined && response.body !== undefined) {
+    body = response.body
+  }
+
   return {
     status: response.status,
     ok: response.status >= 200 && response.status < 300,
     headers: response.headers,
-    body: response.data
+    body
   }
 }
 

--- a/src/client/pages/api/inara-search.js
+++ b/src/client/pages/api/inara-search.js
@@ -1,19 +1,11 @@
-import fetch from 'node-fetch'
-import { estimateByteSize, spendTokensForInaraExchange } from './token-currency.js'
+const axios = require('axios')
 
-export default async function handler(req, res) {
-  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+const { estimateByteSize, spendTokensForInaraExchange } = require('./token-currency.js')
 
-  const { searchType, searchTerm, appName, appVersion } = req.body
-  if (!searchType || !searchTerm || !appName || !appVersion) {
-    return res.status(400).json({ error: 'Missing required fields' })
-  }
+const INARA_API_URL = 'https://inara.cz/inapi/v1/'
 
-  // INARA API endpoint
-  const url = 'https://inara.cz/inapi/v1/'
-
-  // Build INARA API request body
-  const requestBody = {
+function buildRequestPayload ({ searchType, searchTerm, appName, appVersion }) {
+  const payload = {
     header: {
       appName,
       appVersion
@@ -21,48 +13,91 @@ export default async function handler(req, res) {
     events: []
   }
 
-  // Add the appropriate event for the search type
   if (searchType === 'commodity') {
-    requestBody.events.push({ eventName: 'getCommoditiesMarket', eventData: { commodityName: searchTerm } })
+    payload.events.push({ eventName: 'getCommoditiesMarket', eventData: { commodityName: searchTerm } })
   } else if (searchType === 'ship') {
-    requestBody.events.push({ eventName: 'getShipyard', eventData: { shipName: searchTerm } })
+    payload.events.push({ eventName: 'getShipyard', eventData: { shipName: searchTerm } })
   } else if (searchType === 'module') {
-    requestBody.events.push({ eventName: 'getOutfitting', eventData: { moduleName: searchTerm } })
+    payload.events.push({ eventName: 'getOutfitting', eventData: { moduleName: searchTerm } })
   } else if (searchType === 'material') {
-    requestBody.events.push({ eventName: 'getMaterialsMarket', eventData: { materialName: searchTerm } })
-  } else {
+    payload.events.push({ eventName: 'getMaterialsMarket', eventData: { materialName: searchTerm } })
+  }
+
+  return payload
+}
+
+async function performInaraSearch ({ requestPayload }) {
+  const response = await axios({
+    url: INARA_API_URL,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    data: requestPayload,
+    responseType: 'text',
+    validateStatus: () => true
+  })
+
+  let body = response.data
+  if (body === undefined && typeof response.text === 'function') {
+    body = await response.text()
+  } else if (body === undefined && response.body !== undefined) {
+    body = response.body
+  }
+
+  if (body === undefined || body === null) body = ''
+  if (Buffer.isBuffer(body)) body = body.toString('utf8')
+  if (typeof body !== 'string') body = JSON.stringify(body)
+
+  return {
+    status: response.status,
+    ok: response.status >= 200 && response.status < 300,
+    body
+  }
+}
+
+async function handler (req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  const { searchType, searchTerm, appName, appVersion } = req.body || {}
+  if (!searchType || !searchTerm || !appName || !appVersion) {
+    return res.status(400).json({ error: 'Missing required fields' })
+  }
+
+  if (!['commodity', 'ship', 'module', 'material'].includes(searchType)) {
     return res.status(400).json({ error: 'Invalid search type' })
   }
 
-  const requestPayload = JSON.stringify(requestBody)
+  const requestPayload = JSON.stringify(buildRequestPayload({ searchType, searchTerm, appName, appVersion }))
   const requestBytes = estimateByteSize(requestPayload)
+
   let responseText = ''
   let responseStatus = null
-  let error = null
+  let caughtError = null
 
   try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: requestPayload
-    })
-    responseStatus = response.status
-    responseText = await response.text()
+    const httpResponse = await performInaraSearch({ requestPayload })
+    responseStatus = httpResponse.status
+    responseText = httpResponse.body
+
+    if (!httpResponse.ok) {
+      throw new Error(`INARA API request failed with status ${httpResponse.status}`)
+    }
+
     const data = responseText ? JSON.parse(responseText) : null
     res.status(200).json(data)
-  } catch (err) {
-    error = err
-    res.status(500).json({ error: 'INARA API request failed', details: err.message })
+  } catch (error) {
+    caughtError = error
+    res.status(500).json({ error: 'INARA API request failed', details: error.message })
   } finally {
     const metadata = {
       method: 'POST',
       status: responseStatus,
-      error: error ? error.message : undefined,
       searchType,
-      reason: error ? 'inara-request-error' : 'inara-request'
+      error: caughtError ? caughtError.message : undefined,
+      reason: caughtError ? 'inara-request-error' : 'inara-request'
     }
+
     await spendTokensForInaraExchange({
-      endpoint: url,
+      endpoint: INARA_API_URL,
       requestBytes,
       responseBytes: estimateByteSize(responseText),
       metadata
@@ -71,3 +106,5 @@ export default async function handler(req, res) {
     })
   }
 }
+
+module.exports = handler

--- a/src/service/lib/__tests__/inara-client.test.js
+++ b/src/service/lib/__tests__/inara-client.test.js
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('axios', () => jest.fn())
+
+describe('InaraClient default fetch implementation', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.resetModules()
+    jest.clearAllMocks()
+  })
+
+  it('falls back to the axios shim when fetch is unavailable', async () => {
+    jest.resetModules()
+    global.fetch = undefined
+
+    const axiosMock = require('axios')
+    axiosMock.mockResolvedValue({ status: 200, data: '{"ok":true}', headers: {} })
+
+    const InaraClient = require('../inara-client')
+    const client = new InaraClient({ baseUrl: 'https://inara.test/submit' })
+
+    const result = await client.submit('{"payload":true}')
+
+    expect(axiosMock).toHaveBeenCalledTimes(1)
+    expect(axiosMock).toHaveBeenCalledWith(expect.objectContaining({
+      url: 'https://inara.test/submit',
+      method: 'POST'
+    }))
+    expect(result).toEqual({ success: true, data: { ok: true } })
+  })
+
+  it('prefers a provided fetch implementation over the shim', async () => {
+    jest.resetModules()
+
+    const axiosMock = require('axios')
+    axiosMock.mockResolvedValue({ status: 200, data: '{"ok":true}', headers: {} })
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      status: 200,
+      json: jest.fn().mockResolvedValue({ ok: 42 })
+    })
+
+    const InaraClient = require('../inara-client')
+    const client = new InaraClient({ baseUrl: 'https://inara.test/submit', fetchImpl: fetchMock })
+
+    const result = await client.submit('{"payload":false}')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(axiosMock).not.toHaveBeenCalled()
+    expect(result).toEqual({ success: true, data: { ok: 42 } })
+  })
+})

--- a/src/service/lib/inara-client.js
+++ b/src/service/lib/inara-client.js
@@ -1,9 +1,59 @@
 'use strict'
 
+const axios = require('axios')
+
+function createAxiosFetchShim () {
+  return async function axiosFetch (url, options = {}) {
+    const method = typeof options.method === 'string' ? options.method.toUpperCase() : 'GET'
+
+    const response = await axios({
+      url,
+      method,
+      headers: options.headers,
+      data: options.body,
+      responseType: 'text',
+      validateStatus: () => true,
+      timeout: options.timeout,
+      httpsAgent: options.agent || options.httpsAgent
+    })
+
+    const rawData = response.data
+    let bodyText
+    if (typeof rawData === 'string') {
+      bodyText = rawData
+    } else if (rawData === undefined || rawData === null) {
+      bodyText = ''
+    } else if (Buffer.isBuffer(rawData)) {
+      bodyText = rawData.toString('utf8')
+    } else {
+      bodyText = JSON.stringify(rawData)
+    }
+
+    return {
+      status: response.status,
+      ok: response.status >= 200 && response.status < 300,
+      headers: response.headers,
+      url,
+      text: async () => bodyText,
+      json: async () => JSON.parse(bodyText)
+    }
+  }
+}
+
+function resolveDefaultFetchImpl () {
+  if (typeof globalThis.fetch === 'function') {
+    return globalThis.fetch.bind(globalThis)
+  }
+
+  return createAxiosFetchShim()
+}
+
+const DEFAULT_FETCH_IMPL = resolveDefaultFetchImpl()
+
 class InaraClient {
   constructor ({ baseUrl, fetchImpl } = {}) {
     this.baseUrl = baseUrl || process.env.INARA_API_URL || 'https://inara.cz/inapi/v1/'
-    this.fetchImpl = fetchImpl || (typeof fetch === 'function' ? fetch : null)
+    this.fetchImpl = fetchImpl || DEFAULT_FETCH_IMPL
   }
 
   isEnabled () {


### PR DESCRIPTION
## Summary
- add an axios-backed fetch shim so the INARA client works in Node 16/pkg builds
- harden the INARA request cache and API search handler to accept axios mock responses
- add coverage that exercises the new fallback behaviour

## Testing
- npm test -- --runInBand --config jest.config.js

------
https://chatgpt.com/codex/tasks/task_e_68e6a6cf0e8c8323be2b40bb3eca989d